### PR TITLE
feat: Phase 2 — all tools, dual mode, CLI, graph analysis

### DIFF
--- a/scripts/pr-audit.sh
+++ b/scripts/pr-audit.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 REPO="adder-factory/mcp-obsidian-extended"
 OWNER="adder-factory"
 NAME="mcp-obsidian-extended"
-PR=1
+PR=2
 QUICK=false
 FIX_STALE=false
 AUTO_RESOLVE=false

--- a/scripts/pr-audit.sh
+++ b/scripts/pr-audit.sh
@@ -644,6 +644,7 @@ else
 fi
 
 if [ "$greptile_fixes" -gt 0 ]; then
+  # Extract issues from Fix-All URL-encoded prompt
   echo "$GREPTILE" | python3 -c "
 import sys,re,urllib.parse
 t=sys.stdin.read()
@@ -655,6 +656,27 @@ if idx>=0 and end>=0:
         if l.startswith('### Issue') or (l.startswith('**') and l.endswith('**')):
             print(f'  {l[:200]}')
 " 2>/dev/null || true
+fi
+
+# Extract summary-body findings (bullet points with **bold** markers not in threads)
+GREPTILE_BODY_FINDINGS=$(echo "$GREPTILE" | python3 -c "
+import sys
+t = sys.stdin.read()
+findings = []
+for line in t.split('\n'):
+    stripped = line.strip()
+    # Match '- **finding title**:' or '  - **finding**' patterns in body text
+    if stripped.startswith('- **') and '**' in stripped[4:]:
+        findings.append(stripped[:200])
+    elif stripped.startswith('**\`') and '**' in stripped[3:]:
+        findings.append(stripped[:200])
+if findings:
+    print('  Summary-body findings:')
+    for f in findings:
+        print(f'    {f}')
+" 2>/dev/null || true)
+if [ -n "$GREPTILE_BODY_FINDINGS" ]; then
+  log "$GREPTILE_BODY_FINDINGS"
 fi
 log "$(echo "$GREPTILE" | grep -o 'Last reviewed commit: [a-f0-9]*' | sed 's/^/  /' || true)"
 

--- a/scripts/pr-audit.sh
+++ b/scripts/pr-audit.sh
@@ -44,15 +44,15 @@ if [[ -z "$PR" ]]; then
     GH_OUTPUT=$(gh pr list --repo "$REPO" --head "$CURRENT_BRANCH" --state open --json number --jq '.[0].number' 2>&1)
     GH_EXIT=$?
     if [[ $GH_EXIT -ne 0 ]]; then
-      echo "ERROR: GitHub API call failed (exit $GH_EXIT): $GH_OUTPUT"
-      echo "Check authentication: gh auth status"
+      echo "ERROR: GitHub API call failed (exit $GH_EXIT): $GH_OUTPUT" >&2
+      echo "Check authentication: gh auth status" >&2
       exit 1
     fi
     PR="$GH_OUTPUT"
   fi
   if [[ -z "$PR" || "$PR" == "null" ]]; then
-    echo "ERROR: No open PR found for branch '${CURRENT_BRANCH:-<detached>}'."
-    echo "Usage: bash scripts/pr-audit.sh [PR_NUMBER] [FLAGS]"
+    echo "ERROR: No open PR found for branch '${CURRENT_BRANCH:-<detached>}'." >&2
+    echo "Usage: bash scripts/pr-audit.sh [PR_NUMBER] [FLAGS]" >&2
     exit 1
   fi
 fi

--- a/scripts/pr-audit.sh
+++ b/scripts/pr-audit.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 REPO="adder-factory/mcp-obsidian-extended"
 OWNER="adder-factory"
 NAME="mcp-obsidian-extended"
-PR=2
+PR=""
 QUICK=false
 FIX_STALE=false
 AUTO_RESOLVE=false
@@ -36,6 +36,19 @@ for arg in "$@"; do
     [0-9]*) PR="$arg" ;;
   esac
 done
+
+# Auto-detect PR from current branch if not specified
+if [[ -z "$PR" ]]; then
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if [[ -n "$CURRENT_BRANCH" && "$CURRENT_BRANCH" != "main" ]]; then
+    PR=$(gh pr list --repo "$REPO" --head "$CURRENT_BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+  fi
+  if [[ -z "$PR" ]]; then
+    echo "ERROR: No PR number specified and no open PR found for branch '$CURRENT_BRANCH'."
+    echo "Usage: bash scripts/pr-audit.sh [PR_NUMBER] [FLAGS]"
+    exit 1
+  fi
+fi
 
 START_TIME=$(date +%s)
 AUDIT_STATE_DIR="$HOME/.cache/pr-audit"

--- a/scripts/pr-audit.sh
+++ b/scripts/pr-audit.sh
@@ -41,10 +41,17 @@ done
 if [[ -z "$PR" ]]; then
   CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
   if [[ -n "$CURRENT_BRANCH" && "$CURRENT_BRANCH" != "main" ]]; then
-    PR=$(gh pr list --repo "$REPO" --head "$CURRENT_BRANCH" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+    GH_OUTPUT=$(gh pr list --repo "$REPO" --head "$CURRENT_BRANCH" --state open --json number --jq '.[0].number' 2>&1)
+    GH_EXIT=$?
+    if [[ $GH_EXIT -ne 0 ]]; then
+      echo "ERROR: GitHub API call failed (exit $GH_EXIT): $GH_OUTPUT"
+      echo "Check authentication: gh auth status"
+      exit 1
+    fi
+    PR="$GH_OUTPUT"
   fi
-  if [[ -z "$PR" ]]; then
-    echo "ERROR: No PR number specified and no open PR found for branch '$CURRENT_BRANCH'."
+  if [[ -z "$PR" || "$PR" == "null" ]]; then
+    echo "ERROR: No open PR found for branch '${CURRENT_BRANCH:-<detached>}'."
     echo "Usage: bash scripts/pr-audit.sh [PR_NUMBER] [FLAGS]"
     exit 1
   fi

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,4 +6,4 @@ sonar.sourceEncoding=UTF-8
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.exclusions=dist/**,node_modules/**,scripts/**
 sonar.test.inclusions=src/__tests__/**
-sonar.coverage.exclusions=src/__tests__/**,src/index.ts,src/tools/**,src/tools.ts
+sonar.coverage.exclusions=src/__tests__/**,src/index.ts

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1095,14 +1095,14 @@ describe("granular tools — registration and basic behavior", () => {
       expect(getText(result)).toContain("Invalid value");
     });
 
-    it("sets timeout and saves to file", async () => {
+    it("sets timeout and saves to file (requires restart)", async () => {
       const { getTool } = setup();
       const result = await getTool("configure").handler({ action: "set", setting: "timeout", value: "60000" });
       expect(saveConfigToFile).toHaveBeenCalledWith(
         expect.any(String),
         { reliability: { timeout: 60000 } },
       );
-      expect(getText(result)).toContain("effective immediately");
+      expect(getText(result)).toContain("Restart the server");
     });
 
     it("rejects invalid timeout (non-numeric)", async () => {

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -214,7 +214,8 @@ describe("registerAllTools — granular mode", () => {
     expect(getRegistered()).toHaveLength(38);
   });
 
-  it("registers 20 tools in read-only preset", () => {
+  it("registers 19 tools in read-only preset", () => {
+    // open_file removed from read-only (POST /open/{path} can create files)
     const { server } = makeMockServer();
     const client = makeMockClient();
     const cache = makeMockCache();
@@ -222,7 +223,7 @@ describe("registerAllTools — granular mode", () => {
       server as never, client, cache,
       makeConfig({ toolPreset: "read-only" }),
     );
-    expect(count).toBe(20);
+    expect(count).toBe(19);
   });
 
   it("registers 8 tools in minimal preset", () => {
@@ -2208,14 +2209,14 @@ describe("consolidated tools — registration and behavior", () => {
       expect(getText(result)).toContain("Cache refreshed");
     });
 
-    it("blocks refresh in read-only preset", async () => {
+    it("allows refresh in read-only preset (vault_analysis is protected)", async () => {
       const { server, getTool } = makeMockServer();
       const client = makeMockClient();
       const cache = makeMockCache(true);
       registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", toolPreset: "read-only", enableCache: true }));
       const result = await getTool("vault_analysis").handler({ action: "refresh", limit: 10 });
-      expect(result.isError).toBe(true);
-      expect(getText(result)).toContain("not allowed");
+      expect(cache.refresh).toHaveBeenCalled();
+      expect(getText(result)).toContain("Cache refreshed");
     });
 
     it("returns errorResult when cache disabled", async () => {

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -59,7 +59,7 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 /**
- * A captured tool registration: the four arguments passed to server.tool().
+ * A captured tool registration: the arguments passed to server.registerTool().
  * The handler signature matches the SDK: (args: unknown) => Promise<ToolResult>.
  */
 interface CapturedTool {
@@ -70,28 +70,32 @@ interface CapturedTool {
 }
 
 /**
- * Creates a mock McpServer that captures every server.tool() call.
+ * Creates a mock McpServer that captures every server.registerTool() call.
  * Returns both the mock server and a helper to look up captured tools.
  */
 function makeMockServer(): {
-  server: { tool: ReturnType<typeof vi.fn> };
+  server: { registerTool: ReturnType<typeof vi.fn> };
   getTool: (name: string) => CapturedTool;
   getRegistered: () => string[];
 } {
   const captured: CapturedTool[] = [];
 
-  const toolFn = vi.fn(
+  const registerToolFn = vi.fn(
     (
       name: string,
-      description: string,
-      schema: Record<string, unknown>,
+      config: { description?: string; inputSchema?: unknown },
       handler: (args: Record<string, unknown>) => Promise<ToolResult>,
     ) => {
-      captured.push({ name, description, schema, handler });
+      captured.push({
+        name,
+        description: config.description ?? "",
+        schema: config as Record<string, unknown>,
+        handler,
+      });
     },
   );
 
-  const server = { tool: toolFn };
+  const server = { registerTool: registerToolFn };
 
   return {
     server,

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1,0 +1,2269 @@
+/**
+ * Unit tests for tools.ts (dispatcher), tools/granular.ts, and tools/consolidated.ts.
+ *
+ * Strategy:
+ * - Mock McpServer to capture tool registrations and invoke handlers directly.
+ * - Mock ObsidianClient and VaultCache to avoid real HTTP calls.
+ * - Mock config.ts side-effecting exports (saveConfigToFile, setDebugEnabled, log).
+ * - Never use `any` — narrow with type guards throughout.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be hoisted before imports
+// ---------------------------------------------------------------------------
+
+vi.mock("../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config.js")>();
+  return {
+    ...actual,
+    saveConfigToFile: vi.fn(),
+    setDebugEnabled: vi.fn(),
+    log: vi.fn(),
+    getRedactedConfig: vi.fn((cfg: import("../config.js").Config) => ({
+      host: cfg.host,
+      port: cfg.port,
+      apiKey: cfg.apiKey ? "[SET]" : "[NOT SET]",
+    })),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import type { Config } from "../config.js";
+import { saveConfigToFile } from "../config.js";
+import { registerAllTools } from "../tools.js";
+import { registerGranularTools } from "../tools/granular.js";
+import { registerConsolidatedTools } from "../tools/consolidated.js";
+import type { ObsidianClient, NoteJson, ToolResult } from "../obsidian.js";
+import type { VaultCache } from "../cache.js";
+import { ObsidianApiError, ObsidianConnectionError, ObsidianAuthError } from "../errors.js";
+
+// ---------------------------------------------------------------------------
+// Suppress stderr
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers — mock factory types
+// ---------------------------------------------------------------------------
+
+/**
+ * A captured tool registration: the four arguments passed to server.tool().
+ * The handler signature matches the SDK: (args: unknown) => Promise<ToolResult>.
+ */
+interface CapturedTool {
+  name: string;
+  description: string;
+  schema: Record<string, unknown>;
+  handler: (args: Record<string, unknown>) => Promise<ToolResult>;
+}
+
+/**
+ * Creates a mock McpServer that captures every server.tool() call.
+ * Returns both the mock server and a helper to look up captured tools.
+ */
+function makeMockServer(): {
+  server: { tool: ReturnType<typeof vi.fn> };
+  getTool: (name: string) => CapturedTool;
+  getRegistered: () => string[];
+} {
+  const captured: CapturedTool[] = [];
+
+  const toolFn = vi.fn(
+    (
+      name: string,
+      description: string,
+      schema: Record<string, unknown>,
+      handler: (args: Record<string, unknown>) => Promise<ToolResult>,
+    ) => {
+      captured.push({ name, description, schema, handler });
+    },
+  );
+
+  const server = { tool: toolFn };
+
+  return {
+    server,
+    getTool: (name: string): CapturedTool => {
+      const found = captured.find((t) => t.name === name);
+      if (!found) throw new Error(`Tool "${name}" was not registered`);
+      return found;
+    },
+    getRegistered: () => captured.map((t) => t.name),
+  };
+}
+
+/** Creates a partial mock of ObsidianClient with all methods as vi.fn(). */
+function makeMockClient(): ObsidianClient {
+  return {
+    getServerStatus: vi.fn().mockResolvedValue({ ok: true, service: "Obsidian REST API", authenticated: true, versions: {} }),
+    listFilesInVault: vi.fn().mockResolvedValue({ files: [] }),
+    listFilesInDir: vi.fn().mockResolvedValue({ files: [] }),
+    getFileContents: vi.fn().mockResolvedValue("# File content"),
+    putContent: vi.fn().mockResolvedValue(undefined),
+    appendContent: vi.fn().mockResolvedValue(undefined),
+    patchContent: vi.fn().mockResolvedValue(undefined),
+    deleteFile: vi.fn().mockResolvedValue(undefined),
+    getActiveFile: vi.fn().mockResolvedValue("# Active file"),
+    putActiveFile: vi.fn().mockResolvedValue(undefined),
+    appendActiveFile: vi.fn().mockResolvedValue(undefined),
+    patchActiveFile: vi.fn().mockResolvedValue(undefined),
+    deleteActiveFile: vi.fn().mockResolvedValue(undefined),
+    listCommands: vi.fn().mockResolvedValue({ commands: [] }),
+    executeCommand: vi.fn().mockResolvedValue(undefined),
+    openFile: vi.fn().mockResolvedValue(undefined),
+    simpleSearch: vi.fn().mockResolvedValue([]),
+    complexSearch: vi.fn().mockResolvedValue([]),
+    dataviewSearch: vi.fn().mockResolvedValue([]),
+    getPeriodicNote: vi.fn().mockResolvedValue("# Periodic note"),
+    putPeriodicNote: vi.fn().mockResolvedValue(undefined),
+    appendPeriodicNote: vi.fn().mockResolvedValue(undefined),
+    patchPeriodicNote: vi.fn().mockResolvedValue(undefined),
+    deletePeriodicNote: vi.fn().mockResolvedValue(undefined),
+    getPeriodicNoteForDate: vi.fn().mockResolvedValue("# Periodic note for date"),
+    putPeriodicNoteForDate: vi.fn().mockResolvedValue(undefined),
+    appendPeriodicNoteForDate: vi.fn().mockResolvedValue(undefined),
+    patchPeriodicNoteForDate: vi.fn().mockResolvedValue(undefined),
+    deletePeriodicNoteForDate: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ObsidianClient;
+}
+
+/** Creates a mock VaultCache with configurable initialization state. */
+function makeMockCache(initialized = true): VaultCache {
+  return {
+    getIsInitialized: vi.fn().mockReturnValue(initialized),
+    getAllNotes: vi.fn().mockReturnValue([]),
+    getFileList: vi.fn().mockReturnValue([]),
+    noteCount: 0,
+    linkCount: 0,
+    getBacklinks: vi.fn().mockReturnValue([]),
+    getForwardLinks: vi.fn().mockReturnValue([]),
+    getOrphanNotes: vi.fn().mockReturnValue([]),
+    getMostConnectedNotes: vi.fn().mockReturnValue([]),
+    getVaultGraph: vi.fn().mockReturnValue({ nodes: [], edges: [] }),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    startAutoRefresh: vi.fn(),
+    stopAutoRefresh: vi.fn(),
+    getNote: vi.fn().mockReturnValue(undefined),
+    invalidate: vi.fn(),
+    invalidateAll: vi.fn(),
+  } as unknown as VaultCache;
+}
+
+/** Base config used by most tests — granular, full preset, cache enabled. */
+const BASE_CONFIG: Config = {
+  apiKey: "test-key",
+  host: "127.0.0.1",
+  port: 27124,
+  scheme: "https",
+  timeout: 30000,
+  certPath: undefined,
+  verifySsl: false,
+  verifyWrites: false,
+  maxResponseChars: 500000,
+  debug: false,
+  toolMode: "granular",
+  toolPreset: "full",
+  includeTools: [],
+  excludeTools: [],
+  cacheTtl: 600000,
+  enableCache: true,
+  configFilePath: undefined,
+};
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return { ...BASE_CONFIG, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: extract text from a ToolResult content array
+// ---------------------------------------------------------------------------
+
+function getText(result: ToolResult): string {
+  const first = result.content[0];
+  return first ? first.text : "";
+}
+
+// ===========================================================================
+// Section 1: registerAllTools dispatcher
+// ===========================================================================
+
+describe("registerAllTools — granular mode", () => {
+  it("registers 38 tools in full preset", () => {
+    const { server, getRegistered } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    const count = registerAllTools(server as never, client, cache, makeConfig());
+    expect(count).toBe(38);
+    expect(getRegistered()).toHaveLength(38);
+  });
+
+  it("registers 20 tools in read-only preset", () => {
+    const { server } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    const count = registerAllTools(
+      server as never, client, cache,
+      makeConfig({ toolPreset: "read-only" }),
+    );
+    expect(count).toBe(20);
+  });
+
+  it("registers 8 tools in minimal preset", () => {
+    // 7 preset tools + refresh_cache (protected, not in minimal preset)
+    const { server } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    const count = registerAllTools(
+      server as never, client, cache,
+      makeConfig({ toolPreset: "minimal" }),
+    );
+    expect(count).toBe(8);
+  });
+
+  it("registers 34 tools in safe preset", () => {
+    const { server } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    const count = registerAllTools(
+      server as never, client, cache,
+      makeConfig({ toolPreset: "safe" }),
+    );
+    expect(count).toBe(34);
+  });
+
+  it("protected tools are always registered even when excluded", () => {
+    const { server, getRegistered } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    registerAllTools(
+      server as never, client, cache,
+      makeConfig({ excludeTools: ["configure", "get_server_status", "refresh_cache"] }),
+    );
+    const registered = getRegistered();
+    expect(registered).toContain("configure");
+    expect(registered).toContain("get_server_status");
+    expect(registered).toContain("refresh_cache");
+  });
+
+  it("INCLUDE_TOOLS whitelist filters to only specified + protected tools", () => {
+    const { server, getRegistered } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    registerAllTools(
+      server as never, client, cache,
+      makeConfig({ includeTools: ["list_files_in_vault", "simple_search"] }),
+    );
+    const registered = getRegistered();
+    expect(registered).toContain("list_files_in_vault");
+    expect(registered).toContain("simple_search");
+    // Protected tools always appear
+    expect(registered).toContain("configure");
+    expect(registered).toContain("get_server_status");
+    expect(registered).toContain("refresh_cache");
+    // Unspecified non-protected tools must NOT appear
+    expect(registered).not.toContain("delete_file");
+    expect(registered).not.toContain("put_content");
+    expect(registered).not.toContain("append_content");
+  });
+
+  it("EXCLUDE_TOOLS removes tools but preserves protected", () => {
+    const { server, getRegistered } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    registerAllTools(
+      server as never, client, cache,
+      makeConfig({ excludeTools: ["delete_file", "delete_active_file"] }),
+    );
+    const registered = getRegistered();
+    expect(registered).not.toContain("delete_file");
+    expect(registered).not.toContain("delete_active_file");
+    // Protected tools survive exclusion
+    expect(registered).toContain("configure");
+    expect(registered).toContain("get_server_status");
+    expect(registered).toContain("refresh_cache");
+  });
+
+  it("INCLUDE_TOOLS tool not in preset is not registered", () => {
+    // In minimal preset, delete_file is not in the preset; requesting it via INCLUDE should not register it
+    const { server, getRegistered } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    registerAllTools(
+      server as never, client, cache,
+      makeConfig({ toolPreset: "minimal", includeTools: ["delete_file"] }),
+    );
+    // delete_file is not in the minimal preset, so including it has no effect
+    expect(getRegistered()).not.toContain("delete_file");
+  });
+});
+
+describe("registerAllTools — consolidated mode", () => {
+  it("registers 11 tools in full preset", () => {
+    const { server } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    const count = registerAllTools(
+      server as never, client, cache,
+      makeConfig({ toolMode: "consolidated" }),
+    );
+    expect(count).toBe(11);
+  });
+
+  it("registers 4 tools in minimal preset", () => {
+    const { server } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    const count = registerAllTools(
+      server as never, client, cache,
+      makeConfig({ toolMode: "consolidated", toolPreset: "minimal" }),
+    );
+    expect(count).toBe(4);
+  });
+
+  it("protected tools (configure, status) always registered when excluded", () => {
+    const { server, getRegistered } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    registerAllTools(
+      server as never, client, cache,
+      makeConfig({ toolMode: "consolidated", excludeTools: ["configure", "status"] }),
+    );
+    const registered = getRegistered();
+    expect(registered).toContain("configure");
+    expect(registered).toContain("status");
+  });
+
+  it("INCLUDE_TOOLS filters consolidated tools", () => {
+    const { server, getRegistered } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    registerAllTools(
+      server as never, client, cache,
+      makeConfig({ toolMode: "consolidated", includeTools: ["vault", "search"] }),
+    );
+    const registered = getRegistered();
+    expect(registered).toContain("vault");
+    expect(registered).toContain("search");
+    expect(registered).not.toContain("recent");
+    expect(registered).not.toContain("batch_get");
+    // Protected
+    expect(registered).toContain("configure");
+    expect(registered).toContain("status");
+  });
+});
+
+// ===========================================================================
+// Section 2: granular.ts tool handlers
+// ===========================================================================
+
+describe("granular tools — registration and basic behavior", () => {
+  function setup(configOverrides: Partial<Config> = {}): {
+    client: ObsidianClient;
+    cache: VaultCache;
+    getTool: (name: string) => CapturedTool;
+  } {
+    const { server, getTool } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    const config = makeConfig(configOverrides);
+    registerGranularTools(server as never, client, cache, () => true, config);
+    return { client, cache, getTool };
+  }
+
+  // -------------------------------------------------------------------------
+  // list_files_in_vault
+  // -------------------------------------------------------------------------
+  describe("list_files_in_vault", () => {
+    it("calls client.listFilesInVault and returns json result", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.listFilesInVault).mockResolvedValue({ files: ["a.md", "b.md"] });
+      const result = await getTool("list_files_in_vault").handler({});
+      expect(client.listFilesInVault).toHaveBeenCalled();
+      expect(getText(result)).toContain("a.md");
+      expect(result.isError).toBeFalsy();
+    });
+
+    it("returns errorResult on connection error", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.listFilesInVault).mockRejectedValue(new ObsidianConnectionError("refused"));
+      const result = await getTool("list_files_in_vault").handler({});
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("CONNECTION ERROR");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // list_files_in_dir
+  // -------------------------------------------------------------------------
+  describe("list_files_in_dir", () => {
+    it("calls client.listFilesInDir with the given dirPath", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.listFilesInDir).mockResolvedValue({ files: ["dir/note.md"] });
+      const result = await getTool("list_files_in_dir").handler({ dirPath: "dir" });
+      expect(client.listFilesInDir).toHaveBeenCalledWith("dir");
+      expect(getText(result)).toContain("dir/note.md");
+    });
+
+    it("returns errorResult on API 404", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.listFilesInDir).mockRejectedValue(new ObsidianApiError("not found", 404));
+      const result = await getTool("list_files_in_dir").handler({ dirPath: "missing" });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("NOT FOUND");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_file_contents
+  // -------------------------------------------------------------------------
+  describe("get_file_contents", () => {
+    it("returns text for markdown format", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents).mockResolvedValue("# Hello");
+      const result = await getTool("get_file_contents").handler({ filePath: "note.md" });
+      expect(client.getFileContents).toHaveBeenCalledWith("note.md", undefined);
+      expect(getText(result)).toBe("# Hello");
+      expect(result.isError).toBeFalsy();
+    });
+
+    it("serialises NoteJson result as JSON", async () => {
+      const { client, getTool } = setup();
+      const noteJson: NoteJson = {
+        content: "# Hello",
+        frontmatter: {},
+        path: "note.md",
+        tags: [],
+        stat: { ctime: 0, mtime: 1000, size: 10 },
+      };
+      vi.mocked(client.getFileContents).mockResolvedValue(noteJson);
+      const result = await getTool("get_file_contents").handler({ filePath: "note.md", format: "json" });
+      expect(getText(result)).toContain('"path": "note.md"');
+    });
+
+    it("returns errorResult on auth error", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents).mockRejectedValue(new ObsidianAuthError());
+      const result = await getTool("get_file_contents").handler({ filePath: "note.md" });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("AUTH ERROR");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // put_content
+  // -------------------------------------------------------------------------
+  describe("put_content", () => {
+    it("calls client.putContent and returns success message", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("put_content").handler({ filePath: "test.md", content: "hello" });
+      expect(client.putContent).toHaveBeenCalledWith("test.md", "hello");
+      expect(getText(result)).toContain("Written: test.md");
+    });
+
+    it("returns errorResult on failure", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.putContent).mockRejectedValue(new Error("write failed"));
+      const result = await getTool("put_content").handler({ filePath: "test.md", content: "x" });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // append_content
+  // -------------------------------------------------------------------------
+  describe("append_content", () => {
+    it("calls client.appendContent and returns success", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("append_content").handler({ filePath: "note.md", content: "extra" });
+      expect(client.appendContent).toHaveBeenCalledWith("note.md", "extra");
+      expect(getText(result)).toContain("Appended to: note.md");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // patch_content
+  // -------------------------------------------------------------------------
+  describe("patch_content", () => {
+    it("calls client.patchContent with all options", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("patch_content").handler({
+        filePath: "note.md",
+        content: "new line",
+        operation: "append",
+        targetType: "heading",
+        target: "Section",
+        createIfMissing: true,
+      });
+      expect(client.patchContent).toHaveBeenCalledWith("note.md", "new line", {
+        operation: "append",
+        targetType: "heading",
+        target: "Section",
+        targetDelimiter: undefined,
+        trimTargetWhitespace: undefined,
+        createIfMissing: true,
+        contentType: undefined,
+      });
+      expect(getText(result)).toContain("Patched: note.md");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // delete_file
+  // -------------------------------------------------------------------------
+  describe("delete_file", () => {
+    it("calls client.deleteFile and returns success", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("delete_file").handler({ filePath: "old.md" });
+      expect(client.deleteFile).toHaveBeenCalledWith("old.md");
+      expect(getText(result)).toContain("Deleted: old.md");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // search_replace
+  // -------------------------------------------------------------------------
+  describe("search_replace", () => {
+    it("reads file, replaces text, and writes back", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents).mockResolvedValue("Hello world");
+      const result = await getTool("search_replace").handler({
+        filePath: "note.md",
+        search: "world",
+        replace: "Obsidian",
+        useRegex: false,
+        caseSensitive: true,
+        replaceAll: true,
+      });
+      expect(client.putContent).toHaveBeenCalledWith("note.md", "Hello Obsidian");
+      expect(getText(result)).toContain("Replaced in: note.md");
+    });
+
+    it("returns no-match message when pattern not found", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents).mockResolvedValue("Hello world");
+      const result = await getTool("search_replace").handler({
+        filePath: "note.md",
+        search: "xyz",
+        replace: "abc",
+        useRegex: false,
+        caseSensitive: true,
+        replaceAll: true,
+      });
+      expect(client.putContent).not.toHaveBeenCalled();
+      expect(getText(result)).toContain("No matches found");
+    });
+
+    it("uses regex when useRegex=true", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents).mockResolvedValue("cat 123 cat");
+      const result = await getTool("search_replace").handler({
+        filePath: "note.md",
+        search: "\\d+",
+        replace: "NUM",
+        useRegex: true,
+        caseSensitive: true,
+        replaceAll: true,
+      });
+      expect(client.putContent).toHaveBeenCalledWith("note.md", "cat NUM cat");
+      expect(getText(result)).toContain("Replaced in");
+    });
+
+    it("escapes regex special chars when useRegex=false", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents).mockResolvedValue("price: $5.00");
+      const result = await getTool("search_replace").handler({
+        filePath: "note.md",
+        search: "$5.00",
+        replace: "$10.00",
+        useRegex: false,
+        caseSensitive: true,
+        replaceAll: false,
+      });
+      expect(client.putContent).toHaveBeenCalledWith("note.md", "price: $10.00");
+      expect(getText(result)).toContain("Replaced in");
+    });
+
+    it("returns errorResult when getFileContents returns non-string", async () => {
+      const { client, getTool } = setup();
+      const noteJson: NoteJson = { content: "", frontmatter: {}, path: "x.md", tags: [], stat: { ctime: 0, mtime: 0, size: 0 } };
+      vi.mocked(client.getFileContents).mockResolvedValue(noteJson);
+      const result = await getTool("search_replace").handler({
+        filePath: "note.md",
+        search: "x",
+        replace: "y",
+        useRegex: false,
+        caseSensitive: true,
+        replaceAll: true,
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("Expected markdown content");
+    });
+
+    it("case-insensitive replace with caseSensitive=false", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents).mockResolvedValue("Hello WORLD");
+      await getTool("search_replace").handler({
+        filePath: "note.md",
+        search: "world",
+        replace: "Obsidian",
+        useRegex: false,
+        caseSensitive: false,
+        replaceAll: true,
+      });
+      expect(client.putContent).toHaveBeenCalledWith("note.md", "Hello Obsidian");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_active_file
+  // -------------------------------------------------------------------------
+  describe("get_active_file", () => {
+    it("calls client.getActiveFile and returns content", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getActiveFile).mockResolvedValue("# Active");
+      const result = await getTool("get_active_file").handler({});
+      expect(getText(result)).toBe("# Active");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // put_active_file
+  // -------------------------------------------------------------------------
+  describe("put_active_file", () => {
+    it("calls client.putActiveFile with content", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("put_active_file").handler({ content: "new content" });
+      expect(client.putActiveFile).toHaveBeenCalledWith("new content");
+      expect(getText(result)).toContain("Active file updated");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // append_active_file
+  // -------------------------------------------------------------------------
+  describe("append_active_file", () => {
+    it("calls client.appendActiveFile", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("append_active_file").handler({ content: "appended" });
+      expect(client.appendActiveFile).toHaveBeenCalledWith("appended");
+      expect(getText(result)).toContain("Appended to active file");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // patch_active_file
+  // -------------------------------------------------------------------------
+  describe("patch_active_file", () => {
+    it("calls client.patchActiveFile without createIfMissing", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("patch_active_file").handler({
+        content: "text",
+        operation: "prepend",
+        targetType: "frontmatter",
+        target: "status",
+      });
+      expect(client.patchActiveFile).toHaveBeenCalledWith("text", {
+        operation: "prepend",
+        targetType: "frontmatter",
+        target: "status",
+        targetDelimiter: undefined,
+        trimTargetWhitespace: undefined,
+        contentType: undefined,
+      });
+      expect(getText(result)).toContain("Active file patched");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // delete_active_file
+  // -------------------------------------------------------------------------
+  describe("delete_active_file", () => {
+    it("calls client.deleteActiveFile", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("delete_active_file").handler({});
+      expect(client.deleteActiveFile).toHaveBeenCalled();
+      expect(getText(result)).toContain("Active file deleted");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // list_commands
+  // -------------------------------------------------------------------------
+  describe("list_commands", () => {
+    it("returns command list", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.listCommands).mockResolvedValue({ commands: [{ id: "cmd:1", name: "Toggle" }] });
+      const result = await getTool("list_commands").handler({});
+      expect(getText(result)).toContain("Toggle");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // execute_command
+  // -------------------------------------------------------------------------
+  describe("execute_command", () => {
+    it("calls client.executeCommand with commandId", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("execute_command").handler({ commandId: "editor:toggle-bold" });
+      expect(client.executeCommand).toHaveBeenCalledWith("editor:toggle-bold");
+      expect(getText(result)).toContain("Executed: editor:toggle-bold");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // open_file
+  // -------------------------------------------------------------------------
+  describe("open_file", () => {
+    it("calls client.openFile with path and newLeaf", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("open_file").handler({ filePath: "note.md", newLeaf: true });
+      expect(client.openFile).toHaveBeenCalledWith("note.md", true);
+      expect(getText(result)).toContain("Opened: note.md");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // simple_search
+  // -------------------------------------------------------------------------
+  describe("simple_search", () => {
+    it("calls client.simpleSearch with query and contextLength", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.simpleSearch).mockResolvedValue([{ filename: "match.md", score: 1 }]);
+      const result = await getTool("simple_search").handler({ query: "hello", contextLength: 200 });
+      expect(client.simpleSearch).toHaveBeenCalledWith("hello", 200);
+      expect(getText(result)).toContain("match.md");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // complex_search
+  // -------------------------------------------------------------------------
+  describe("complex_search", () => {
+    it("calls client.complexSearch with query object", async () => {
+      const { client, getTool } = setup();
+      const query = { glob: [{ var: "path" }, "*.md"] };
+      await getTool("complex_search").handler({ query });
+      expect(client.complexSearch).toHaveBeenCalledWith(query);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // dataview_search
+  // -------------------------------------------------------------------------
+  describe("dataview_search", () => {
+    it("calls client.dataviewSearch with dql string", async () => {
+      const { client, getTool } = setup();
+      await getTool("dataview_search").handler({ dql: 'LIST FROM ""' });
+      expect(client.dataviewSearch).toHaveBeenCalledWith('LIST FROM ""');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_periodic_note
+  // -------------------------------------------------------------------------
+  describe("get_periodic_note", () => {
+    it("calls client.getPeriodicNote with period and format", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getPeriodicNote).mockResolvedValue("# Daily");
+      const result = await getTool("get_periodic_note").handler({ period: "daily" });
+      expect(client.getPeriodicNote).toHaveBeenCalledWith("daily", undefined);
+      expect(getText(result)).toBe("# Daily");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // put_periodic_note
+  // -------------------------------------------------------------------------
+  describe("put_periodic_note", () => {
+    it("calls client.putPeriodicNote", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("put_periodic_note").handler({ period: "weekly", content: "# Week" });
+      expect(client.putPeriodicNote).toHaveBeenCalledWith("weekly", "# Week");
+      expect(getText(result)).toContain("Updated weekly note");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // append_periodic_note
+  // -------------------------------------------------------------------------
+  describe("append_periodic_note", () => {
+    it("calls client.appendPeriodicNote", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("append_periodic_note").handler({ period: "daily", content: "- item" });
+      expect(client.appendPeriodicNote).toHaveBeenCalledWith("daily", "- item");
+      expect(getText(result)).toContain("Appended to daily note");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // patch_periodic_note
+  // -------------------------------------------------------------------------
+  describe("patch_periodic_note", () => {
+    it("calls client.patchPeriodicNote with patch options", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("patch_periodic_note").handler({
+        period: "monthly",
+        content: "value",
+        operation: "replace",
+        targetType: "frontmatter",
+        target: "status",
+      });
+      expect(client.patchPeriodicNote).toHaveBeenCalledWith("monthly", "value", {
+        operation: "replace",
+        targetType: "frontmatter",
+        target: "status",
+        targetDelimiter: undefined,
+        trimTargetWhitespace: undefined,
+        createIfMissing: undefined,
+        contentType: undefined,
+      });
+      expect(getText(result)).toContain("Patched monthly note");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // delete_periodic_note
+  // -------------------------------------------------------------------------
+  describe("delete_periodic_note", () => {
+    it("calls client.deletePeriodicNote", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("delete_periodic_note").handler({ period: "yearly" });
+      expect(client.deletePeriodicNote).toHaveBeenCalledWith("yearly");
+      expect(getText(result)).toContain("Deleted yearly note");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_periodic_note_for_date
+  // -------------------------------------------------------------------------
+  describe("get_periodic_note_for_date", () => {
+    it("calls client.getPeriodicNoteForDate with correct args", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getPeriodicNoteForDate).mockResolvedValue("# Jan 5");
+      const result = await getTool("get_periodic_note_for_date").handler({
+        period: "daily", year: 2025, month: 1, day: 5,
+      });
+      expect(client.getPeriodicNoteForDate).toHaveBeenCalledWith("daily", 2025, 1, 5, undefined);
+      expect(getText(result)).toBe("# Jan 5");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // put_periodic_note_for_date
+  // -------------------------------------------------------------------------
+  describe("put_periodic_note_for_date", () => {
+    it("calls client.putPeriodicNoteForDate with correct args", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("put_periodic_note_for_date").handler({
+        period: "daily", year: 2025, month: 3, day: 14, content: "# Pi Day",
+      });
+      expect(client.putPeriodicNoteForDate).toHaveBeenCalledWith("daily", 2025, 3, 14, "# Pi Day");
+      expect(getText(result)).toContain("2025-3-14");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // append_periodic_note_for_date
+  // -------------------------------------------------------------------------
+  describe("append_periodic_note_for_date", () => {
+    it("calls client.appendPeriodicNoteForDate", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("append_periodic_note_for_date").handler({
+        period: "daily", year: 2025, month: 6, day: 1, content: "extra",
+      });
+      expect(client.appendPeriodicNoteForDate).toHaveBeenCalledWith("daily", 2025, 6, 1, "extra");
+      expect(getText(result)).toContain("Appended to daily note for 2025-6-1");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // patch_periodic_note_for_date
+  // -------------------------------------------------------------------------
+  describe("patch_periodic_note_for_date", () => {
+    it("calls client.patchPeriodicNoteForDate with patch options", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("patch_periodic_note_for_date").handler({
+        period: "daily", year: 2025, month: 1, day: 1, content: "val",
+        operation: "append", targetType: "heading", target: "Tasks",
+      });
+      expect(client.patchPeriodicNoteForDate).toHaveBeenCalledWith(
+        "daily", 2025, 1, 1, "val",
+        { operation: "append", targetType: "heading", target: "Tasks",
+          targetDelimiter: undefined, trimTargetWhitespace: undefined,
+          createIfMissing: undefined, contentType: undefined },
+      );
+      expect(getText(result)).toContain("Patched daily note for 2025-1-1");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // delete_periodic_note_for_date
+  // -------------------------------------------------------------------------
+  describe("delete_periodic_note_for_date", () => {
+    it("calls client.deletePeriodicNoteForDate", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("delete_periodic_note_for_date").handler({
+        period: "daily", year: 2025, month: 12, day: 31,
+      });
+      expect(client.deletePeriodicNoteForDate).toHaveBeenCalledWith("daily", 2025, 12, 31);
+      expect(getText(result)).toContain("Deleted daily note for 2025-12-31");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_server_status (PROTECTED)
+  // -------------------------------------------------------------------------
+  describe("get_server_status", () => {
+    it("calls client.getServerStatus and returns json", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getServerStatus).mockResolvedValue({
+        ok: true, service: "Obsidian Local REST API", authenticated: true, versions: { obsidian: "1.7" },
+      });
+      const result = await getTool("get_server_status").handler({});
+      expect(getText(result)).toContain("Obsidian Local REST API");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // batch_get_file_contents
+  // -------------------------------------------------------------------------
+  describe("batch_get_file_contents", () => {
+    it("fetches all files and returns combined result", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents)
+        .mockResolvedValueOnce("# Note A")
+        .mockResolvedValueOnce("# Note B");
+      const result = await getTool("batch_get_file_contents").handler({
+        filePaths: ["a.md", "b.md"],
+      });
+      const parsed: unknown = JSON.parse(getText(result));
+      expect(Array.isArray(parsed)).toBe(true);
+      if (Array.isArray(parsed)) {
+        expect(parsed).toHaveLength(2);
+      }
+    });
+
+    it("handles partial failures — includes error for failed files", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents)
+        .mockResolvedValueOnce("# Note A")
+        .mockRejectedValueOnce(new ObsidianApiError("not found", 404));
+      const result = await getTool("batch_get_file_contents").handler({
+        filePaths: ["a.md", "missing.md"],
+      });
+      const parsed: unknown = JSON.parse(getText(result));
+      expect(Array.isArray(parsed)).toBe(true);
+      if (Array.isArray(parsed)) {
+        // One success, one error entry
+        const hasError = parsed.some((item) => {
+          if (item !== null && typeof item === "object" && "error" in item) return true;
+          return false;
+        });
+        expect(hasError).toBe(true);
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_recent_changes — cache path
+  // -------------------------------------------------------------------------
+  describe("get_recent_changes — cache enabled", () => {
+    it("returns sorted notes from cache when initialized", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      vi.mocked(cache.getAllNotes).mockReturnValue([
+        { path: "old.md", content: "", frontmatter: {}, tags: [], stat: { ctime: 0, mtime: 100, size: 0 }, links: [], cachedAt: 0 },
+        { path: "new.md", content: "", frontmatter: {}, tags: [], stat: { ctime: 0, mtime: 999, size: 0 }, links: [], cachedAt: 0 },
+      ] as never);
+      registerGranularTools(server as never, client, cache, () => true, makeConfig({ enableCache: true }));
+      const result = await getTool("get_recent_changes").handler({ limit: 5 });
+      const parsed: unknown = JSON.parse(getText(result));
+      expect(Array.isArray(parsed)).toBe(true);
+      if (Array.isArray(parsed)) {
+        const first = parsed[0] as Record<string, unknown>;
+        expect(first["path"]).toBe("new.md");
+      }
+    });
+
+    it("falls back to API listing when cache is disabled", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(false);
+      vi.mocked(client.listFilesInVault).mockResolvedValue({ files: ["note.md"] });
+      vi.mocked(client.getFileContents).mockResolvedValue({
+        content: "", frontmatter: {}, path: "note.md", tags: [], stat: { ctime: 0, mtime: 500, size: 0 },
+      } as NoteJson);
+      registerGranularTools(server as never, client, cache, () => true, makeConfig({ enableCache: false }));
+      const result = await getTool("get_recent_changes").handler({ limit: 5 });
+      expect(client.listFilesInVault).toHaveBeenCalled();
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_recent_periodic_notes
+  // -------------------------------------------------------------------------
+  describe("get_recent_periodic_notes", () => {
+    it("filters vault files by period directory and returns sorted list", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.listFilesInVault).mockResolvedValue({
+        files: [
+          "Daily Notes/2025-01-01.md",
+          "Daily Notes/2025-01-02.md",
+          "Other/note.md",
+        ],
+      });
+      const result = await getTool("get_recent_periodic_notes").handler({ period: "daily", limit: 5 });
+      const parsed: unknown = JSON.parse(getText(result));
+      expect(Array.isArray(parsed)).toBe(true);
+      if (Array.isArray(parsed)) {
+        expect(parsed).toHaveLength(2);
+        expect(parsed[0]).toContain("Daily Notes");
+        // Should be reversed (most recent first)
+        expect(parsed[0]).toContain("2025-01-02");
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // configure — show
+  // -------------------------------------------------------------------------
+  describe("configure — show action", () => {
+    it("returns redacted config as JSON", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "show" });
+      expect(result.isError).toBeFalsy();
+      // The mocked getRedactedConfig returns apiKey: "[SET]"
+      expect(getText(result)).toContain("[SET]");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // configure — set (immediate settings)
+  // -------------------------------------------------------------------------
+  describe("configure — set action (immediate settings)", () => {
+    it("sets debug=true and calls saveConfigToFile", async () => {
+      const { getTool } = setup({ configFilePath: "/tmp/test-config.json" });
+      const result = await getTool("configure").handler({ action: "set", setting: "debug", value: "true" });
+      expect(saveConfigToFile).toHaveBeenCalledWith("/tmp/test-config.json", { debug: true });
+      expect(getText(result)).toContain("effective immediately");
+    });
+
+    it("returns errorResult for unknown setting", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "unknownSetting", value: "foo" });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("Unknown setting");
+    });
+
+    it("returns errorResult when setting is missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set" });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("Setting name is required");
+    });
+
+    it("returns errorResult when value is missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "debug" });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("Value is required");
+    });
+
+    it("returns errorResult for invalid debug value", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "debug", value: "maybe" });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("Invalid value");
+    });
+
+    it("sets timeout and saves to file", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "timeout", value: "60000" });
+      expect(saveConfigToFile).toHaveBeenCalledWith(
+        expect.any(String),
+        { reliability: { timeout: 60000 } },
+      );
+      expect(getText(result)).toContain("effective immediately");
+    });
+
+    it("rejects invalid timeout (non-numeric)", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "timeout", value: "abc" });
+      expect(result.isError).toBe(true);
+    });
+
+    it("sets toolMode — requires restart", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "toolMode", value: "consolidated" });
+      expect(getText(result)).toContain("Restart the server");
+    });
+
+    it("rejects invalid toolMode value", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "toolMode", value: "unknown" });
+      expect(result.isError).toBe(true);
+    });
+
+    it("sets toolPreset — requires restart", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "toolPreset", value: "read-only" });
+      expect(getText(result)).toContain("Restart the server");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // configure — reset
+  // -------------------------------------------------------------------------
+  describe("configure — reset action", () => {
+    it("resets debug to default", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "reset", setting: "debug" });
+      expect(saveConfigToFile).toHaveBeenCalledWith(expect.any(String), { debug: false });
+      expect(getText(result)).toContain("reset to default");
+    });
+
+    it("returns errorResult for unknown setting", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "reset", setting: "unknownKey" });
+      expect(result.isError).toBe(true);
+    });
+
+    it("returns errorResult when setting is missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "reset" });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_backlinks (cache-dependent)
+  // -------------------------------------------------------------------------
+  describe("get_backlinks", () => {
+    it("returns backlinks from cache when initialized", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      vi.mocked(cache.getBacklinks).mockReturnValue([
+        { source: "linker.md", context: "...see [[target.md]]..." },
+      ]);
+      registerGranularTools(server as never, client, cache, () => true, makeConfig({ enableCache: true }));
+      const result = await getTool("get_backlinks").handler({ filePath: "target.md" });
+      expect(cache.getBacklinks).toHaveBeenCalledWith("target.md");
+      expect(getText(result)).toContain("linker.md");
+    });
+
+    it("returns errorResult when cache is disabled", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      registerGranularTools(server as never, client, cache, () => true, makeConfig({ enableCache: false }));
+      const result = await getTool("get_backlinks").handler({ filePath: "target.md" });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("Cache is disabled");
+    });
+
+    it("returns errorResult when cache is not yet initialized", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(false);
+      registerGranularTools(server as never, client, cache, () => true, makeConfig({ enableCache: true }));
+      const result = await getTool("get_backlinks").handler({ filePath: "target.md" });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("still building");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_vault_structure (cache-dependent)
+  // -------------------------------------------------------------------------
+  describe("get_vault_structure", () => {
+    it("returns vault stats from cache", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      vi.mocked(cache.getOrphanNotes).mockReturnValue(["orphan.md"]);
+      vi.mocked(cache.getMostConnectedNotes).mockReturnValue([{ path: "hub.md", inbound: 5, outbound: 3 }]);
+      vi.mocked(cache.getVaultGraph).mockReturnValue({ nodes: ["a.md"], edges: [{ source: "a.md", target: "b.md" }] });
+      vi.mocked(cache.getFileList).mockReturnValue(["subdir/note.md", "root.md"]);
+      Object.defineProperty(cache, "noteCount", { get: vi.fn().mockReturnValue(10) });
+      Object.defineProperty(cache, "linkCount", { get: vi.fn().mockReturnValue(5) });
+      registerGranularTools(server as never, client, cache, () => true, makeConfig({ enableCache: true }));
+      const result = await getTool("get_vault_structure").handler({ limit: 10 });
+      expect(result.isError).toBeFalsy();
+      const parsed: unknown = JSON.parse(getText(result));
+      expect(parsed).toMatchObject({ orphanCount: 1, edgeCount: 1 });
+    });
+
+    it("returns errorResult when cache disabled", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      registerGranularTools(server as never, client, cache, () => true, makeConfig({ enableCache: false }));
+      const result = await getTool("get_vault_structure").handler({ limit: 10 });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("Cache is disabled");
+    });
+
+    it("returns errorResult when cache not initialized", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(false);
+      registerGranularTools(server as never, client, cache, () => true, makeConfig({ enableCache: true }));
+      const result = await getTool("get_vault_structure").handler({ limit: 10 });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_note_connections (cache-dependent)
+  // -------------------------------------------------------------------------
+  describe("get_note_connections", () => {
+    it("returns backlinks and forward links from cache", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      vi.mocked(cache.getBacklinks).mockReturnValue([{ source: "a.md", context: "see [[target]]" }]);
+      vi.mocked(cache.getForwardLinks).mockReturnValue([{ target: "b.md", type: "wikilink", context: "[[b]]" }]);
+      registerGranularTools(server as never, client, cache, () => true, makeConfig({ enableCache: true }));
+      const result = await getTool("get_note_connections").handler({ filePath: "target.md" });
+      const parsed: unknown = JSON.parse(getText(result));
+      expect(parsed).toMatchObject({ backlinks: [{ source: "a.md" }], forwardLinks: [{ target: "b.md" }] });
+    });
+
+    it("returns errorResult when cache disabled", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      registerGranularTools(server as never, client, cache, () => true, makeConfig({ enableCache: false }));
+      const result = await getTool("get_note_connections").handler({ filePath: "x.md" });
+      expect(result.isError).toBe(true);
+    });
+
+    it("returns errorResult when cache not initialized", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(false);
+      registerGranularTools(server as never, client, cache, () => true, makeConfig({ enableCache: true }));
+      const result = await getTool("get_note_connections").handler({ filePath: "x.md" });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // refresh_cache (PROTECTED)
+  // -------------------------------------------------------------------------
+  describe("refresh_cache", () => {
+    it("calls cache.refresh and returns count summary", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      registerGranularTools(server as never, client, cache, () => true, makeConfig({ enableCache: true }));
+      const result = await getTool("refresh_cache").handler({});
+      expect(cache.refresh).toHaveBeenCalled();
+      expect(result.isError).toBeFalsy();
+      expect(getText(result)).toContain("Cache refreshed");
+    });
+
+    it("returns errorResult when cache is disabled", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      registerGranularTools(server as never, client, cache, () => true, makeConfig({ enableCache: false }));
+      const result = await getTool("refresh_cache").handler({});
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("Cache is disabled");
+    });
+
+    it("returns errorResult when cache.refresh rejects", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      vi.mocked(cache.refresh).mockRejectedValue(new Error("network error"));
+      registerGranularTools(server as never, client, cache, () => true, makeConfig({ enableCache: true }));
+      const result = await getTool("refresh_cache").handler({});
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tool not registered when shouldRegister returns false
+  // -------------------------------------------------------------------------
+  describe("shouldRegister predicate", () => {
+    it("skips tools when shouldRegister returns false", () => {
+      const { server, getRegistered } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache();
+      registerGranularTools(server as never, client, cache, (name) => name === "list_files_in_vault", makeConfig());
+      const registered = getRegistered();
+      expect(registered).toEqual(["list_files_in_vault"]);
+    });
+  });
+});
+
+// ===========================================================================
+// Section 3: consolidated.ts tool handlers
+// ===========================================================================
+
+describe("consolidated tools — registration and behavior", () => {
+  function setup(configOverrides: Partial<Config> = {}): {
+    client: ObsidianClient;
+    cache: VaultCache;
+    getTool: (name: string) => CapturedTool;
+  } {
+    const { server, getTool } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    const config = makeConfig({ toolMode: "consolidated", ...configOverrides });
+    registerConsolidatedTools(server as never, client, cache, () => true, config);
+    return { client, cache, getTool };
+  }
+
+  // -------------------------------------------------------------------------
+  // vault tool
+  // -------------------------------------------------------------------------
+  describe("vault — list action", () => {
+    it("calls client.listFilesInVault", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.listFilesInVault).mockResolvedValue({ files: ["x.md"] });
+      const result = await getTool("vault").handler({ action: "list", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(client.listFilesInVault).toHaveBeenCalled();
+      expect(getText(result)).toContain("x.md");
+    });
+  });
+
+  describe("vault — list_dir action", () => {
+    it("calls client.listFilesInDir with path", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("vault").handler({ action: "list_dir", path: "mydir", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(client.listFilesInDir).toHaveBeenCalledWith("mydir");
+    });
+
+    it("returns errorResult when path is missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("vault").handler({ action: "list_dir", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("path is required");
+    });
+  });
+
+  describe("vault — get action", () => {
+    it("calls client.getFileContents with path and format", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents).mockResolvedValue("# Content");
+      const result = await getTool("vault").handler({ action: "get", path: "note.md", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(client.getFileContents).toHaveBeenCalledWith("note.md", undefined);
+      expect(getText(result)).toBe("# Content");
+    });
+
+    it("returns errorResult when path is missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("vault").handler({ action: "get", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("vault — put action", () => {
+    it("calls client.putContent", async () => {
+      const { client, getTool } = setup();
+      await getTool("vault").handler({ action: "put", path: "note.md", content: "body", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(client.putContent).toHaveBeenCalledWith("note.md", "body");
+    });
+
+    it("returns errorResult when path missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("vault").handler({ action: "put", content: "body", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(result.isError).toBe(true);
+    });
+
+    it("returns errorResult when content missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("vault").handler({ action: "put", path: "note.md", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("vault — append action", () => {
+    it("calls client.appendContent", async () => {
+      const { client, getTool } = setup();
+      await getTool("vault").handler({ action: "append", path: "note.md", content: "extra", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(client.appendContent).toHaveBeenCalledWith("note.md", "extra");
+    });
+  });
+
+  describe("vault — patch action", () => {
+    it("calls client.patchContent with all patch options", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("vault").handler({
+        action: "patch", path: "note.md", content: "text",
+        operation: "append", targetType: "heading", target: "Section",
+        useRegex: false, caseSensitive: true, replaceAll: true,
+      });
+      expect(client.patchContent).toHaveBeenCalledWith("note.md", "text", {
+        operation: "append", targetType: "heading", target: "Section",
+        targetDelimiter: undefined, trimTargetWhitespace: undefined,
+        createIfMissing: undefined, contentType: undefined,
+      });
+      expect(getText(result)).toContain("Patched: note.md");
+    });
+
+    it("returns errorResult when operation missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("vault").handler({
+        action: "patch", path: "note.md", content: "text",
+        targetType: "heading", target: "Section",
+        useRegex: false, caseSensitive: true, replaceAll: true,
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("vault — delete action", () => {
+    it("calls client.deleteFile", async () => {
+      const { client, getTool } = setup();
+      await getTool("vault").handler({ action: "delete", path: "note.md", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(client.deleteFile).toHaveBeenCalledWith("note.md");
+    });
+
+    it("returns errorResult when path missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("vault").handler({ action: "delete", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("vault — search_replace action", () => {
+    it("reads, replaces, and writes file", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents).mockResolvedValue("old text");
+      const result = await getTool("vault").handler({
+        action: "search_replace", path: "note.md", search: "old", replace: "new",
+        useRegex: false, caseSensitive: true, replaceAll: true,
+      });
+      expect(client.putContent).toHaveBeenCalledWith("note.md", "new text");
+      expect(getText(result)).toContain("Replaced in");
+    });
+
+    it("returns no-match message when not found", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents).mockResolvedValue("unchanged");
+      const result = await getTool("vault").handler({
+        action: "search_replace", path: "note.md", search: "xyz", replace: "abc",
+        useRegex: false, caseSensitive: true, replaceAll: true,
+      });
+      expect(client.putContent).not.toHaveBeenCalled();
+      expect(getText(result)).toContain("No matches found");
+    });
+
+    it("returns errorResult when search is missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("vault").handler({
+        action: "search_replace", path: "note.md", replace: "new",
+        useRegex: false, caseSensitive: true, replaceAll: true,
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it("returns errorResult when replace is missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("vault").handler({
+        action: "search_replace", path: "note.md", search: "old",
+        useRegex: false, caseSensitive: true, replaceAll: true,
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // vault — read-only preset blocks write actions
+  // -------------------------------------------------------------------------
+  describe("vault — read-only preset blocks write actions", () => {
+    it("blocks put in read-only preset", async () => {
+      const { getTool } = setup({ toolPreset: "read-only" });
+      const result = await getTool("vault").handler({
+        action: "put", path: "note.md", content: "body",
+        useRegex: false, caseSensitive: true, replaceAll: true,
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("not allowed");
+    });
+
+    it("blocks append in read-only preset", async () => {
+      const { getTool } = setup({ toolPreset: "read-only" });
+      const result = await getTool("vault").handler({
+        action: "append", path: "note.md", content: "x",
+        useRegex: false, caseSensitive: true, replaceAll: true,
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it("allows list in read-only preset", async () => {
+      const { client, getTool } = setup({ toolPreset: "read-only" });
+      const result = await getTool("vault").handler({ action: "list", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(result.isError).toBeFalsy();
+      expect(client.listFilesInVault).toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // vault — safe preset blocks delete
+  // -------------------------------------------------------------------------
+  describe("vault — safe preset blocks delete", () => {
+    it("blocks delete in safe preset", async () => {
+      const { getTool } = setup({ toolPreset: "safe" });
+      const result = await getTool("vault").handler({
+        action: "delete", path: "note.md", useRegex: false, caseSensitive: true, replaceAll: true,
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("not allowed");
+    });
+
+    it("allows put in safe preset", async () => {
+      const { client, getTool } = setup({ toolPreset: "safe" });
+      const result = await getTool("vault").handler({
+        action: "put", path: "note.md", content: "body",
+        useRegex: false, caseSensitive: true, replaceAll: true,
+      });
+      expect(client.putContent).toHaveBeenCalled();
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // active_file tool
+  // -------------------------------------------------------------------------
+  describe("active_file — get", () => {
+    it("calls client.getActiveFile", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getActiveFile).mockResolvedValue("# Active");
+      const result = await getTool("active_file").handler({ action: "get" });
+      expect(getText(result)).toBe("# Active");
+    });
+  });
+
+  describe("active_file — put", () => {
+    it("calls client.putActiveFile", async () => {
+      const { client, getTool } = setup();
+      await getTool("active_file").handler({ action: "put", content: "new" });
+      expect(client.putActiveFile).toHaveBeenCalledWith("new");
+    });
+
+    it("returns errorResult when content missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("active_file").handler({ action: "put" });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("active_file — append", () => {
+    it("calls client.appendActiveFile", async () => {
+      const { client, getTool } = setup();
+      await getTool("active_file").handler({ action: "append", content: "more" });
+      expect(client.appendActiveFile).toHaveBeenCalledWith("more");
+    });
+  });
+
+  describe("active_file — patch", () => {
+    it("calls client.patchActiveFile", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("active_file").handler({
+        action: "patch", content: "val",
+        operation: "append", targetType: "heading", target: "Section",
+      });
+      expect(client.patchActiveFile).toHaveBeenCalledWith("val", {
+        operation: "append", targetType: "heading", target: "Section",
+        targetDelimiter: undefined, trimTargetWhitespace: undefined, contentType: undefined,
+      });
+      expect(getText(result)).toContain("Active file patched");
+    });
+
+    it("returns errorResult when operation missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("active_file").handler({
+        action: "patch", content: "val", targetType: "heading", target: "Section",
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("active_file — delete", () => {
+    it("calls client.deleteActiveFile", async () => {
+      const { client, getTool } = setup();
+      await getTool("active_file").handler({ action: "delete" });
+      expect(client.deleteActiveFile).toHaveBeenCalled();
+    });
+
+    it("blocks delete in safe preset", async () => {
+      const { getTool } = setup({ toolPreset: "safe" });
+      const result = await getTool("active_file").handler({ action: "delete" });
+      expect(result.isError).toBe(true);
+    });
+
+    it("blocks delete in read-only preset", async () => {
+      const { getTool } = setup({ toolPreset: "read-only" });
+      const result = await getTool("active_file").handler({ action: "delete" });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // commands tool
+  // -------------------------------------------------------------------------
+  describe("commands — list", () => {
+    it("calls client.listCommands", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.listCommands).mockResolvedValue({ commands: [{ id: "x", name: "X" }] });
+      const result = await getTool("commands").handler({ action: "list" });
+      expect(getText(result)).toContain('"name": "X"');
+    });
+  });
+
+  describe("commands — execute", () => {
+    it("calls client.executeCommand with commandId", async () => {
+      const { client, getTool } = setup();
+      await getTool("commands").handler({ action: "execute", commandId: "editor:bold" });
+      expect(client.executeCommand).toHaveBeenCalledWith("editor:bold");
+    });
+
+    it("returns errorResult when commandId missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("commands").handler({ action: "execute" });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // open_file tool
+  // -------------------------------------------------------------------------
+  describe("open_file", () => {
+    it("calls client.openFile", async () => {
+      const { client, getTool } = setup();
+      await getTool("open_file").handler({ path: "note.md", newLeaf: false });
+      expect(client.openFile).toHaveBeenCalledWith("note.md", false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // search tool
+  // -------------------------------------------------------------------------
+  describe("search — simple", () => {
+    it("calls client.simpleSearch", async () => {
+      const { client, getTool } = setup();
+      await getTool("search").handler({ type: "simple", query: "hello", contextLength: 100 });
+      expect(client.simpleSearch).toHaveBeenCalledWith("hello", 100);
+    });
+
+    it("returns errorResult when query missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("search").handler({ type: "simple", contextLength: 100 });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("search — jsonlogic", () => {
+    it("calls client.complexSearch with jsonQuery", async () => {
+      const { client, getTool } = setup();
+      const jsonQuery = { glob: [{ var: "path" }, "*.md"] };
+      await getTool("search").handler({ type: "jsonlogic", jsonQuery, contextLength: 100 });
+      expect(client.complexSearch).toHaveBeenCalledWith(jsonQuery);
+    });
+
+    it("returns errorResult when jsonQuery missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("search").handler({ type: "jsonlogic", contextLength: 100 });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("search — dataview", () => {
+    it("calls client.dataviewSearch with query", async () => {
+      const { client, getTool } = setup();
+      await getTool("search").handler({ type: "dataview", query: 'LIST FROM ""', contextLength: 100 });
+      expect(client.dataviewSearch).toHaveBeenCalledWith('LIST FROM ""');
+    });
+
+    it("returns errorResult when query missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("search").handler({ type: "dataview", contextLength: 100 });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // periodic_note tool
+  // -------------------------------------------------------------------------
+  describe("periodic_note — get (current)", () => {
+    it("calls client.getPeriodicNote for current period", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getPeriodicNote).mockResolvedValue("# Today");
+      const result = await getTool("periodic_note").handler({ action: "get", period: "daily" });
+      expect(client.getPeriodicNote).toHaveBeenCalledWith("daily", undefined);
+      expect(getText(result)).toBe("# Today");
+    });
+  });
+
+  describe("periodic_note — get (by date)", () => {
+    it("calls client.getPeriodicNoteForDate when year/month/day all present", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getPeriodicNoteForDate).mockResolvedValue("# Specific day");
+      const result = await getTool("periodic_note").handler({
+        action: "get", period: "daily", year: 2025, month: 3, day: 14,
+      });
+      expect(client.getPeriodicNoteForDate).toHaveBeenCalledWith("daily", 2025, 3, 14, undefined);
+      expect(getText(result)).toBe("# Specific day");
+    });
+  });
+
+  describe("periodic_note — put (current)", () => {
+    it("calls client.putPeriodicNote", async () => {
+      const { client, getTool } = setup();
+      await getTool("periodic_note").handler({ action: "put", period: "weekly", content: "# Week" });
+      expect(client.putPeriodicNote).toHaveBeenCalledWith("weekly", "# Week");
+    });
+
+    it("returns errorResult when content missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("periodic_note").handler({ action: "put", period: "daily" });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("periodic_note — put (by date)", () => {
+    it("calls client.putPeriodicNoteForDate", async () => {
+      const { client, getTool } = setup();
+      await getTool("periodic_note").handler({
+        action: "put", period: "daily", year: 2025, month: 1, day: 1, content: "# New Year",
+      });
+      expect(client.putPeriodicNoteForDate).toHaveBeenCalledWith("daily", 2025, 1, 1, "# New Year");
+    });
+  });
+
+  describe("periodic_note — append", () => {
+    it("calls client.appendPeriodicNote for current period", async () => {
+      const { client, getTool } = setup();
+      await getTool("periodic_note").handler({ action: "append", period: "daily", content: "item" });
+      expect(client.appendPeriodicNote).toHaveBeenCalledWith("daily", "item");
+    });
+
+    it("calls client.appendPeriodicNoteForDate when date given", async () => {
+      const { client, getTool } = setup();
+      await getTool("periodic_note").handler({
+        action: "append", period: "daily", year: 2025, month: 6, day: 15, content: "item",
+      });
+      expect(client.appendPeriodicNoteForDate).toHaveBeenCalledWith("daily", 2025, 6, 15, "item");
+    });
+  });
+
+  describe("periodic_note — patch", () => {
+    it("calls client.patchPeriodicNote for current period", async () => {
+      const { client, getTool } = setup();
+      const result = await getTool("periodic_note").handler({
+        action: "patch", period: "daily", content: "val",
+        operation: "replace", targetType: "frontmatter", target: "status",
+      });
+      expect(client.patchPeriodicNote).toHaveBeenCalledWith("daily", "val", {
+        operation: "replace", targetType: "frontmatter", target: "status",
+        targetDelimiter: undefined, trimTargetWhitespace: undefined,
+        createIfMissing: undefined, contentType: undefined,
+      });
+      expect(getText(result)).toContain("Patched daily note");
+    });
+
+    it("calls client.patchPeriodicNoteForDate when date provided", async () => {
+      const { client, getTool } = setup();
+      await getTool("periodic_note").handler({
+        action: "patch", period: "daily", year: 2025, month: 3, day: 1, content: "val",
+        operation: "append", targetType: "heading", target: "Tasks",
+      });
+      expect(client.patchPeriodicNoteForDate).toHaveBeenCalled();
+    });
+
+    it("returns errorResult when operation missing", async () => {
+      const { getTool } = setup();
+      const result = await getTool("periodic_note").handler({
+        action: "patch", period: "daily", content: "val",
+        targetType: "heading", target: "Section",
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("periodic_note — delete", () => {
+    it("calls client.deletePeriodicNote for current period", async () => {
+      const { client, getTool } = setup();
+      await getTool("periodic_note").handler({ action: "delete", period: "daily" });
+      expect(client.deletePeriodicNote).toHaveBeenCalledWith("daily");
+    });
+
+    it("calls client.deletePeriodicNoteForDate when date given", async () => {
+      const { client, getTool } = setup();
+      await getTool("periodic_note").handler({
+        action: "delete", period: "daily", year: 2025, month: 12, day: 31,
+      });
+      expect(client.deletePeriodicNoteForDate).toHaveBeenCalledWith("daily", 2025, 12, 31);
+    });
+
+    it("blocks delete in safe preset", async () => {
+      const { getTool } = setup({ toolPreset: "safe" });
+      const result = await getTool("periodic_note").handler({ action: "delete", period: "daily" });
+      expect(result.isError).toBe(true);
+    });
+
+    it("blocks delete in read-only preset", async () => {
+      const { getTool } = setup({ toolPreset: "read-only" });
+      const result = await getTool("periodic_note").handler({ action: "delete", period: "daily" });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // status tool (PROTECTED)
+  // -------------------------------------------------------------------------
+  describe("status", () => {
+    it("calls client.getServerStatus", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getServerStatus).mockResolvedValue({
+        ok: true, service: "Obsidian REST API", authenticated: true, versions: {},
+      });
+      const result = await getTool("status").handler({});
+      expect(client.getServerStatus).toHaveBeenCalled();
+      expect(getText(result)).toContain("Obsidian REST API");
+    });
+
+    it("returns errorResult on connection error", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getServerStatus).mockRejectedValue(new ObsidianConnectionError("refused"));
+      const result = await getTool("status").handler({});
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("CONNECTION ERROR");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // batch_get tool
+  // -------------------------------------------------------------------------
+  describe("batch_get", () => {
+    it("fetches all paths and returns combined results", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents)
+        .mockResolvedValueOnce("# Note 1")
+        .mockResolvedValueOnce("# Note 2");
+      const result = await getTool("batch_get").handler({ paths: ["a.md", "b.md"] });
+      const parsed: unknown = JSON.parse(getText(result));
+      expect(Array.isArray(parsed)).toBe(true);
+      if (Array.isArray(parsed)) {
+        expect(parsed).toHaveLength(2);
+      }
+    });
+
+    it("handles partial failures gracefully", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents)
+        .mockResolvedValueOnce("# Note")
+        .mockRejectedValueOnce(new ObsidianApiError("not found", 404));
+      const result = await getTool("batch_get").handler({ paths: ["ok.md", "missing.md"] });
+      const parsed: unknown = JSON.parse(getText(result));
+      expect(Array.isArray(parsed)).toBe(true);
+      if (Array.isArray(parsed)) {
+        const hasError = parsed.some((item) => {
+          return item !== null && typeof item === "object" && "error" in item;
+        });
+        expect(hasError).toBe(true);
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // recent tool
+  // -------------------------------------------------------------------------
+  describe("recent — changes (with cache)", () => {
+    it("returns sorted notes from cache", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      vi.mocked(cache.getAllNotes).mockReturnValue([
+        { path: "old.md", content: "", frontmatter: {}, tags: [], stat: { ctime: 0, mtime: 100, size: 0 }, links: [], cachedAt: 0 },
+        { path: "new.md", content: "", frontmatter: {}, tags: [], stat: { ctime: 0, mtime: 999, size: 0 }, links: [], cachedAt: 0 },
+      ] as never);
+      registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", enableCache: true }));
+      const result = await getTool("recent").handler({ type: "changes", limit: 5 });
+      const parsed: unknown = JSON.parse(getText(result));
+      expect(Array.isArray(parsed)).toBe(true);
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        const first = parsed[0] as Record<string, unknown>;
+        expect(first["path"]).toBe("new.md");
+      }
+    });
+
+    it("falls back to API when cache not initialized", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(false);
+      vi.mocked(client.listFilesInVault).mockResolvedValue({ files: ["note.md"] });
+      vi.mocked(client.getFileContents).mockResolvedValue({
+        content: "", frontmatter: {}, path: "note.md", tags: [], stat: { ctime: 0, mtime: 500, size: 0 },
+      } as NoteJson);
+      registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", enableCache: true }));
+      const result = await getTool("recent").handler({ type: "changes", limit: 5 });
+      expect(client.listFilesInVault).toHaveBeenCalled();
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe("recent — periodic_notes", () => {
+    it("filters vault files by period directory", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.listFilesInVault).mockResolvedValue({
+        files: [
+          "Weekly Notes/2025-W01.md",
+          "Weekly Notes/2025-W02.md",
+          "Daily Notes/2025-01-01.md",
+        ],
+      });
+      const result = await getTool("recent").handler({ type: "periodic_notes", period: "weekly", limit: 10 });
+      const parsed: unknown = JSON.parse(getText(result));
+      expect(Array.isArray(parsed)).toBe(true);
+      if (Array.isArray(parsed)) {
+        expect(parsed).toHaveLength(2);
+        expect((parsed as string[])[0]).toContain("Weekly Notes");
+      }
+    });
+
+    it("returns errorResult when period missing for periodic_notes type", async () => {
+      const { getTool } = setup();
+      const result = await getTool("recent").handler({ type: "periodic_notes", limit: 10 });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("period is required");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // configure tool (PROTECTED) — consolidated version
+  // -------------------------------------------------------------------------
+  describe("configure — consolidated show", () => {
+    it("returns redacted config", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "show" });
+      expect(result.isError).toBeFalsy();
+      expect(getText(result)).toContain("[SET]");
+    });
+  });
+
+  describe("configure — consolidated set", () => {
+    it("sets debug=false", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "debug", value: "false" });
+      expect(saveConfigToFile).toHaveBeenCalledWith(expect.any(String), { debug: false });
+      expect(getText(result)).toContain("effective immediately");
+    });
+
+    it("returns errorResult for unknown setting", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "badKey", value: "x" });
+      expect(result.isError).toBe(true);
+    });
+
+    it("returns errorResult when setting omitted", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set" });
+      expect(result.isError).toBe(true);
+    });
+
+    it("returns errorResult when value omitted", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "debug" });
+      expect(result.isError).toBe(true);
+    });
+
+    it("rejects invalid maxResponseChars (negative)", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "maxResponseChars", value: "-1" });
+      expect(result.isError).toBe(true);
+    });
+
+    it("sets maxResponseChars=0 (disabled)", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "maxResponseChars", value: "0" });
+      expect(saveConfigToFile).toHaveBeenCalledWith(
+        expect.any(String),
+        { reliability: { maxResponseChars: 0 } },
+      );
+      expect(result.isError).toBeFalsy();
+    });
+
+    it("sets verifyWrites=true", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "verifyWrites", value: "true" });
+      expect(saveConfigToFile).toHaveBeenCalledWith(
+        expect.any(String),
+        { reliability: { verifyWrites: true } },
+      );
+      expect(result.isError).toBeFalsy();
+    });
+
+    it("rejects invalid toolPreset value", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "set", setting: "toolPreset", value: "invalid" });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("configure — consolidated reset", () => {
+    it("resets timeout to 30000", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "reset", setting: "timeout" });
+      expect(saveConfigToFile).toHaveBeenCalledWith(
+        expect.any(String),
+        { reliability: { timeout: 30000 } },
+      );
+      expect(getText(result)).toContain("reset to default");
+    });
+
+    it("resets verifyWrites to false", async () => {
+      const { getTool } = setup();
+      await getTool("configure").handler({ action: "reset", setting: "verifyWrites" });
+      expect(saveConfigToFile).toHaveBeenCalledWith(
+        expect.any(String),
+        { reliability: { verifyWrites: false } },
+      );
+    });
+
+    it("resets maxResponseChars to 500000", async () => {
+      const { getTool } = setup();
+      await getTool("configure").handler({ action: "reset", setting: "maxResponseChars" });
+      expect(saveConfigToFile).toHaveBeenCalledWith(
+        expect.any(String),
+        { reliability: { maxResponseChars: 500000 } },
+      );
+    });
+
+    it("resets toolMode to granular", async () => {
+      const { getTool } = setup();
+      await getTool("configure").handler({ action: "reset", setting: "toolMode" });
+      expect(saveConfigToFile).toHaveBeenCalledWith(
+        expect.any(String),
+        { tools: { mode: "granular" } },
+      );
+    });
+
+    it("resets toolPreset to full", async () => {
+      const { getTool } = setup();
+      await getTool("configure").handler({ action: "reset", setting: "toolPreset" });
+      expect(saveConfigToFile).toHaveBeenCalledWith(
+        expect.any(String),
+        { tools: { preset: "full" } },
+      );
+    });
+
+    it("returns errorResult for unknown setting", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "reset", setting: "unknownKey" });
+      expect(result.isError).toBe(true);
+    });
+
+    it("returns errorResult when setting omitted", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({ action: "reset" });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // vault_analysis tool
+  // -------------------------------------------------------------------------
+  describe("vault_analysis — backlinks", () => {
+    it("returns backlinks from cache", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      vi.mocked(cache.getBacklinks).mockReturnValue([{ source: "ref.md", context: "see [[target]]" }]);
+      registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", enableCache: true }));
+      const result = await getTool("vault_analysis").handler({ action: "backlinks", path: "target.md", limit: 10 });
+      expect(cache.getBacklinks).toHaveBeenCalledWith("target.md");
+      expect(getText(result)).toContain("ref.md");
+    });
+
+    it("returns errorResult when path missing", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", enableCache: true }));
+      const result = await getTool("vault_analysis").handler({ action: "backlinks", limit: 10 });
+      expect(result.isError).toBe(true);
+    });
+
+    it("returns errorResult when cache disabled", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", enableCache: false }));
+      const result = await getTool("vault_analysis").handler({ action: "backlinks", path: "x.md", limit: 10 });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("Cache is disabled");
+    });
+
+    it("returns errorResult when cache not initialized", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(false);
+      registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", enableCache: true }));
+      const result = await getTool("vault_analysis").handler({ action: "backlinks", path: "x.md", limit: 10 });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("still building");
+    });
+  });
+
+  describe("vault_analysis — connections", () => {
+    it("returns backlinks and forward links", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      vi.mocked(cache.getBacklinks).mockReturnValue([{ source: "a.md", context: "ctx" }]);
+      vi.mocked(cache.getForwardLinks).mockReturnValue([{ target: "b.md", type: "wikilink", context: "[[b]]" }]);
+      registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", enableCache: true }));
+      const result = await getTool("vault_analysis").handler({ action: "connections", path: "center.md", limit: 10 });
+      const parsed: unknown = JSON.parse(getText(result));
+      expect(parsed).toMatchObject({ backlinks: [{ source: "a.md" }], forwardLinks: [{ target: "b.md" }] });
+    });
+
+    it("returns errorResult when path missing", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", enableCache: true }));
+      const result = await getTool("vault_analysis").handler({ action: "connections", limit: 10 });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("vault_analysis — structure", () => {
+    it("returns vault structure stats", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      vi.mocked(cache.getOrphanNotes).mockReturnValue(["orphan.md"]);
+      vi.mocked(cache.getMostConnectedNotes).mockReturnValue([{ path: "hub.md", inbound: 7, outbound: 2 }]);
+      vi.mocked(cache.getVaultGraph).mockReturnValue({ nodes: ["a.md"], edges: [{ source: "a.md", target: "b.md" }] });
+      vi.mocked(cache.getFileList).mockReturnValue(["folder/note.md"]);
+      registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", enableCache: true }));
+      const result = await getTool("vault_analysis").handler({ action: "structure", limit: 10 });
+      expect(result.isError).toBeFalsy();
+      const parsed: unknown = JSON.parse(getText(result));
+      expect(parsed).toMatchObject({ orphanCount: 1, edgeCount: 1 });
+    });
+
+    it("returns errorResult when cache not initialized", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(false);
+      registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", enableCache: true }));
+      const result = await getTool("vault_analysis").handler({ action: "structure", limit: 10 });
+      expect(result.isError).toBe(true);
+    });
+
+    it("blocks structure in read-only preset", async () => {
+      // read-only only allows backlinks/connections/structure — "refresh" is blocked
+      // structure itself is allowed in read-only; let's verify it goes through
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      vi.mocked(cache.getOrphanNotes).mockReturnValue([]);
+      vi.mocked(cache.getMostConnectedNotes).mockReturnValue([]);
+      vi.mocked(cache.getVaultGraph).mockReturnValue({ nodes: [], edges: [] });
+      vi.mocked(cache.getFileList).mockReturnValue([]);
+      registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", toolPreset: "read-only", enableCache: true }));
+      const result = await getTool("vault_analysis").handler({ action: "structure", limit: 10 });
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe("vault_analysis — refresh", () => {
+    it("calls cache.refresh and returns summary", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", enableCache: true }));
+      const result = await getTool("vault_analysis").handler({ action: "refresh", limit: 10 });
+      expect(cache.refresh).toHaveBeenCalled();
+      expect(getText(result)).toContain("Cache refreshed");
+    });
+
+    it("blocks refresh in read-only preset", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", toolPreset: "read-only", enableCache: true }));
+      const result = await getTool("vault_analysis").handler({ action: "refresh", limit: 10 });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("not allowed");
+    });
+
+    it("returns errorResult when cache disabled", async () => {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      registerConsolidatedTools(server as never, client, cache, () => true, makeConfig({ toolMode: "consolidated", enableCache: false }));
+      const result = await getTool("vault_analysis").handler({ action: "refresh", limit: 10 });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error propagation — API error types map to correct messages
+  // -------------------------------------------------------------------------
+  describe("error propagation via buildErrorMessage", () => {
+    it("connection error produces CONNECTION ERROR prefix", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.listFilesInVault).mockRejectedValue(new ObsidianConnectionError("ECONNREFUSED"));
+      const result = await getTool("vault").handler({ action: "list", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("CONNECTION ERROR");
+    });
+
+    it("auth error produces AUTH ERROR prefix", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.listFilesInVault).mockRejectedValue(new ObsidianAuthError());
+      const result = await getTool("vault").handler({ action: "list", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("AUTH ERROR");
+    });
+
+    it("400 API error produces BAD REQUEST message", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents).mockRejectedValue(new ObsidianApiError("malformed", 400));
+      const result = await getTool("vault").handler({ action: "get", path: "x.md", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("BAD REQUEST");
+    });
+
+    it("405 API error produces NOT SUPPORTED message", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents).mockRejectedValue(new ObsidianApiError("not supported", 405));
+      const result = await getTool("vault").handler({ action: "get", path: "x.md", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("NOT SUPPORTED");
+    });
+
+    it("generic Error produces ERROR prefix", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.listFilesInVault).mockRejectedValue(new Error("unexpected"));
+      const result = await getTool("vault").handler({ action: "list", useRegex: false, caseSensitive: true, replaceAll: true });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("ERROR: unexpected");
+    });
+  });
+});

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -326,7 +326,7 @@ describe("registerAllTools — consolidated mode", () => {
     expect(count).toBe(11);
   });
 
-  it("registers 4 tools in minimal preset", () => {
+  it("registers 5 tools in minimal preset (vault_analysis is protected)", () => {
     const { server } = makeMockServer();
     const client = makeMockClient();
     const cache = makeMockCache();
@@ -334,20 +334,22 @@ describe("registerAllTools — consolidated mode", () => {
       server as never, client, cache,
       makeConfig({ toolMode: "consolidated", toolPreset: "minimal" }),
     );
-    expect(count).toBe(4);
+    // vault, search, status, configure (preset) + vault_analysis (protected)
+    expect(count).toBe(5);
   });
 
-  it("protected tools (configure, status) always registered when excluded", () => {
+  it("protected tools (configure, status, vault_analysis) always registered when excluded", () => {
     const { server, getRegistered } = makeMockServer();
     const client = makeMockClient();
     const cache = makeMockCache();
     registerAllTools(
       server as never, client, cache,
-      makeConfig({ toolMode: "consolidated", excludeTools: ["configure", "status"] }),
+      makeConfig({ toolMode: "consolidated", excludeTools: ["configure", "status", "vault_analysis"] }),
     );
     const registered = getRegistered();
     expect(registered).toContain("configure");
     expect(registered).toContain("status");
+    expect(registered).toContain("vault_analysis");
   });
 
   it("INCLUDE_TOOLS filters consolidated tools", () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -33,7 +33,7 @@ export class ObsidianAuthError extends Error {
 /** Context for building structured error messages. */
 interface ErrorContext {
   readonly tool: string;
-  readonly path?: string;
+  readonly path?: string | undefined;
 }
 
 /** Builds an LLM-friendly error message with actionable guidance based on error type. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,12 +188,14 @@ async function setup(): Promise<void> {
 
   // Output Claude Desktop config snippet
   process.stderr.write("  Add this to your Claude Desktop config:\n\n");
-  const defaultPaths = [
-    join(homedir(), ".obsidian-mcp.config.json"),
-    join(homedir(), ".config", "obsidian-mcp", "config.json"),
-    resolve("./obsidian-mcp.config.json"),
-  ];
-  const isNonDefaultPath = !defaultPaths.includes(resolvedPath);
+  // Config auto-discovery paths (must match config.ts CONFIG_SEARCH_PATHS)
+  const defaultPaths = new Set([
+    resolve(join(homedir(), ".obsidian-mcp.config.json")),
+    resolve(join(homedir(), ".config", "obsidian-mcp", "config.json")),
+  ]);
+  // CWD-relative path excluded — it varies by runtime context, so always
+  // include OBSIDIAN_CONFIG in the snippet when the user picks a CWD-relative path.
+  const isNonDefaultPath = !defaultPaths.has(resolvedPath);
   const maskedKey = apiKey.length > 4 ? `${apiKey.slice(0, 4)}${"*".repeat(apiKey.length - 4)}` : "****";
   const envBlock: Record<string, string> = { OBSIDIAN_API_KEY: maskedKey };
   if (isNonDefaultPath) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,9 +155,12 @@ async function setup(): Promise<void> {
 
   // Step 3: Reliability
   process.stderr.write("\nStep 3/4: Reliability\n\n");
-  const verifyWrites = await ask("  Verify writes (true/false)", "false");
+  const validBools = new Set(["true", "false"] as const);
+  const verifyWritesRaw = await ask("  Verify writes (true/false)", "false");
+  const verifyWrites = validateEnum(verifyWritesRaw, validBools, "verify writes", "false" as const);
   const maxResponseChars = await ask("  Max response chars (0 = unlimited)", "500000");
-  const debug = await ask("  Debug logging (true/false)", "false");
+  const debugRaw = await ask("  Debug logging (true/false)", "false");
+  const debug = validateEnum(debugRaw, validBools, "debug", "false" as const);
 
   // Step 4: Save
   process.stderr.write("\nStep 4/4: Save\n\n");

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,8 +104,22 @@ async function setup(): Promise<void> {
   }
   const host = await ask("  Host", "127.0.0.1");
   const portStr = await ask("  Port", "27124");
-  const port = Number(portStr) || 27124;
-  const scheme = await ask("  Scheme (https/http)", "https");
+  const portNum = Number(portStr);
+  let port: number;
+  if (!Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
+    process.stderr.write(`  Warning: invalid port "${portStr}" — using default 27124\n`);
+    port = 27124;
+  } else {
+    port = portNum;
+  }
+  const schemeRaw = await ask("  Scheme (https/http)", "https");
+  let scheme: string;
+  if (schemeRaw !== "http" && schemeRaw !== "https") {
+    process.stderr.write(`  Warning: invalid scheme "${schemeRaw}" — using default "https"\n`);
+    scheme = "https";
+  } else {
+    scheme = schemeRaw;
+  }
 
   // Test connection
   process.stderr.write("\n  Testing connection...\n");
@@ -130,8 +144,23 @@ async function setup(): Promise<void> {
 
   // Step 2: Tool Mode
   process.stderr.write("Step 2/4: Tool Mode\n\n");
-  const toolMode = await ask("  Mode (granular = 38 tools, consolidated = 11 tools)", "granular");
-  const toolPreset = await ask("  Preset (full, read-only, minimal, safe)", "full");
+  const toolModeRaw = await ask("  Mode (granular = 38 tools, consolidated = 11 tools)", "granular");
+  let toolMode: string;
+  if (toolModeRaw !== "granular" && toolModeRaw !== "consolidated") {
+    process.stderr.write(`  Warning: invalid mode "${toolModeRaw}" — using default "granular"\n`);
+    toolMode = "granular";
+  } else {
+    toolMode = toolModeRaw;
+  }
+  const toolPresetRaw = await ask("  Preset (full, read-only, minimal, safe)", "full");
+  const validPresets = new Set(["full", "read-only", "minimal", "safe"]);
+  let toolPreset: string;
+  if (!validPresets.has(toolPresetRaw)) {
+    process.stderr.write(`  Warning: invalid preset "${toolPresetRaw}" — using default "full"\n`);
+    toolPreset = "full";
+  } else {
+    toolPreset = toolPresetRaw;
+  }
 
   // Step 3: Reliability
   process.stderr.write("\nStep 3/4: Reliability\n\n");

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,11 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
 import { readFileSync } from "node:fs";
+import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
-
-import { loadConfig, log, setDebugEnabled } from "./config.js";
+import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { loadConfig, getRedactedConfig, saveConfigToFile, log, setDebugEnabled } from "./config.js";
 import { ObsidianClient } from "./obsidian.js";
 import { VaultCache } from "./cache.js";
 import { registerAllTools } from "./tools.js";
@@ -19,14 +20,189 @@ const VERSION: string =
     ? (pkg as Record<string, unknown>)["version"] as string
     : "unknown";
 
+// --- CLI: --show-config ---
+
+/** Prints the active configuration (API key redacted) to stderr and exits. */
+function showConfig(): void {
+  const config = loadConfig();
+  const redacted = getRedactedConfig(config);
+  process.stderr.write(`mcp-obsidian-extended v${VERSION} — Active Configuration\n\n`);
+  process.stderr.write(`${JSON.stringify(redacted, null, 2)}\n`);
+  process.exit(0);
+}
+
+// --- CLI: --validate ---
+
+/** Tests connectivity and authentication against the configured Obsidian instance. */
+async function validate(): Promise<void> {
+  process.stderr.write(`mcp-obsidian-extended v${VERSION} — Validating connection...\n\n`);
+  const config = loadConfig();
+
+  if (!config.apiKey) {
+    process.stderr.write("FAIL: OBSIDIAN_API_KEY is not set.\n");
+    process.exit(1);
+  }
+
+  process.stderr.write(`  Host: ${config.scheme}://${config.host}:${String(config.port)}\n`);
+  process.stderr.write(`  API Key: [SET]\n`);
+  if (config.configFilePath) {
+    process.stderr.write(`  Config: ${config.configFilePath}\n`);
+  }
+  process.stderr.write("\n");
+
+  const client = new ObsidianClient(config);
+  try {
+    const status = await client.getServerStatus();
+    process.stderr.write(`  Connection: OK (${status.service})\n`);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`  Connection: FAIL — ${message}\n`);
+    process.exit(1);
+  }
+
+  try {
+    await client.listFilesInVault();
+    process.stderr.write("  Authentication: OK\n");
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`  Authentication: FAIL — ${message}\n`);
+    process.exit(1);
+  }
+
+  process.stderr.write("\nAll checks passed.\n");
+  process.exit(0);
+}
+
+// --- CLI: --setup ---
+
+/** Interactive setup wizard. Prompts for connection details, tests, and saves config. */
+async function setup(): Promise<void> {
+  if (!process.stdin.isTTY) {
+    process.stderr.write("Error: --setup requires an interactive terminal (TTY).\n");
+    process.exit(1);
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  const ask = (prompt: string, defaultVal?: string): Promise<string> =>
+    new Promise((res) => {
+      const suffix = defaultVal !== undefined ? ` [${defaultVal}]` : "";
+      rl.question(`${prompt}${suffix}: `, (answer) => {
+        res(answer.trim() || defaultVal || "");
+      });
+    });
+
+  process.stderr.write(`\nmcp-obsidian-extended v${VERSION} — Setup Wizard\n`);
+  process.stderr.write(`${"━".repeat(50)}\n\n`);
+
+  // Step 1: Connection
+  process.stderr.write("Step 1/4: Connection\n\n");
+  const apiKey = await ask("  API Key (from Obsidian Settings → Local REST API)");
+  if (!apiKey) {
+    process.stderr.write("\nError: API key is required.\n");
+    rl.close();
+    process.exit(1);
+  }
+  const host = await ask("  Host", "127.0.0.1");
+  const portStr = await ask("  Port", "27124");
+  const port = Number(portStr) || 27124;
+  const scheme = await ask("  Scheme (https/http)", "https");
+
+  // Test connection
+  process.stderr.write("\n  Testing connection...\n");
+  const testConfig = loadConfig();
+  const tempConfig = {
+    ...testConfig,
+    apiKey,
+    host,
+    port,
+    scheme: scheme === "http" ? "http" as const : "https" as const,
+  };
+  const testClient = new ObsidianClient(tempConfig);
+  try {
+    await testClient.getServerStatus();
+    await testClient.listFilesInVault();
+    process.stderr.write("  ✓ Connected and authenticated!\n\n");
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`  ✗ Connection failed: ${message}\n`);
+    process.stderr.write("  Saving config anyway — you can fix the connection later.\n\n");
+  }
+
+  // Step 2: Tool Mode
+  process.stderr.write("Step 2/4: Tool Mode\n\n");
+  const toolMode = await ask("  Mode (granular = 38 tools, consolidated = 11 tools)", "granular");
+  const toolPreset = await ask("  Preset (full, read-only, minimal, safe)", "full");
+
+  // Step 3: Reliability
+  process.stderr.write("\nStep 3/4: Reliability\n\n");
+  const verifyWrites = await ask("  Verify writes (true/false)", "false");
+  const maxResponseChars = await ask("  Max response chars (0 = unlimited)", "500000");
+  const debug = await ask("  Debug logging (true/false)", "false");
+
+  // Step 4: Save
+  process.stderr.write("\nStep 4/4: Save\n\n");
+  const savePath = await ask("  Config file path", join(homedir(), ".obsidian-mcp.config.json"));
+  const resolvedPath = resolve(savePath);
+
+  const configToSave: Record<string, unknown> = {
+    host,
+    port,
+    scheme: scheme === "http" ? "http" : "https",
+    tools: {
+      mode: toolMode === "consolidated" ? "consolidated" : "granular",
+      preset: toolPreset,
+    },
+    reliability: {
+      verifyWrites: verifyWrites === "true",
+      maxResponseChars: Number(maxResponseChars) || 500000,
+    },
+    debug: debug === "true",
+  };
+
+  saveConfigToFile(resolvedPath, configToSave);
+  process.stderr.write(`\n  Config saved to: ${resolvedPath}\n\n`);
+
+  // Output Claude Desktop config snippet
+  process.stderr.write("  Add this to your Claude Desktop config:\n\n");
+  const snippet = {
+    mcpServers: {
+      "mcp-obsidian-extended": {
+        command: "npx",
+        args: ["-y", "mcp-obsidian-extended"],
+        env: { OBSIDIAN_API_KEY: apiKey },
+      },
+    },
+  };
+  process.stderr.write(`${JSON.stringify(snippet, null, 2)}\n\n`);
+
+  rl.close();
+  process.exit(0);
+}
+
+// --- Main ---
+
 /** Entry point: parses CLI flags, loads config, creates client/cache/server, and connects transport. */
 async function main(): Promise<void> {
   const args = new Set(process.argv.slice(2));
 
-  // CLI flags — Phase 2 will add --setup, --show-config, --validate
   if (args.has("--version") || args.has("-v")) {
     process.stderr.write(`mcp-obsidian-extended v${VERSION}\n`);
     process.exit(0);
+  }
+
+  if (args.has("--show-config")) {
+    showConfig();
+    return;
+  }
+
+  if (args.has("--validate")) {
+    await validate();
+    return;
+  }
+
+  if (args.has("--setup")) {
+    await setup();
+    return;
   }
 
   const config = loadConfig();

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ async function setup(): Promise<void> {
   const rl = createInterface({ input: process.stdin, output: process.stderr });
   const ask = (prompt: string, defaultVal?: string): Promise<string> =>
     new Promise((res) => {
-      const suffix = defaultVal !== undefined ? ` [${defaultVal}]` : "";
+      const suffix = defaultVal === undefined ? "" : ` [${defaultVal}]`;
       rl.question(`${prompt}${suffix}: `, (answer) => {
         res(answer.trim() || defaultVal || "");
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,12 +187,22 @@ async function setup(): Promise<void> {
 
   // Output Claude Desktop config snippet
   process.stderr.write("  Add this to your Claude Desktop config:\n\n");
+  const defaultPaths = [
+    join(homedir(), ".obsidian-mcp.config.json"),
+    join(homedir(), ".config", "obsidian-mcp", "config.json"),
+    resolve("./obsidian-mcp.config.json"),
+  ];
+  const isNonDefaultPath = !defaultPaths.includes(resolvedPath);
+  const envBlock: Record<string, string> = { OBSIDIAN_API_KEY: apiKey };
+  if (isNonDefaultPath) {
+    envBlock["OBSIDIAN_CONFIG"] = resolvedPath;
+  }
   const snippet = {
     mcpServers: {
       "mcp-obsidian-extended": {
         command: "npx",
         args: ["-y", "mcp-obsidian-extended"],
-        env: { OBSIDIAN_API_KEY: apiKey },
+        env: envBlock,
       },
     },
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
-import { readFileSync } from "node:fs";
+import { readFileSync, mkdirSync } from "node:fs";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
@@ -182,6 +182,7 @@ async function setup(): Promise<void> {
     debug: debug === "true",
   };
 
+  mkdirSync(dirname(resolvedPath), { recursive: true });
   saveConfigToFile(resolvedPath, configToSave);
   process.stderr.write(`\n  Config saved to: ${resolvedPath}\n\n`);
 
@@ -193,7 +194,8 @@ async function setup(): Promise<void> {
     resolve("./obsidian-mcp.config.json"),
   ];
   const isNonDefaultPath = !defaultPaths.includes(resolvedPath);
-  const envBlock: Record<string, string> = { OBSIDIAN_API_KEY: apiKey };
+  const maskedKey = apiKey.length > 4 ? `${apiKey.slice(0, 4)}${"*".repeat(apiKey.length - 4)}` : "****";
+  const envBlock: Record<string, string> = { OBSIDIAN_API_KEY: maskedKey };
   if (isNonDefaultPath) {
     envBlock["OBSIDIAN_CONFIG"] = resolvedPath;
   }
@@ -207,6 +209,7 @@ async function setup(): Promise<void> {
     },
   };
   process.stderr.write(`${JSON.stringify(snippet, null, 2)}\n\n`);
+  process.stderr.write("  (API key shown masked — replace with your actual key in the config above)\n\n");
 
   rl.close();
   process.exit(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,10 @@ async function setup(): Promise<void> {
     },
     reliability: {
       verifyWrites: verifyWrites === "true",
-      maxResponseChars: Number(maxResponseChars) || 500000,
+      maxResponseChars: (() => {
+        const parsed = Number(maxResponseChars);
+        return Number.isFinite(parsed) && parsed >= 0 ? parsed : 500000;
+      })(),
     },
     debug: debug === "true",
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,23 @@ async function validate(): Promise<void> {
   process.exit(0);
 }
 
+// --- CLI: --setup helpers ---
+
+/** Validates and returns a port number, warning and defaulting on invalid input. */
+function validatePort(portStr: string): number {
+  const portNum = Number(portStr);
+  if (Number.isInteger(portNum) && portNum >= 1 && portNum <= 65535) return portNum;
+  process.stderr.write(`  Warning: invalid port "${portStr}" — using default 27124\n`);
+  return 27124;
+}
+
+/** Validates and returns an enum value, warning and defaulting on invalid input. */
+function validateEnum<T extends string>(value: string, valid: ReadonlySet<T>, label: string, fallback: T): T {
+  if (valid.has(value as T)) return value as T;
+  process.stderr.write(`  Warning: invalid ${label} "${value}" — using default "${fallback}"\n`);
+  return fallback;
+}
+
 // --- CLI: --setup ---
 
 /** Interactive setup wizard. Prompts for connection details, tests, and saves config. */
@@ -104,22 +121,9 @@ async function setup(): Promise<void> {
   }
   const host = await ask("  Host", "127.0.0.1");
   const portStr = await ask("  Port", "27124");
-  const portNum = Number(portStr);
-  let port: number;
-  if (!Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
-    process.stderr.write(`  Warning: invalid port "${portStr}" — using default 27124\n`);
-    port = 27124;
-  } else {
-    port = portNum;
-  }
+  const port = validatePort(portStr);
   const schemeRaw = await ask("  Scheme (https/http)", "https");
-  let scheme: string;
-  if (schemeRaw !== "http" && schemeRaw !== "https") {
-    process.stderr.write(`  Warning: invalid scheme "${schemeRaw}" — using default "https"\n`);
-    scheme = "https";
-  } else {
-    scheme = schemeRaw;
-  }
+  const scheme = validateEnum(schemeRaw, new Set(["http", "https"] as const), "scheme", "https" as const);
 
   // Test connection
   process.stderr.write("\n  Testing connection...\n");
@@ -145,22 +149,9 @@ async function setup(): Promise<void> {
   // Step 2: Tool Mode
   process.stderr.write("Step 2/4: Tool Mode\n\n");
   const toolModeRaw = await ask("  Mode (granular = 38 tools, consolidated = 11 tools)", "granular");
-  let toolMode: string;
-  if (toolModeRaw !== "granular" && toolModeRaw !== "consolidated") {
-    process.stderr.write(`  Warning: invalid mode "${toolModeRaw}" — using default "granular"\n`);
-    toolMode = "granular";
-  } else {
-    toolMode = toolModeRaw;
-  }
+  const toolMode = validateEnum(toolModeRaw, new Set(["granular", "consolidated"] as const), "mode", "granular" as const);
   const toolPresetRaw = await ask("  Preset (full, read-only, minimal, safe)", "full");
-  const validPresets = new Set(["full", "read-only", "minimal", "safe"]);
-  let toolPreset: string;
-  if (!validPresets.has(toolPresetRaw)) {
-    process.stderr.write(`  Warning: invalid preset "${toolPresetRaw}" — using default "full"\n`);
-    toolPreset = "full";
-  } else {
-    toolPreset = toolPresetRaw;
-  }
+  const toolPreset = validateEnum(toolPresetRaw, new Set(["full", "read-only", "minimal", "safe"] as const), "preset", "full" as const);
 
   // Step 3: Reliability
   process.stderr.write("\nStep 3/4: Reliability\n\n");

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -30,10 +30,10 @@ export interface PatchOptions {
   readonly operation: "append" | "prepend" | "replace";
   readonly targetType: "heading" | "block" | "frontmatter";
   readonly target: string;
-  readonly targetDelimiter?: string;
-  readonly trimTargetWhitespace?: boolean;
-  readonly createIfMissing?: boolean;
-  readonly contentType?: "markdown" | "json";
+  readonly targetDelimiter?: string | undefined;
+  readonly trimTargetWhitespace?: boolean | undefined;
+  readonly createIfMissing?: boolean | undefined;
+  readonly contentType?: "markdown" | "json" | undefined;
 }
 
 /** A single match within a search result, with position and surrounding context. */
@@ -105,10 +105,11 @@ function acceptHeaderForFormat(format: FileFormat): string {
 
 // --- Tool Result Helpers ---
 
-/** Standard MCP tool response shape. */
+/** Standard MCP tool response shape (index signature required by MCP SDK). */
 export interface ToolResult {
-  readonly content: ReadonlyArray<{ readonly type: "text"; readonly text: string }>;
-  readonly isError?: boolean;
+  [key: string]: unknown;
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
 }
 
 /** Wraps a plain text string as an MCP tool result. */
@@ -457,7 +458,7 @@ export class ObsidianClient {
   // --- Helpers ---
 
   /** Builds HTTP headers for PATCH operations from PatchOptions (createIfMissing is optional). */
-  private buildPatchHeaders(options: Omit<PatchOptions, "createIfMissing"> & { createIfMissing?: boolean }): Record<string, string> {
+  private buildPatchHeaders(options: Omit<PatchOptions, "createIfMissing"> & { createIfMissing?: boolean | undefined }): Record<string, string> {
     const headers: Record<string, string> = {
       "Content-Type": options.contentType === "json" ? "application/json" : "text/markdown",
       "Operation": options.operation,

--- a/src/obsidian.ts
+++ b/src/obsidian.ts
@@ -620,8 +620,15 @@ export class ObsidianClient {
     return this.parseJsonResponse<{ files: string[] }>(res.body, dirPath, res.headers);
   }
 
-  /** Reads a vault file in the specified format (markdown, JSON, or document map). */
-  async getFileContents(filePath: string, format: FileFormat = "markdown"): Promise<FileContentsResult> {
+  /**
+   * Reads a vault file in the specified format (markdown, JSON, or document map).
+   * @param filePath - Vault-relative path to the file.
+   * @param format - Response format: markdown, json, or map.
+   * @param skipTruncation - When true, returns full markdown content without truncation.
+   *   Use for read-modify-write operations (e.g. search_replace) where partial reads
+   *   would corrupt the file.
+   */
+  async getFileContents(filePath: string, format: FileFormat = "markdown", skipTruncation = false): Promise<FileContentsResult> {
     const res = await this.requestWithFallback("GET", "/vault/", filePath, {
       headers: { "Accept": acceptHeaderForFormat(format) },
     });
@@ -631,7 +638,7 @@ export class ObsidianClient {
     }
 
     if (format === "markdown") {
-      return this.truncateResponse(res.body);
+      return skipTruncation ? res.body : this.truncateResponse(res.body);
     }
     return this.parseJsonResponse<NoteJson | DocumentMap>(res.body, filePath, res.headers);
   }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -95,13 +95,15 @@ function buildFilter(
       return true;
     }
 
-    // If INCLUDE is specified, only those tools (from the preset) are allowed
+    // If INCLUDE is specified, only those tools (from the preset) are allowed.
+    // EXCLUDE is intentionally ignored when INCLUDE is set — INCLUDE is a whitelist
+    // that takes full precedence (documented in cc-instructions-final.md).
     if (includeTools.length > 0) {
       const includeSet = new Set(includeTools);
       return includeSet.has(name) && presetSet.has(name);
     }
 
-    // If EXCLUDE is specified, remove those from the preset
+    // If EXCLUDE is specified (and INCLUDE is not), remove those from the preset
     if (excludeTools.length > 0) {
       const excludeSet = new Set(excludeTools);
       return presetSet.has(name) && !excludeSet.has(name);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -69,7 +69,7 @@ const CONSOLIDATED_PRESETS: Record<string, readonly string[]> = {
 
 /** Protected tools that are always registered regardless of filtering. */
 const PROTECTED_GRANULAR = new Set(["configure", "get_server_status", "refresh_cache"]);
-const PROTECTED_CONSOLIDATED = new Set(["configure", "status"]);
+const PROTECTED_CONSOLIDATED = new Set(["configure", "status", "vault_analysis"]);
 
 // --- Filtering Logic ---
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3,14 +3,130 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ObsidianClient } from "./obsidian.js";
 import type { VaultCache } from "./cache.js";
 import type { Config } from "./config.js";
+import { registerGranularTools } from "./tools/granular.js";
+import { registerConsolidatedTools } from "./tools/consolidated.js";
+
+// --- Preset Definitions ---
+
+/** Tool names included in each granular-mode preset. */
+const GRANULAR_PRESETS: Record<string, readonly string[]> = {
+  full: [
+    "list_files_in_vault", "list_files_in_dir", "get_file_contents", "put_content",
+    "append_content", "patch_content", "delete_file", "search_replace",
+    "get_active_file", "put_active_file", "append_active_file", "patch_active_file", "delete_active_file",
+    "list_commands", "execute_command", "open_file",
+    "simple_search", "complex_search", "dataview_search",
+    "get_periodic_note", "put_periodic_note", "append_periodic_note", "patch_periodic_note", "delete_periodic_note",
+    "get_periodic_note_for_date", "put_periodic_note_for_date", "append_periodic_note_for_date",
+    "patch_periodic_note_for_date", "delete_periodic_note_for_date",
+    "get_server_status", "batch_get_file_contents", "get_recent_changes", "get_recent_periodic_notes",
+    "configure", "get_backlinks", "get_vault_structure", "get_note_connections", "refresh_cache",
+  ],
+  "read-only": [
+    "list_files_in_vault", "list_files_in_dir", "get_file_contents",
+    "get_active_file", "list_commands", "open_file",
+    "simple_search", "complex_search", "dataview_search",
+    "get_periodic_note", "get_periodic_note_for_date",
+    "get_server_status", "batch_get_file_contents", "get_recent_changes", "get_recent_periodic_notes",
+    "configure", "get_backlinks", "get_vault_structure", "get_note_connections", "refresh_cache",
+  ],
+  minimal: [
+    "list_files_in_vault", "get_file_contents", "append_content", "simple_search",
+    "get_server_status", "batch_get_file_contents", "configure",
+  ],
+  safe: [
+    "list_files_in_vault", "list_files_in_dir", "get_file_contents", "put_content",
+    "append_content", "patch_content", "search_replace",
+    "get_active_file", "put_active_file", "append_active_file", "patch_active_file",
+    "list_commands", "execute_command", "open_file",
+    "simple_search", "complex_search", "dataview_search",
+    "get_periodic_note", "put_periodic_note", "append_periodic_note", "patch_periodic_note",
+    "get_periodic_note_for_date", "put_periodic_note_for_date", "append_periodic_note_for_date",
+    "patch_periodic_note_for_date",
+    "get_server_status", "batch_get_file_contents", "get_recent_changes", "get_recent_periodic_notes",
+    "configure", "get_backlinks", "get_vault_structure", "get_note_connections", "refresh_cache",
+  ],
+};
+
+/** Tool names included in each consolidated-mode preset. */
+const CONSOLIDATED_PRESETS: Record<string, readonly string[]> = {
+  full: [
+    "vault", "active_file", "commands", "open_file", "search",
+    "periodic_note", "status", "batch_get", "recent", "configure", "vault_analysis",
+  ],
+  "read-only": [
+    "vault", "active_file", "commands", "open_file", "search",
+    "periodic_note", "status", "batch_get", "recent", "configure", "vault_analysis",
+  ],
+  minimal: [
+    "vault", "search", "status", "configure",
+  ],
+  safe: [
+    "vault", "active_file", "commands", "open_file", "search",
+    "periodic_note", "status", "batch_get", "recent", "configure", "vault_analysis",
+  ],
+};
+
+/** Protected tools that are always registered regardless of filtering. */
+const PROTECTED_GRANULAR = new Set(["configure", "get_server_status", "refresh_cache"]);
+const PROTECTED_CONSOLIDATED = new Set(["configure", "status"]);
+
+// --- Filtering Logic ---
+
+/**
+ * Builds the shouldRegister predicate from preset + include/exclude + protected.
+ * Priority: Protected (always) → INCLUDE whitelist → EXCLUDE blacklist → preset base set.
+ */
+function buildFilter(
+  preset: readonly string[],
+  includeTools: readonly string[],
+  excludeTools: readonly string[],
+  protectedTools: ReadonlySet<string>,
+): (name: string) => boolean {
+  const presetSet = new Set(preset);
+
+  return (name: string): boolean => {
+    // Protected tools always pass
+    if (protectedTools.has(name)) {
+      return true;
+    }
+
+    // If INCLUDE is specified, only those tools (from the preset) are allowed
+    if (includeTools.length > 0) {
+      const includeSet = new Set(includeTools);
+      return includeSet.has(name) && presetSet.has(name);
+    }
+
+    // If EXCLUDE is specified, remove those from the preset
+    if (excludeTools.length > 0) {
+      const excludeSet = new Set(excludeTools);
+      return presetSet.has(name) && !excludeSet.has(name);
+    }
+
+    // Default: use the preset as-is
+    return presetSet.has(name);
+  };
+}
+
+// --- Main Entry ---
 
 /** Registers MCP tools based on the active mode, preset, and include/exclude filters. */
 export function registerAllTools(
-  _server: McpServer,
-  _client: ObsidianClient,
-  _cache: VaultCache,
-  _config: Config,
+  server: McpServer,
+  client: ObsidianClient,
+  cache: VaultCache,
+  config: Config,
 ): number {
-  // Phase 2: tool registration will be implemented here
-  return 0;
+  const isConsolidated = config.toolMode === "consolidated";
+  const presets = isConsolidated ? CONSOLIDATED_PRESETS : GRANULAR_PRESETS;
+  const protectedTools = isConsolidated ? PROTECTED_CONSOLIDATED : PROTECTED_GRANULAR;
+  const preset = presets[config.toolPreset] ?? presets["full"];
+
+  // preset is guaranteed defined since we default to "full" above
+  const shouldRegister = buildFilter(preset!, config.includeTools, config.excludeTools, protectedTools);
+
+  if (isConsolidated) {
+    return registerConsolidatedTools(server, client, cache, shouldRegister, config);
+  }
+  return registerGranularTools(server, client, cache, shouldRegister, config);
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -124,10 +124,13 @@ export function registerAllTools(
   const isConsolidated = config.toolMode === "consolidated";
   const presets = isConsolidated ? CONSOLIDATED_PRESETS : GRANULAR_PRESETS;
   const protectedTools = isConsolidated ? PROTECTED_CONSOLIDATED : PROTECTED_GRANULAR;
-  const preset = presets[config.toolPreset] ?? presets["full"];
+  const preset = presets[config.toolPreset];
+  if (!preset) {
+    // toolPreset is validated in config.ts — this is a defensive guard
+    throw new Error(`Unknown tool preset: "${config.toolPreset}". Valid presets: ${Object.keys(presets).join(", ")}`);
+  }
 
-  // preset is guaranteed defined since we default to "full" above
-  const shouldRegister = buildFilter(preset!, config.includeTools, config.excludeTools, protectedTools);
+  const shouldRegister = buildFilter(preset, config.includeTools, config.excludeTools, protectedTools);
 
   if (isConsolidated) {
     return registerConsolidatedTools(server, client, cache, shouldRegister, config);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -55,7 +55,7 @@ const CONSOLIDATED_PRESETS: Record<string, readonly string[]> = {
     "periodic_note", "status", "batch_get", "recent", "configure", "vault_analysis",
   ],
   "read-only": [
-    "vault", "active_file", "commands", "open_file", "search",
+    "vault", "active_file", "commands", "search",
     "periodic_note", "status", "batch_get", "recent", "configure", "vault_analysis",
   ],
   minimal: [

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -67,7 +67,11 @@ const CONSOLIDATED_PRESETS: Record<string, readonly string[]> = {
   ],
 };
 
-/** Protected tools that are always registered regardless of filtering. */
+/**
+ * Protected tools that are always registered regardless of filtering or preset.
+ * These may cause the actual tool count to exceed the preset's listed count
+ * (e.g. minimal + protected tools = preset count + unlisted protected tools).
+ */
 const PROTECTED_GRANULAR = new Set(["configure", "get_server_status", "refresh_cache"]);
 const PROTECTED_CONSOLIDATED = new Set(["configure", "status", "vault_analysis"]);
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -24,7 +24,7 @@ const GRANULAR_PRESETS: Record<string, readonly string[]> = {
   ],
   "read-only": [
     "list_files_in_vault", "list_files_in_dir", "get_file_contents",
-    "get_active_file", "list_commands", "open_file",
+    "get_active_file", "list_commands",
     "simple_search", "complex_search", "dataview_search",
     "get_periodic_note", "get_periodic_note_for_date",
     "get_server_status", "batch_get_file_contents", "get_recent_changes", "get_recent_periodic_notes",

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import type { ObsidianClient, NoteJson, DocumentMap } from "../obsidian.js";
+import type { ObsidianClient, NoteJson, DocumentMap, ToolResult } from "../obsidian.js";
 import { textResult, errorResult, jsonResult } from "../obsidian.js";
 import type { VaultCache } from "../cache.js";
 import type { Config } from "../config.js";
@@ -37,7 +37,7 @@ const SAFE_BLOCKED_ACTIONS: Record<string, ReadonlySet<string>> = {
 // --- Helpers ---
 
 /** Formats file contents for display. */
-function formatFileContents(result: string | NoteJson | DocumentMap): ReturnType<typeof textResult> {
+function formatFileContents(result: string | NoteJson | DocumentMap): ToolResult {
   if (typeof result === "string") {
     return textResult(result);
   }
@@ -62,6 +62,209 @@ function isActionAllowed(toolName: string, action: string, preset: string): bool
   return true;
 }
 
+// --- Extracted vault action handlers ---
+
+/** Handles the vault "patch" action. */
+async function handleVaultPatch(
+  client: ObsidianClient,
+  path: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const content = args["content"] as string | undefined;
+  if (content === undefined) return errorResult("[vault] content is required for patch");
+  const operation = args["operation"] as "append" | "prepend" | "replace" | undefined;
+  const targetType = args["targetType"] as "heading" | "block" | "frontmatter" | undefined;
+  const target = args["target"] as string | undefined;
+  if (!operation) return errorResult("[vault] operation is required for patch");
+  if (!targetType) return errorResult("[vault] targetType is required for patch");
+  if (!target) return errorResult("[vault] target is required for patch");
+  await client.patchContent(path, content, {
+    operation,
+    targetType,
+    target,
+    targetDelimiter: args["targetDelimiter"] as string | undefined,
+    trimTargetWhitespace: args["trimTargetWhitespace"] as boolean | undefined,
+    createIfMissing: args["createIfMissing"] as boolean | undefined,
+    contentType: args["contentType"] as "markdown" | "json" | undefined,
+  });
+  return textResult(`Patched: ${path}`);
+}
+
+/** Handles the vault "search_replace" action. */
+async function handleVaultSearchReplace(
+  client: ObsidianClient,
+  path: string,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const search = args["search"] as string | undefined;
+  const replaceText = args["replace"] as string | undefined;
+  if (!search) return errorResult("[vault] search is required for search_replace");
+  if (replaceText === undefined) return errorResult("[vault] replace is required for search_replace");
+  const result = await client.getFileContents(path, "markdown");
+  if (typeof result !== "string") {
+    return errorResult("[vault] Expected markdown content");
+  }
+  const caseSensitive = args["caseSensitive"] as boolean;
+  const replaceAll = args["replaceAll"] as boolean;
+  const useRegex = args["useRegex"] as boolean;
+  const flags = `${caseSensitive ? "" : "i"}${replaceAll ? "g" : ""}`;
+  const pattern = useRegex ? new RegExp(search, flags) : new RegExp(escapeRegex(search), flags);
+  const updated = result.replace(pattern, replaceText);
+  if (updated === result) {
+    return textResult(`No matches found for "${search}" in ${path}`);
+  }
+  await client.putContent(path, updated);
+  return textResult(`Replaced in: ${path}`);
+}
+
+// --- Extracted periodic_note action handlers ---
+
+/** Handles periodic_note "patch" action. */
+async function handlePeriodicPatch(
+  client: ObsidianClient,
+  period: string,
+  isByDate: boolean,
+  year: number,
+  month: number,
+  day: number,
+  args: Record<string, unknown>,
+): Promise<ToolResult> {
+  const content = args["content"] as string | undefined;
+  if (content === undefined) return errorResult("[periodic_note] content is required for patch");
+  const operation = args["operation"] as "append" | "prepend" | "replace" | undefined;
+  const targetType = args["targetType"] as "heading" | "block" | "frontmatter" | undefined;
+  const target = args["target"] as string | undefined;
+  if (!operation) return errorResult("[periodic_note] operation is required for patch");
+  if (!targetType) return errorResult("[periodic_note] targetType is required for patch");
+  if (!target) return errorResult("[periodic_note] target is required for patch");
+  const patchOpts = {
+    operation,
+    targetType,
+    target,
+    targetDelimiter: args["targetDelimiter"] as string | undefined,
+    trimTargetWhitespace: args["trimTargetWhitespace"] as boolean | undefined,
+    createIfMissing: args["createIfMissing"] as boolean | undefined,
+    contentType: args["contentType"] as "markdown" | "json" | undefined,
+  };
+  if (isByDate) {
+    await client.patchPeriodicNoteForDate(period, year, month, day, content, patchOpts);
+  } else {
+    await client.patchPeriodicNote(period, content, patchOpts);
+  }
+  return textResult(`Patched ${period} note`);
+}
+
+// --- Extracted recent handlers ---
+
+/** Fetches recent changes using cache or fallback API calls. */
+async function handleRecentChanges(
+  client: ObsidianClient,
+  cache: VaultCache,
+  config: Config,
+  limit: number,
+): Promise<ToolResult> {
+  if (config.enableCache && cache.getIsInitialized()) {
+    const allNotes = cache.getAllNotes();
+    const sorted = [...allNotes]
+      .sort((a, b) => b.stat.mtime - a.stat.mtime)
+      .slice(0, limit)
+      .map((n) => ({ path: n.path, mtime: n.stat.mtime }));
+    return jsonResult(sorted);
+  }
+  const { files } = await client.listFilesInVault();
+  const mdFiles = files.filter((f) => f.toLowerCase().endsWith(".md"));
+  const withStats = await Promise.allSettled(
+    mdFiles.map(async (fp) => {
+      const result = await client.getFileContents(fp, "json");
+      if (typeof result !== "string" && "stat" in result) {
+        return { path: fp, mtime: result.stat.mtime };
+      }
+      return { path: fp, mtime: 0 };
+    }),
+  );
+  const sorted = withStats
+    .filter((r): r is PromiseFulfilledResult<{ path: string; mtime: number }> => r.status === "fulfilled")
+    .map((r) => r.value)
+    .sort((a, b) => b.mtime - a.mtime)
+    .slice(0, limit);
+  return jsonResult(sorted);
+}
+
+/** Fetches recent periodic notes by listing the vault directory. */
+async function handleRecentPeriodicNotes(
+  client: ObsidianClient,
+  period: string,
+  limit: number,
+): Promise<ToolResult> {
+  const { files } = await client.listFilesInVault();
+  const periodDirs: Record<string, string> = {
+    daily: "Daily Notes",
+    weekly: "Weekly Notes",
+    monthly: "Monthly Notes",
+    quarterly: "Quarterly Notes",
+    yearly: "Yearly Notes",
+  };
+  const dirName = periodDirs[period] ?? period;
+  const periodFiles = files
+    .filter((f) => f.startsWith(`${dirName}/`) && f.toLowerCase().endsWith(".md"))
+    .sort((a, b) => b.localeCompare(a))
+    .slice(0, limit);
+  return jsonResult(periodFiles);
+}
+
+// --- Extracted configure handler ---
+
+/** Handles the "set" action for the configure tool. */
+function handleConfigureSet(
+  setting: string | undefined,
+  value: string | undefined,
+  config: Config,
+): ToolResult {
+  if (!setting) return errorResult("[configure] setting is required for 'set'");
+  if (value === undefined) return errorResult("[configure] value is required for 'set'");
+  const immediateSettings = new Set(["debug", "timeout", "verifyWrites", "maxResponseChars"]);
+  const restartSettings = new Set(["toolMode", "toolPreset"]);
+  if (!immediateSettings.has(setting) && !restartSettings.has(setting)) {
+    return errorResult(`[configure] Unknown setting: ${setting}. Available: ${[...immediateSettings, ...restartSettings].join(", ")}`);
+  }
+  const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
+  const updates = buildConfigUpdate(setting, value);
+  if (updates === undefined) {
+    return errorResult(`[configure] Invalid value "${value}" for setting "${setting}"`);
+  }
+  saveConfigToFile(configPath, updates);
+  if (immediateSettings.has(setting)) {
+    applyImmediateSetting(setting, value);
+    return textResult(`Setting "${setting}" updated to "${value}" (effective immediately)`);
+  }
+  return textResult(`Setting "${setting}" saved. Restart the server for this change to take effect.`);
+}
+
+// --- Extracted vault_analysis handler ---
+
+/** Builds vault structure statistics from cache. */
+function buildVaultStructure(cache: VaultCache, limit: number): ToolResult {
+  const orphans = cache.getOrphanNotes();
+  const mostConnected = cache.getMostConnectedNotes(limit);
+  const graph = cache.getVaultGraph();
+  const dirs = new Set<string>();
+  for (const p of cache.getFileList()) {
+    const lastSlash = p.lastIndexOf("/");
+    if (lastSlash !== -1) {
+      dirs.add(p.slice(0, lastSlash));
+    }
+  }
+  return jsonResult({
+    noteCount: cache.noteCount,
+    linkCount: cache.linkCount,
+    directoryCount: dirs.size,
+    orphanCount: orphans.length,
+    orphans: orphans.slice(0, 20),
+    mostConnected,
+    edgeCount: graph.edges.length,
+  });
+}
+
 // --- Registration ---
 
 /** Registers all 11 consolidated tools, filtered by the shouldRegister predicate. */
@@ -76,26 +279,28 @@ export function registerConsolidatedTools(
 
   // --- 1. vault ---
   if (shouldRegister("vault")) {
-    server.tool(
+    server.registerTool(
       "vault",
-      "Read, write, search, and manage vault files",
       {
-        action: z.enum(["list", "list_dir", "get", "put", "append", "patch", "delete", "search_replace"]).describe("Operation"),
-        path: z.string().optional().describe("File or directory path"),
-        content: z.string().optional().describe("Content for writes"),
-        format: formatSchema.optional(),
-        operation: patchOperationSchema.optional(),
-        targetType: patchTargetTypeSchema.optional(),
-        target: z.string().optional().describe("Patch target"),
-        targetDelimiter: z.string().optional().describe("Heading delimiter"),
-        trimTargetWhitespace: z.boolean().optional().describe("Trim whitespace"),
-        createIfMissing: z.boolean().optional().describe("Create if missing"),
-        contentType: patchContentTypeSchema.optional(),
-        search: z.string().optional().describe("Search text"),
-        replace: z.string().optional().describe("Replace text"),
-        useRegex: z.boolean().default(false).describe("Regex matching"),
-        caseSensitive: z.boolean().default(true).describe("Case sensitive"),
-        replaceAll: z.boolean().default(true).describe("Replace all"),
+        description: "Read, write, search, and manage vault files",
+        inputSchema: z.object({
+          action: z.enum(["list", "list_dir", "get", "put", "append", "patch", "delete", "search_replace"]).describe("Operation"),
+          path: z.string().optional().describe("File or directory path"),
+          content: z.string().optional().describe("Content for writes"),
+          format: formatSchema.optional(),
+          operation: patchOperationSchema.optional(),
+          targetType: patchTargetTypeSchema.optional(),
+          target: z.string().optional().describe("Patch target"),
+          targetDelimiter: z.string().optional().describe("Heading delimiter"),
+          trimTargetWhitespace: z.boolean().optional().describe("Trim whitespace"),
+          createIfMissing: z.boolean().optional().describe("Create if missing"),
+          contentType: patchContentTypeSchema.optional(),
+          search: z.string().optional().describe("Search text"),
+          replace: z.string().optional().describe("Replace text"),
+          useRegex: z.boolean().default(false).describe("Regex matching"),
+          caseSensitive: z.boolean().default(true).describe("Case sensitive"),
+          replaceAll: z.boolean().default(true).describe("Replace all"),
+        }),
       },
       async (args) => {
         const { action, path } = args;
@@ -106,68 +311,32 @@ export function registerConsolidatedTools(
           switch (action) {
             case "list":
               return jsonResult(await client.listFilesInVault());
-
             case "list_dir":
               if (!path) return errorResult("[vault] path is required for list_dir");
               return jsonResult(await client.listFilesInDir(path));
-
             case "get":
               if (!path) return errorResult("[vault] path is required for get");
               return formatFileContents(await client.getFileContents(path, args.format));
-
             case "put":
               if (!path) return errorResult("[vault] path is required for put");
               if (args.content === undefined) return errorResult("[vault] content is required for put");
               await client.putContent(path, args.content);
               return textResult(`Written: ${path}`);
-
             case "append":
               if (!path) return errorResult("[vault] path is required for append");
               if (args.content === undefined) return errorResult("[vault] content is required for append");
               await client.appendContent(path, args.content);
               return textResult(`Appended to: ${path}`);
-
-            case "patch": {
+            case "patch":
               if (!path) return errorResult("[vault] path is required for patch");
-              if (args.content === undefined) return errorResult("[vault] content is required for patch");
-              if (!args.operation) return errorResult("[vault] operation is required for patch");
-              if (!args.targetType) return errorResult("[vault] targetType is required for patch");
-              if (!args.target) return errorResult("[vault] target is required for patch");
-              await client.patchContent(path, args.content, {
-                operation: args.operation,
-                targetType: args.targetType,
-                target: args.target,
-                targetDelimiter: args.targetDelimiter,
-                trimTargetWhitespace: args.trimTargetWhitespace,
-                createIfMissing: args.createIfMissing,
-                contentType: args.contentType,
-              });
-              return textResult(`Patched: ${path}`);
-            }
-
+              return handleVaultPatch(client, path, args as unknown as Record<string, unknown>);
             case "delete":
               if (!path) return errorResult("[vault] path is required for delete");
               await client.deleteFile(path);
               return textResult(`Deleted: ${path}`);
-
-            case "search_replace": {
+            case "search_replace":
               if (!path) return errorResult("[vault] path is required for search_replace");
-              if (!args.search) return errorResult("[vault] search is required for search_replace");
-              if (args.replace === undefined) return errorResult("[vault] replace is required for search_replace");
-              const result = await client.getFileContents(path, "markdown");
-              if (typeof result !== "string") {
-                return errorResult("[vault] Expected markdown content");
-              }
-              const flags = `${args.caseSensitive ? "" : "i"}${args.replaceAll ? "g" : ""}`;
-              const pattern = args.useRegex ? new RegExp(args.search, flags) : new RegExp(escapeRegex(args.search), flags);
-              const updated = result.replace(pattern, args.replace);
-              if (updated === result) {
-                return textResult(`No matches found for "${args.search}" in ${path}`);
-              }
-              await client.putContent(path, updated);
-              return textResult(`Replaced in: ${path}`);
-            }
-
+              return handleVaultSearchReplace(client, path, args as unknown as Record<string, unknown>);
             default: {
               const _exhaustive: never = action;
               return errorResult(`[vault] Unknown action: ${String(_exhaustive)}`);
@@ -183,19 +352,21 @@ export function registerConsolidatedTools(
 
   // --- 2. active_file ---
   if (shouldRegister("active_file")) {
-    server.tool(
+    server.registerTool(
       "active_file",
-      "Read, write, or delete the currently open file",
       {
-        action: z.enum(["get", "put", "append", "patch", "delete"]).describe("Operation"),
-        content: z.string().optional().describe("Content for writes"),
-        format: formatSchema.optional(),
-        operation: patchOperationSchema.optional(),
-        targetType: patchTargetTypeSchema.optional(),
-        target: z.string().optional().describe("Patch target"),
-        targetDelimiter: z.string().optional().describe("Heading delimiter"),
-        trimTargetWhitespace: z.boolean().optional().describe("Trim whitespace"),
-        contentType: patchContentTypeSchema.optional(),
+        description: "Read, write, or delete the currently open file",
+        inputSchema: z.object({
+          action: z.enum(["get", "put", "append", "patch", "delete"]).describe("Operation"),
+          content: z.string().optional().describe("Content for writes"),
+          format: formatSchema.optional(),
+          operation: patchOperationSchema.optional(),
+          targetType: patchTargetTypeSchema.optional(),
+          target: z.string().optional().describe("Patch target"),
+          targetDelimiter: z.string().optional().describe("Heading delimiter"),
+          trimTargetWhitespace: z.boolean().optional().describe("Trim whitespace"),
+          contentType: patchContentTypeSchema.optional(),
+        }),
       },
       async (args) => {
         const { action } = args;
@@ -206,17 +377,14 @@ export function registerConsolidatedTools(
           switch (action) {
             case "get":
               return formatFileContents(await client.getActiveFile(args.format));
-
             case "put":
               if (args.content === undefined) return errorResult("[active_file] content is required for put");
               await client.putActiveFile(args.content);
               return textResult("Active file updated");
-
             case "append":
               if (args.content === undefined) return errorResult("[active_file] content is required for append");
               await client.appendActiveFile(args.content);
               return textResult("Appended to active file");
-
             case "patch": {
               if (args.content === undefined) return errorResult("[active_file] content is required for patch");
               if (!args.operation) return errorResult("[active_file] operation is required for patch");
@@ -232,11 +400,9 @@ export function registerConsolidatedTools(
               });
               return textResult("Active file patched");
             }
-
             case "delete":
               await client.deleteActiveFile();
               return textResult("Active file deleted");
-
             default: {
               const _exhaustive: never = action;
               return errorResult(`[active_file] Unknown action: ${String(_exhaustive)}`);
@@ -252,24 +418,24 @@ export function registerConsolidatedTools(
 
   // --- 3. commands ---
   if (shouldRegister("commands")) {
-    server.tool(
+    server.registerTool(
       "commands",
-      "List or execute Obsidian commands",
       {
-        action: z.enum(["list", "execute"]).describe("Operation"),
-        commandId: z.string().optional().describe("Command ID for execute"),
+        description: "List or execute Obsidian commands",
+        inputSchema: z.object({
+          action: z.enum(["list", "execute"]).describe("Operation"),
+          commandId: z.string().optional().describe("Command ID for execute"),
+        }),
       },
       async ({ action, commandId }) => {
         try {
           switch (action) {
             case "list":
               return jsonResult(await client.listCommands());
-
             case "execute":
               if (!commandId) return errorResult("[commands] commandId is required for execute");
               await client.executeCommand(commandId);
               return textResult(`Executed: ${commandId}`);
-
             default: {
               const _exhaustive: never = action;
               return errorResult(`[commands] Unknown action: ${String(_exhaustive)}`);
@@ -285,12 +451,14 @@ export function registerConsolidatedTools(
 
   // --- 4. open_file ---
   if (shouldRegister("open_file")) {
-    server.tool(
+    server.registerTool(
       "open_file",
-      "Open a file in the Obsidian UI",
       {
-        path: z.string().describe("File path"),
-        newLeaf: z.boolean().default(false).describe("Open in new tab"),
+        description: "Open a file in the Obsidian UI",
+        inputSchema: z.object({
+          path: z.string().describe("File path"),
+          newLeaf: z.boolean().default(false).describe("Open in new tab"),
+        }),
       },
       async ({ path, newLeaf }) => {
         try {
@@ -306,14 +474,16 @@ export function registerConsolidatedTools(
 
   // --- 5. search ---
   if (shouldRegister("search")) {
-    server.tool(
+    server.registerTool(
       "search",
-      "Search vault with text, JsonLogic, or Dataview DQL",
       {
-        type: z.enum(["simple", "jsonlogic", "dataview"]).describe("Search type"),
-        query: z.string().optional().describe("Query for simple/dataview"),
-        jsonQuery: z.record(z.unknown()).optional().describe("JsonLogic object"),
-        contextLength: z.number().default(100).describe("Context chars"),
+        description: "Search vault with text, JsonLogic, or Dataview DQL",
+        inputSchema: z.object({
+          type: z.enum(["simple", "jsonlogic", "dataview"]).describe("Search type"),
+          query: z.string().optional().describe("Query for simple/dataview"),
+          jsonQuery: z.record(z.unknown()).optional().describe("JsonLogic object"),
+          contextLength: z.number().default(100).describe("Context chars"),
+        }),
       },
       async ({ type, query, jsonQuery, contextLength }) => {
         try {
@@ -321,15 +491,12 @@ export function registerConsolidatedTools(
             case "simple":
               if (!query) return errorResult("[search] query is required for simple search");
               return jsonResult(await client.simpleSearch(query, contextLength));
-
             case "jsonlogic":
               if (!jsonQuery) return errorResult("[search] jsonQuery is required for jsonlogic search");
               return jsonResult(await client.complexSearch(jsonQuery));
-
             case "dataview":
               if (!query) return errorResult("[search] query is required for dataview search");
               return jsonResult(await client.dataviewSearch(query));
-
             default: {
               const _exhaustive: never = type;
               return errorResult(`[search] Unknown type: ${String(_exhaustive)}`);
@@ -345,24 +512,26 @@ export function registerConsolidatedTools(
 
   // --- 6. periodic_note ---
   if (shouldRegister("periodic_note")) {
-    server.tool(
+    server.registerTool(
       "periodic_note",
-      "CRUD operations on periodic notes (current or by date)",
       {
-        action: z.enum(["get", "put", "append", "patch", "delete"]).describe("Operation"),
-        period: periodSchema,
-        year: z.number().int().optional().describe("Year (omit for current)"),
-        month: z.number().int().min(1).max(12).optional().describe("Month (1-12)"),
-        day: z.number().int().min(1).max(31).optional().describe("Day (1-31)"),
-        content: z.string().optional().describe("Content for writes"),
-        format: formatSchema.optional(),
-        operation: patchOperationSchema.optional(),
-        targetType: patchTargetTypeSchema.optional(),
-        target: z.string().optional().describe("Patch target"),
-        targetDelimiter: z.string().optional().describe("Heading delimiter"),
-        trimTargetWhitespace: z.boolean().optional().describe("Trim whitespace"),
-        createIfMissing: z.boolean().optional().describe("Create if missing"),
-        contentType: patchContentTypeSchema.optional(),
+        description: "CRUD operations on periodic notes (current or by date)",
+        inputSchema: z.object({
+          action: z.enum(["get", "put", "append", "patch", "delete"]).describe("Operation"),
+          period: periodSchema,
+          year: z.number().int().optional().describe("Year (omit for current)"),
+          month: z.number().int().min(1).max(12).optional().describe("Month (1-12)"),
+          day: z.number().int().min(1).max(31).optional().describe("Day (1-31)"),
+          content: z.string().optional().describe("Content for writes"),
+          format: formatSchema.optional(),
+          operation: patchOperationSchema.optional(),
+          targetType: patchTargetTypeSchema.optional(),
+          target: z.string().optional().describe("Patch target"),
+          targetDelimiter: z.string().optional().describe("Heading delimiter"),
+          trimTargetWhitespace: z.boolean().optional().describe("Trim whitespace"),
+          createIfMissing: z.boolean().optional().describe("Create if missing"),
+          contentType: patchContentTypeSchema.optional(),
+        }),
       },
       async (args) => {
         const { action, period, year, month, day } = args;
@@ -370,7 +539,6 @@ export function registerConsolidatedTools(
           return errorResult(`[periodic_note] Action "${action}" is not allowed in "${config.toolPreset}" preset`);
         }
         const isByDate = year !== undefined && month !== undefined && day !== undefined;
-
         try {
           switch (action) {
             case "get":
@@ -378,55 +546,22 @@ export function registerConsolidatedTools(
                 return formatFileContents(await client.getPeriodicNoteForDate(period, year, month!, day!, args.format));
               }
               return formatFileContents(await client.getPeriodicNote(period, args.format));
-
             case "put":
               if (args.content === undefined) return errorResult("[periodic_note] content is required for put");
-              if (isByDate) {
-                await client.putPeriodicNoteForDate(period, year, month!, day!, args.content);
-              } else {
-                await client.putPeriodicNote(period, args.content);
-              }
+              if (isByDate) { await client.putPeriodicNoteForDate(period, year, month!, day!, args.content); }
+              else { await client.putPeriodicNote(period, args.content); }
               return textResult(`Updated ${period} note`);
-
             case "append":
               if (args.content === undefined) return errorResult("[periodic_note] content is required for append");
-              if (isByDate) {
-                await client.appendPeriodicNoteForDate(period, year, month!, day!, args.content);
-              } else {
-                await client.appendPeriodicNote(period, args.content);
-              }
+              if (isByDate) { await client.appendPeriodicNoteForDate(period, year, month!, day!, args.content); }
+              else { await client.appendPeriodicNote(period, args.content); }
               return textResult(`Appended to ${period} note`);
-
-            case "patch": {
-              if (args.content === undefined) return errorResult("[periodic_note] content is required for patch");
-              if (!args.operation) return errorResult("[periodic_note] operation is required for patch");
-              if (!args.targetType) return errorResult("[periodic_note] targetType is required for patch");
-              if (!args.target) return errorResult("[periodic_note] target is required for patch");
-              const patchOpts = {
-                operation: args.operation,
-                targetType: args.targetType,
-                target: args.target,
-                targetDelimiter: args.targetDelimiter,
-                trimTargetWhitespace: args.trimTargetWhitespace,
-                createIfMissing: args.createIfMissing,
-                contentType: args.contentType,
-              };
-              if (isByDate) {
-                await client.patchPeriodicNoteForDate(period, year, month!, day!, args.content, patchOpts);
-              } else {
-                await client.patchPeriodicNote(period, args.content, patchOpts);
-              }
-              return textResult(`Patched ${period} note`);
-            }
-
+            case "patch":
+              return handlePeriodicPatch(client, period, isByDate, year ?? 0, month ?? 0, day ?? 0, args as unknown as Record<string, unknown>);
             case "delete":
-              if (isByDate) {
-                await client.deletePeriodicNoteForDate(period, year, month!, day!);
-              } else {
-                await client.deletePeriodicNote(period);
-              }
+              if (isByDate) { await client.deletePeriodicNoteForDate(period, year, month!, day!); }
+              else { await client.deletePeriodicNote(period); }
               return textResult(`Deleted ${period} note`);
-
             default: {
               const _exhaustive: never = action;
               return errorResult(`[periodic_note] Unknown action: ${String(_exhaustive)}`);
@@ -442,10 +577,11 @@ export function registerConsolidatedTools(
 
   // --- 7. status (PROTECTED) ---
   if (shouldRegister("status")) {
-    server.tool(
+    server.registerTool(
       "status",
-      "Check Obsidian API connection and version",
-      {},
+      {
+        description: "Check Obsidian API connection and version",
+      },
       async () => {
         try {
           return jsonResult(await client.getServerStatus());
@@ -459,12 +595,14 @@ export function registerConsolidatedTools(
 
   // --- 8. batch_get ---
   if (shouldRegister("batch_get")) {
-    server.tool(
+    server.registerTool(
       "batch_get",
-      "Read multiple vault files in one call",
       {
-        paths: z.array(z.string()).min(1).describe("File paths"),
-        format: formatSchema.optional(),
+        description: "Read multiple vault files in one call",
+        inputSchema: z.object({
+          paths: z.array(z.string()).min(1).describe("File paths"),
+          format: formatSchema.optional(),
+        }),
       },
       async ({ paths, format }) => {
         try {
@@ -494,65 +632,24 @@ export function registerConsolidatedTools(
 
   // --- 9. recent ---
   if (shouldRegister("recent")) {
-    server.tool(
+    server.registerTool(
       "recent",
-      "Get recently modified files or periodic notes",
       {
-        type: z.enum(["changes", "periodic_notes"]).describe("Query type"),
-        period: periodSchema.optional(),
-        limit: z.number().int().min(1).default(10).describe("Max results"),
+        description: "Get recently modified files or periodic notes",
+        inputSchema: z.object({
+          type: z.enum(["changes", "periodic_notes"]).describe("Query type"),
+          period: periodSchema.optional(),
+          limit: z.number().int().min(1).default(10).describe("Max results"),
+        }),
       },
       async ({ type, period, limit }) => {
         try {
           switch (type) {
-            case "changes": {
-              if (config.enableCache && cache.getIsInitialized()) {
-                const allNotes = cache.getAllNotes();
-                const sorted = [...allNotes]
-                  .sort((a, b) => b.stat.mtime - a.stat.mtime)
-                  .slice(0, limit)
-                  .map((n) => ({ path: n.path, mtime: n.stat.mtime }));
-                return jsonResult(sorted);
-              }
-              // Fallback without cache
-              const { files } = await client.listFilesInVault();
-              const mdFiles = files.filter((f) => f.toLowerCase().endsWith(".md"));
-              const withStats = await Promise.allSettled(
-                mdFiles.map(async (fp) => {
-                  const result = await client.getFileContents(fp, "json");
-                  if (typeof result !== "string" && "stat" in result) {
-                    return { path: fp, mtime: result.stat.mtime };
-                  }
-                  return { path: fp, mtime: 0 };
-                }),
-              );
-              const sorted = withStats
-                .filter((r): r is PromiseFulfilledResult<{ path: string; mtime: number }> => r.status === "fulfilled")
-                .map((r) => r.value)
-                .sort((a, b) => b.mtime - a.mtime)
-                .slice(0, limit);
-              return jsonResult(sorted);
-            }
-
-            case "periodic_notes": {
+            case "changes":
+              return handleRecentChanges(client, cache, config, limit);
+            case "periodic_notes":
               if (!period) return errorResult("[recent] period is required for periodic_notes");
-              const { files } = await client.listFilesInVault();
-              const periodDirs: Record<string, string> = {
-                daily: "Daily Notes",
-                weekly: "Weekly Notes",
-                monthly: "Monthly Notes",
-                quarterly: "Quarterly Notes",
-                yearly: "Yearly Notes",
-              };
-              const dirName = periodDirs[period] ?? period;
-              const periodFiles = files
-                .filter((f) => f.startsWith(`${dirName}/`) && f.toLowerCase().endsWith(".md"))
-                .sort()
-                .reverse()
-                .slice(0, limit);
-              return jsonResult(periodFiles);
-            }
-
+              return handleRecentPeriodicNotes(client, period, limit);
             default: {
               const _exhaustive: never = type;
               return errorResult(`[recent] Unknown type: ${String(_exhaustive)}`);
@@ -568,41 +665,23 @@ export function registerConsolidatedTools(
 
   // --- 10. configure (PROTECTED) ---
   if (shouldRegister("configure")) {
-    server.tool(
+    server.registerTool(
       "configure",
-      "View or change server settings",
       {
-        action: z.enum(["show", "set", "reset"]).describe("Action"),
-        setting: z.string().optional().describe("Setting name"),
-        value: z.string().optional().describe("New value"),
+        description: "View or change server settings",
+        inputSchema: z.object({
+          action: z.enum(["show", "set", "reset"]).describe("Action"),
+          setting: z.string().optional().describe("Setting name"),
+          value: z.string().optional().describe("New value"),
+        }),
       },
       async ({ action, setting, value }) => {
         try {
           switch (action) {
             case "show":
               return jsonResult(getRedactedConfig(config));
-
-            case "set": {
-              if (!setting) return errorResult("[configure] setting is required for 'set'");
-              if (value === undefined) return errorResult("[configure] value is required for 'set'");
-              const immediateSettings = new Set(["debug", "timeout", "verifyWrites", "maxResponseChars"]);
-              const restartSettings = new Set(["toolMode", "toolPreset"]);
-              if (!immediateSettings.has(setting) && !restartSettings.has(setting)) {
-                return errorResult(`[configure] Unknown setting: ${setting}. Available: ${[...immediateSettings, ...restartSettings].join(", ")}`);
-              }
-              const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
-              const updates = buildConfigUpdate(setting, value);
-              if (updates === undefined) {
-                return errorResult(`[configure] Invalid value "${value}" for setting "${setting}"`);
-              }
-              saveConfigToFile(configPath, updates);
-              if (immediateSettings.has(setting)) {
-                applyImmediateSetting(setting, value);
-                return textResult(`Setting "${setting}" updated to "${value}" (effective immediately)`);
-              }
-              return textResult(`Setting "${setting}" saved. Restart the server for this change to take effect.`);
-            }
-
+            case "set":
+              return handleConfigureSet(setting, value, config);
             case "reset": {
               if (!setting) return errorResult("[configure] setting is required for 'reset'");
               const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
@@ -613,7 +692,6 @@ export function registerConsolidatedTools(
               saveConfigToFile(configPath, resetUpdates);
               return textResult(`Setting "${setting}" reset to default. Restart for this change to take effect.`);
             }
-
             default: {
               const _exhaustive: never = action;
               return errorResult(`[configure] Unknown action: ${String(_exhaustive)}`);
@@ -629,13 +707,15 @@ export function registerConsolidatedTools(
 
   // --- 11. vault_analysis ---
   if (shouldRegister("vault_analysis")) {
-    server.tool(
+    server.registerTool(
       "vault_analysis",
-      "Backlinks, connections, structure, and cache refresh",
       {
-        action: z.enum(["backlinks", "connections", "structure", "refresh"]).describe("Analysis type"),
-        path: z.string().optional().describe("File path for backlinks/connections"),
-        limit: z.number().int().min(1).default(10).describe("Top N for structure"),
+        description: "Backlinks, connections, structure, and cache refresh",
+        inputSchema: z.object({
+          action: z.enum(["backlinks", "connections", "structure", "refresh"]).describe("Analysis type"),
+          path: z.string().optional().describe("File path for backlinks/connections"),
+          limit: z.number().int().min(1).default(10).describe("Top N for structure"),
+        }),
       },
       async ({ action, path, limit }) => {
         if (!isActionAllowed("vault_analysis", action, config.toolPreset)) {
@@ -645,55 +725,21 @@ export function registerConsolidatedTools(
           if (!config.enableCache) {
             return errorResult("[vault_analysis] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
           }
-
           switch (action) {
-            case "backlinks": {
+            case "backlinks":
               if (!path) return errorResult("[vault_analysis] path is required for backlinks");
-              if (!cache.getIsInitialized()) {
-                return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
-              }
+              if (!cache.getIsInitialized()) return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
               return jsonResult(cache.getBacklinks(path));
-            }
-
-            case "connections": {
+            case "connections":
               if (!path) return errorResult("[vault_analysis] path is required for connections");
-              if (!cache.getIsInitialized()) {
-                return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
-              }
-              const backlinks = cache.getBacklinks(path);
-              const forwardLinks = cache.getForwardLinks(path);
-              return jsonResult({ backlinks, forwardLinks });
-            }
-
-            case "structure": {
-              if (!cache.getIsInitialized()) {
-                return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
-              }
-              const orphans = cache.getOrphanNotes();
-              const mostConnected = cache.getMostConnectedNotes(limit);
-              const graph = cache.getVaultGraph();
-              const dirs = new Set<string>();
-              for (const p of cache.getFileList()) {
-                const lastSlash = p.lastIndexOf("/");
-                if (lastSlash !== -1) {
-                  dirs.add(p.slice(0, lastSlash));
-                }
-              }
-              return jsonResult({
-                noteCount: cache.noteCount,
-                linkCount: cache.linkCount,
-                directoryCount: dirs.size,
-                orphanCount: orphans.length,
-                orphans: orphans.slice(0, 20),
-                mostConnected,
-                edgeCount: graph.edges.length,
-              });
-            }
-
+              if (!cache.getIsInitialized()) return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
+              return jsonResult({ backlinks: cache.getBacklinks(path), forwardLinks: cache.getForwardLinks(path) });
+            case "structure":
+              if (!cache.getIsInitialized()) return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
+              return buildVaultStructure(cache, limit);
             case "refresh":
               await cache.refresh();
               return textResult(`Cache refreshed: ${String(cache.noteCount)} notes, ${String(cache.linkCount)} links`);
-
             default: {
               const _exhaustive: never = action;
               return errorResult(`[vault_analysis] Unknown action: ${String(_exhaustive)}`);

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -175,7 +175,12 @@ async function handleVaultSearchReplace(
     return errorResult("[vault] Expected markdown content");
   }
   const flags = `${caseSensitive ? "" : "i"}${replaceAll ? "g" : ""}`;
-  const pattern = useRegex ? new RegExp(search, flags) : new RegExp(escapeRegex(search), flags);
+  let pattern: RegExp;
+  if (useRegex) {
+    try { pattern = new RegExp(search, flags); } catch { return errorResult(`[vault] Invalid regex: "${search}"`); }
+  } else {
+    pattern = new RegExp(escapeRegex(search), flags);
+  }
   const updated = result.replace(pattern, replaceText);
   if (updated === result) {
     return textResult(`No matches found for "${search}" in ${path}`);

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import type { ObsidianClient, NoteJson, DocumentMap, ToolResult } from "../obsidian.js";
+import type { ObsidianClient, NoteJson, DocumentMap, ToolResult, PatchOptions } from "../obsidian.js";
 import { textResult, errorResult, jsonResult } from "../obsidian.js";
 import type { VaultCache } from "../cache.js";
 import type { Config } from "../config.js";
@@ -70,18 +70,24 @@ interface VaultArgs {
   readonly path?: string | undefined;
   readonly content?: string | undefined;
   readonly format?: "markdown" | "json" | "map" | undefined;
-  readonly operation?: "append" | "prepend" | "replace" | undefined;
-  readonly targetType?: "heading" | "block" | "frontmatter" | undefined;
+  readonly operation?: PatchOptions["operation"] | undefined;
+  readonly targetType?: PatchOptions["targetType"] | undefined;
   readonly target?: string | undefined;
   readonly targetDelimiter?: string | undefined;
   readonly trimTargetWhitespace?: boolean | undefined;
   readonly createIfMissing?: boolean | undefined;
-  readonly contentType?: "markdown" | "json" | undefined;
+  readonly contentType?: PatchOptions["contentType"];
   readonly search?: string | undefined;
   readonly replace?: string | undefined;
   readonly useRegex: boolean;
   readonly caseSensitive: boolean;
   readonly replaceAll: boolean;
+}
+
+/** Validates that path is present, returning an error result if missing. */
+function requirePath(action: string, path: string | undefined): ToolResult | undefined {
+  if (!path) return errorResult(`[vault] path is required for ${action}`);
+  return undefined;
 }
 
 /** Dispatches a vault action to the appropriate client method. */
@@ -91,35 +97,31 @@ async function handleVaultAction(
   path: string | undefined,
   args: VaultArgs,
 ): Promise<ToolResult> {
+  if (action === "list") return jsonResult(await client.listFilesInVault());
+  const pathErr = requirePath(action, path);
+  if (pathErr) return pathErr;
+  // After requirePath, path is guaranteed non-empty
+  const safePath = path!;
   switch (action) {
-    case "list":
-      return jsonResult(await client.listFilesInVault());
     case "list_dir":
-      if (!path) return errorResult("[vault] path is required for list_dir");
-      return jsonResult(await client.listFilesInDir(path));
+      return jsonResult(await client.listFilesInDir(safePath));
     case "get":
-      if (!path) return errorResult("[vault] path is required for get");
-      return formatFileContents(await client.getFileContents(path, args.format));
+      return formatFileContents(await client.getFileContents(safePath, args.format));
     case "put":
-      if (!path) return errorResult("[vault] path is required for put");
       if (args.content === undefined) return errorResult("[vault] content is required for put");
-      await client.putContent(path, args.content);
-      return textResult(`Written: ${path}`);
+      await client.putContent(safePath, args.content);
+      return textResult(`Written: ${safePath}`);
     case "append":
-      if (!path) return errorResult("[vault] path is required for append");
       if (args.content === undefined) return errorResult("[vault] content is required for append");
-      await client.appendContent(path, args.content);
-      return textResult(`Appended to: ${path}`);
+      await client.appendContent(safePath, args.content);
+      return textResult(`Appended to: ${safePath}`);
     case "patch":
-      if (!path) return errorResult("[vault] path is required for patch");
-      return handleVaultPatch(client, path, args);
+      return handleVaultPatch(client, safePath, args);
     case "delete":
-      if (!path) return errorResult("[vault] path is required for delete");
-      await client.deleteFile(path);
-      return textResult(`Deleted: ${path}`);
+      await client.deleteFile(safePath);
+      return textResult(`Deleted: ${safePath}`);
     case "search_replace":
-      if (!path) return errorResult("[vault] path is required for search_replace");
-      return handleVaultSearchReplace(client, path, args.search, args.replace, args.caseSensitive, args.replaceAll, args.useRegex);
+      return handleVaultSearchReplace(client, safePath, args.search, args.replace, args.caseSensitive, args.replaceAll, args.useRegex);
     default: {
       const _exhaustive: never = action;
       return errorResult(`[vault] Unknown action: ${String(_exhaustive)}`);
@@ -132,13 +134,13 @@ async function handleVaultAction(
 /** Args for the vault "patch" action. */
 interface VaultPatchArgs {
   readonly content?: string | undefined;
-  readonly operation?: "append" | "prepend" | "replace" | undefined;
-  readonly targetType?: "heading" | "block" | "frontmatter" | undefined;
+  readonly operation?: PatchOptions["operation"] | undefined;
+  readonly targetType?: PatchOptions["targetType"] | undefined;
   readonly target?: string | undefined;
   readonly targetDelimiter?: string | undefined;
   readonly trimTargetWhitespace?: boolean | undefined;
   readonly createIfMissing?: boolean | undefined;
-  readonly contentType?: "markdown" | "json" | undefined;
+  readonly contentType?: PatchOptions["contentType"];
 }
 
 /** Handles the vault "patch" action. */

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -1,15 +1,764 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 
-import type { ObsidianClient } from "../obsidian.js";
+import type { ObsidianClient, NoteJson, DocumentMap } from "../obsidian.js";
+import { textResult, errorResult, jsonResult } from "../obsidian.js";
 import type { VaultCache } from "../cache.js";
+import type { Config } from "../config.js";
+import { getRedactedConfig, saveConfigToFile, setDebugEnabled, log } from "../config.js";
+import { buildErrorMessage } from "../errors.js";
+import {
+  formatSchema,
+  periodSchema,
+  patchOperationSchema,
+  patchTargetTypeSchema,
+  patchContentTypeSchema,
+} from "../schemas.js";
+
+// --- Preset action restrictions for consolidated mode ---
+
+/** Actions allowed in read-only preset (consolidated mode). */
+const READ_ONLY_ACTIONS: Record<string, ReadonlySet<string>> = {
+  vault: new Set(["list", "list_dir", "get"]),
+  active_file: new Set(["get"]),
+  commands: new Set(["list"]),
+  periodic_note: new Set(["get"]),
+  recent: new Set(["changes", "periodic_notes"]),
+  vault_analysis: new Set(["backlinks", "connections", "structure"]),
+};
+
+/** Actions removed in safe preset (consolidated mode). */
+const SAFE_BLOCKED_ACTIONS: Record<string, ReadonlySet<string>> = {
+  vault: new Set(["delete"]),
+  active_file: new Set(["delete"]),
+  periodic_note: new Set(["delete"]),
+};
+
+// --- Helpers ---
+
+/** Formats file contents for display. */
+function formatFileContents(result: string | NoteJson | DocumentMap): ReturnType<typeof textResult> {
+  if (typeof result === "string") {
+    return textResult(result);
+  }
+  return jsonResult(result);
+}
+
+/** Escapes a string for use as a literal in a RegExp. */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Checks if an action is allowed under the active preset for a given tool. */
+function isActionAllowed(toolName: string, action: string, preset: string): boolean {
+  if (preset === "read-only") {
+    const allowed = READ_ONLY_ACTIONS[toolName];
+    return allowed !== undefined ? allowed.has(action) : true;
+  }
+  if (preset === "safe") {
+    const blocked = SAFE_BLOCKED_ACTIONS[toolName];
+    return blocked !== undefined ? !blocked.has(action) : true;
+  }
+  return true;
+}
+
+// --- Registration ---
 
 /** Registers all 11 consolidated tools, filtered by the shouldRegister predicate. */
 export function registerConsolidatedTools(
-  _server: McpServer,
-  _client: ObsidianClient,
-  _cache: VaultCache,
-  _shouldRegister: (name: string) => boolean,
+  server: McpServer,
+  client: ObsidianClient,
+  cache: VaultCache,
+  shouldRegister: (name: string) => boolean,
+  config: Config,
 ): number {
-  // Phase 2: all 11 consolidated tools will be registered here
-  return 0;
+  let count = 0;
+
+  // --- 1. vault ---
+  if (shouldRegister("vault")) {
+    server.tool(
+      "vault",
+      "Read, write, search, and manage vault files",
+      {
+        action: z.enum(["list", "list_dir", "get", "put", "append", "patch", "delete", "search_replace"]).describe("Operation"),
+        path: z.string().optional().describe("File or directory path"),
+        content: z.string().optional().describe("Content for writes"),
+        format: formatSchema.optional(),
+        operation: patchOperationSchema.optional(),
+        targetType: patchTargetTypeSchema.optional(),
+        target: z.string().optional().describe("Patch target"),
+        targetDelimiter: z.string().optional().describe("Heading delimiter"),
+        trimTargetWhitespace: z.boolean().optional().describe("Trim whitespace"),
+        createIfMissing: z.boolean().optional().describe("Create if missing"),
+        contentType: patchContentTypeSchema.optional(),
+        search: z.string().optional().describe("Search text"),
+        replace: z.string().optional().describe("Replace text"),
+        useRegex: z.boolean().default(false).describe("Regex matching"),
+        caseSensitive: z.boolean().default(true).describe("Case sensitive"),
+        replaceAll: z.boolean().default(true).describe("Replace all"),
+      },
+      async (args) => {
+        const { action, path } = args;
+        if (!isActionAllowed("vault", action, config.toolPreset)) {
+          return errorResult(`[vault] Action "${action}" is not allowed in "${config.toolPreset}" preset`);
+        }
+        try {
+          switch (action) {
+            case "list":
+              return jsonResult(await client.listFilesInVault());
+
+            case "list_dir":
+              if (!path) return errorResult("[vault] path is required for list_dir");
+              return jsonResult(await client.listFilesInDir(path));
+
+            case "get":
+              if (!path) return errorResult("[vault] path is required for get");
+              return formatFileContents(await client.getFileContents(path, args.format));
+
+            case "put":
+              if (!path) return errorResult("[vault] path is required for put");
+              if (args.content === undefined) return errorResult("[vault] content is required for put");
+              await client.putContent(path, args.content);
+              return textResult(`Written: ${path}`);
+
+            case "append":
+              if (!path) return errorResult("[vault] path is required for append");
+              if (args.content === undefined) return errorResult("[vault] content is required for append");
+              await client.appendContent(path, args.content);
+              return textResult(`Appended to: ${path}`);
+
+            case "patch": {
+              if (!path) return errorResult("[vault] path is required for patch");
+              if (args.content === undefined) return errorResult("[vault] content is required for patch");
+              if (!args.operation) return errorResult("[vault] operation is required for patch");
+              if (!args.targetType) return errorResult("[vault] targetType is required for patch");
+              if (!args.target) return errorResult("[vault] target is required for patch");
+              await client.patchContent(path, args.content, {
+                operation: args.operation,
+                targetType: args.targetType,
+                target: args.target,
+                targetDelimiter: args.targetDelimiter,
+                trimTargetWhitespace: args.trimTargetWhitespace,
+                createIfMissing: args.createIfMissing,
+                contentType: args.contentType,
+              });
+              return textResult(`Patched: ${path}`);
+            }
+
+            case "delete":
+              if (!path) return errorResult("[vault] path is required for delete");
+              await client.deleteFile(path);
+              return textResult(`Deleted: ${path}`);
+
+            case "search_replace": {
+              if (!path) return errorResult("[vault] path is required for search_replace");
+              if (!args.search) return errorResult("[vault] search is required for search_replace");
+              if (args.replace === undefined) return errorResult("[vault] replace is required for search_replace");
+              const result = await client.getFileContents(path, "markdown");
+              if (typeof result !== "string") {
+                return errorResult("[vault] Expected markdown content");
+              }
+              const flags = `${args.caseSensitive ? "" : "i"}${args.replaceAll ? "g" : ""}`;
+              const pattern = args.useRegex ? new RegExp(args.search, flags) : new RegExp(escapeRegex(args.search), flags);
+              const updated = result.replace(pattern, args.replace);
+              if (updated === result) {
+                return textResult(`No matches found for "${args.search}" in ${path}`);
+              }
+              await client.putContent(path, updated);
+              return textResult(`Replaced in: ${path}`);
+            }
+
+            default: {
+              const _exhaustive: never = action;
+              return errorResult(`[vault] Unknown action: ${String(_exhaustive)}`);
+            }
+          }
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "vault", path }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 2. active_file ---
+  if (shouldRegister("active_file")) {
+    server.tool(
+      "active_file",
+      "Read, write, or delete the currently open file",
+      {
+        action: z.enum(["get", "put", "append", "patch", "delete"]).describe("Operation"),
+        content: z.string().optional().describe("Content for writes"),
+        format: formatSchema.optional(),
+        operation: patchOperationSchema.optional(),
+        targetType: patchTargetTypeSchema.optional(),
+        target: z.string().optional().describe("Patch target"),
+        targetDelimiter: z.string().optional().describe("Heading delimiter"),
+        trimTargetWhitespace: z.boolean().optional().describe("Trim whitespace"),
+        contentType: patchContentTypeSchema.optional(),
+      },
+      async (args) => {
+        const { action } = args;
+        if (!isActionAllowed("active_file", action, config.toolPreset)) {
+          return errorResult(`[active_file] Action "${action}" is not allowed in "${config.toolPreset}" preset`);
+        }
+        try {
+          switch (action) {
+            case "get":
+              return formatFileContents(await client.getActiveFile(args.format));
+
+            case "put":
+              if (args.content === undefined) return errorResult("[active_file] content is required for put");
+              await client.putActiveFile(args.content);
+              return textResult("Active file updated");
+
+            case "append":
+              if (args.content === undefined) return errorResult("[active_file] content is required for append");
+              await client.appendActiveFile(args.content);
+              return textResult("Appended to active file");
+
+            case "patch": {
+              if (args.content === undefined) return errorResult("[active_file] content is required for patch");
+              if (!args.operation) return errorResult("[active_file] operation is required for patch");
+              if (!args.targetType) return errorResult("[active_file] targetType is required for patch");
+              if (!args.target) return errorResult("[active_file] target is required for patch");
+              await client.patchActiveFile(args.content, {
+                operation: args.operation,
+                targetType: args.targetType,
+                target: args.target,
+                targetDelimiter: args.targetDelimiter,
+                trimTargetWhitespace: args.trimTargetWhitespace,
+                contentType: args.contentType,
+              });
+              return textResult("Active file patched");
+            }
+
+            case "delete":
+              await client.deleteActiveFile();
+              return textResult("Active file deleted");
+
+            default: {
+              const _exhaustive: never = action;
+              return errorResult(`[active_file] Unknown action: ${String(_exhaustive)}`);
+            }
+          }
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "active_file" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 3. commands ---
+  if (shouldRegister("commands")) {
+    server.tool(
+      "commands",
+      "List or execute Obsidian commands",
+      {
+        action: z.enum(["list", "execute"]).describe("Operation"),
+        commandId: z.string().optional().describe("Command ID for execute"),
+      },
+      async ({ action, commandId }) => {
+        try {
+          switch (action) {
+            case "list":
+              return jsonResult(await client.listCommands());
+
+            case "execute":
+              if (!commandId) return errorResult("[commands] commandId is required for execute");
+              await client.executeCommand(commandId);
+              return textResult(`Executed: ${commandId}`);
+
+            default: {
+              const _exhaustive: never = action;
+              return errorResult(`[commands] Unknown action: ${String(_exhaustive)}`);
+            }
+          }
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "commands" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 4. open_file ---
+  if (shouldRegister("open_file")) {
+    server.tool(
+      "open_file",
+      "Open a file in the Obsidian UI",
+      {
+        path: z.string().describe("File path"),
+        newLeaf: z.boolean().default(false).describe("Open in new tab"),
+      },
+      async ({ path, newLeaf }) => {
+        try {
+          await client.openFile(path, newLeaf);
+          return textResult(`Opened: ${path}`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "open_file", path }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 5. search ---
+  if (shouldRegister("search")) {
+    server.tool(
+      "search",
+      "Search vault with text, JsonLogic, or Dataview DQL",
+      {
+        type: z.enum(["simple", "jsonlogic", "dataview"]).describe("Search type"),
+        query: z.string().optional().describe("Query for simple/dataview"),
+        jsonQuery: z.record(z.unknown()).optional().describe("JsonLogic object"),
+        contextLength: z.number().default(100).describe("Context chars"),
+      },
+      async ({ type, query, jsonQuery, contextLength }) => {
+        try {
+          switch (type) {
+            case "simple":
+              if (!query) return errorResult("[search] query is required for simple search");
+              return jsonResult(await client.simpleSearch(query, contextLength));
+
+            case "jsonlogic":
+              if (!jsonQuery) return errorResult("[search] jsonQuery is required for jsonlogic search");
+              return jsonResult(await client.complexSearch(jsonQuery));
+
+            case "dataview":
+              if (!query) return errorResult("[search] query is required for dataview search");
+              return jsonResult(await client.dataviewSearch(query));
+
+            default: {
+              const _exhaustive: never = type;
+              return errorResult(`[search] Unknown type: ${String(_exhaustive)}`);
+            }
+          }
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "search" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 6. periodic_note ---
+  if (shouldRegister("periodic_note")) {
+    server.tool(
+      "periodic_note",
+      "CRUD operations on periodic notes (current or by date)",
+      {
+        action: z.enum(["get", "put", "append", "patch", "delete"]).describe("Operation"),
+        period: periodSchema,
+        year: z.number().int().optional().describe("Year (omit for current)"),
+        month: z.number().int().min(1).max(12).optional().describe("Month (1-12)"),
+        day: z.number().int().min(1).max(31).optional().describe("Day (1-31)"),
+        content: z.string().optional().describe("Content for writes"),
+        format: formatSchema.optional(),
+        operation: patchOperationSchema.optional(),
+        targetType: patchTargetTypeSchema.optional(),
+        target: z.string().optional().describe("Patch target"),
+        targetDelimiter: z.string().optional().describe("Heading delimiter"),
+        trimTargetWhitespace: z.boolean().optional().describe("Trim whitespace"),
+        createIfMissing: z.boolean().optional().describe("Create if missing"),
+        contentType: patchContentTypeSchema.optional(),
+      },
+      async (args) => {
+        const { action, period, year, month, day } = args;
+        if (!isActionAllowed("periodic_note", action, config.toolPreset)) {
+          return errorResult(`[periodic_note] Action "${action}" is not allowed in "${config.toolPreset}" preset`);
+        }
+        const isByDate = year !== undefined && month !== undefined && day !== undefined;
+
+        try {
+          switch (action) {
+            case "get":
+              if (isByDate) {
+                return formatFileContents(await client.getPeriodicNoteForDate(period, year, month!, day!, args.format));
+              }
+              return formatFileContents(await client.getPeriodicNote(period, args.format));
+
+            case "put":
+              if (args.content === undefined) return errorResult("[periodic_note] content is required for put");
+              if (isByDate) {
+                await client.putPeriodicNoteForDate(period, year, month!, day!, args.content);
+              } else {
+                await client.putPeriodicNote(period, args.content);
+              }
+              return textResult(`Updated ${period} note`);
+
+            case "append":
+              if (args.content === undefined) return errorResult("[periodic_note] content is required for append");
+              if (isByDate) {
+                await client.appendPeriodicNoteForDate(period, year, month!, day!, args.content);
+              } else {
+                await client.appendPeriodicNote(period, args.content);
+              }
+              return textResult(`Appended to ${period} note`);
+
+            case "patch": {
+              if (args.content === undefined) return errorResult("[periodic_note] content is required for patch");
+              if (!args.operation) return errorResult("[periodic_note] operation is required for patch");
+              if (!args.targetType) return errorResult("[periodic_note] targetType is required for patch");
+              if (!args.target) return errorResult("[periodic_note] target is required for patch");
+              const patchOpts = {
+                operation: args.operation,
+                targetType: args.targetType,
+                target: args.target,
+                targetDelimiter: args.targetDelimiter,
+                trimTargetWhitespace: args.trimTargetWhitespace,
+                createIfMissing: args.createIfMissing,
+                contentType: args.contentType,
+              };
+              if (isByDate) {
+                await client.patchPeriodicNoteForDate(period, year, month!, day!, args.content, patchOpts);
+              } else {
+                await client.patchPeriodicNote(period, args.content, patchOpts);
+              }
+              return textResult(`Patched ${period} note`);
+            }
+
+            case "delete":
+              if (isByDate) {
+                await client.deletePeriodicNoteForDate(period, year, month!, day!);
+              } else {
+                await client.deletePeriodicNote(period);
+              }
+              return textResult(`Deleted ${period} note`);
+
+            default: {
+              const _exhaustive: never = action;
+              return errorResult(`[periodic_note] Unknown action: ${String(_exhaustive)}`);
+            }
+          }
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "periodic_note" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 7. status (PROTECTED) ---
+  if (shouldRegister("status")) {
+    server.tool(
+      "status",
+      "Check Obsidian API connection and version",
+      {},
+      async () => {
+        try {
+          return jsonResult(await client.getServerStatus());
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "status" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 8. batch_get ---
+  if (shouldRegister("batch_get")) {
+    server.tool(
+      "batch_get",
+      "Read multiple vault files in one call",
+      {
+        paths: z.array(z.string()).min(1).describe("File paths"),
+        format: formatSchema.optional(),
+      },
+      async ({ paths, format }) => {
+        try {
+          const results = await Promise.allSettled(
+            paths.map(async (fp) => {
+              const content = await client.getFileContents(fp, format);
+              return { path: fp, content };
+            }),
+          );
+          const output: Array<{ path: string; content?: unknown; error?: string }> = [];
+          for (const r of results) {
+            if (r.status === "fulfilled") {
+              output.push(r.value);
+            } else {
+              const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
+              output.push({ path: "(unknown)", error: reason });
+            }
+          }
+          return jsonResult(output);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "batch_get" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 9. recent ---
+  if (shouldRegister("recent")) {
+    server.tool(
+      "recent",
+      "Get recently modified files or periodic notes",
+      {
+        type: z.enum(["changes", "periodic_notes"]).describe("Query type"),
+        period: periodSchema.optional(),
+        limit: z.number().int().min(1).default(10).describe("Max results"),
+      },
+      async ({ type, period, limit }) => {
+        try {
+          switch (type) {
+            case "changes": {
+              if (config.enableCache && cache.getIsInitialized()) {
+                const allNotes = cache.getAllNotes();
+                const sorted = [...allNotes]
+                  .sort((a, b) => b.stat.mtime - a.stat.mtime)
+                  .slice(0, limit)
+                  .map((n) => ({ path: n.path, mtime: n.stat.mtime }));
+                return jsonResult(sorted);
+              }
+              // Fallback without cache
+              const { files } = await client.listFilesInVault();
+              const mdFiles = files.filter((f) => f.toLowerCase().endsWith(".md"));
+              const withStats = await Promise.allSettled(
+                mdFiles.map(async (fp) => {
+                  const result = await client.getFileContents(fp, "json");
+                  if (typeof result !== "string" && "stat" in result) {
+                    return { path: fp, mtime: result.stat.mtime };
+                  }
+                  return { path: fp, mtime: 0 };
+                }),
+              );
+              const sorted = withStats
+                .filter((r): r is PromiseFulfilledResult<{ path: string; mtime: number }> => r.status === "fulfilled")
+                .map((r) => r.value)
+                .sort((a, b) => b.mtime - a.mtime)
+                .slice(0, limit);
+              return jsonResult(sorted);
+            }
+
+            case "periodic_notes": {
+              if (!period) return errorResult("[recent] period is required for periodic_notes");
+              const { files } = await client.listFilesInVault();
+              const periodDirs: Record<string, string> = {
+                daily: "Daily Notes",
+                weekly: "Weekly Notes",
+                monthly: "Monthly Notes",
+                quarterly: "Quarterly Notes",
+                yearly: "Yearly Notes",
+              };
+              const dirName = periodDirs[period] ?? period;
+              const periodFiles = files
+                .filter((f) => f.startsWith(`${dirName}/`) && f.toLowerCase().endsWith(".md"))
+                .sort()
+                .reverse()
+                .slice(0, limit);
+              return jsonResult(periodFiles);
+            }
+
+            default: {
+              const _exhaustive: never = type;
+              return errorResult(`[recent] Unknown type: ${String(_exhaustive)}`);
+            }
+          }
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "recent" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 10. configure (PROTECTED) ---
+  if (shouldRegister("configure")) {
+    server.tool(
+      "configure",
+      "View or change server settings",
+      {
+        action: z.enum(["show", "set", "reset"]).describe("Action"),
+        setting: z.string().optional().describe("Setting name"),
+        value: z.string().optional().describe("New value"),
+      },
+      async ({ action, setting, value }) => {
+        try {
+          switch (action) {
+            case "show":
+              return jsonResult(getRedactedConfig(config));
+
+            case "set": {
+              if (!setting) return errorResult("[configure] setting is required for 'set'");
+              if (value === undefined) return errorResult("[configure] value is required for 'set'");
+              const immediateSettings = new Set(["debug", "timeout", "verifyWrites", "maxResponseChars"]);
+              const restartSettings = new Set(["toolMode", "toolPreset"]);
+              if (!immediateSettings.has(setting) && !restartSettings.has(setting)) {
+                return errorResult(`[configure] Unknown setting: ${setting}. Available: ${[...immediateSettings, ...restartSettings].join(", ")}`);
+              }
+              const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
+              const updates = buildConfigUpdate(setting, value);
+              if (updates === undefined) {
+                return errorResult(`[configure] Invalid value "${value}" for setting "${setting}"`);
+              }
+              saveConfigToFile(configPath, updates);
+              if (immediateSettings.has(setting)) {
+                applyImmediateSetting(setting, value);
+                return textResult(`Setting "${setting}" updated to "${value}" (effective immediately)`);
+              }
+              return textResult(`Setting "${setting}" saved. Restart the server for this change to take effect.`);
+            }
+
+            case "reset": {
+              if (!setting) return errorResult("[configure] setting is required for 'reset'");
+              const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
+              const resetUpdates = buildConfigReset(setting);
+              if (resetUpdates === undefined) {
+                return errorResult(`[configure] Unknown setting: ${setting}`);
+              }
+              saveConfigToFile(configPath, resetUpdates);
+              return textResult(`Setting "${setting}" reset to default. Restart for this change to take effect.`);
+            }
+
+            default: {
+              const _exhaustive: never = action;
+              return errorResult(`[configure] Unknown action: ${String(_exhaustive)}`);
+            }
+          }
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "configure" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 11. vault_analysis ---
+  if (shouldRegister("vault_analysis")) {
+    server.tool(
+      "vault_analysis",
+      "Backlinks, connections, structure, and cache refresh",
+      {
+        action: z.enum(["backlinks", "connections", "structure", "refresh"]).describe("Analysis type"),
+        path: z.string().optional().describe("File path for backlinks/connections"),
+        limit: z.number().int().min(1).default(10).describe("Top N for structure"),
+      },
+      async ({ action, path, limit }) => {
+        if (!isActionAllowed("vault_analysis", action, config.toolPreset)) {
+          return errorResult(`[vault_analysis] Action "${action}" is not allowed in "${config.toolPreset}" preset`);
+        }
+        try {
+          if (!config.enableCache) {
+            return errorResult("[vault_analysis] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
+          }
+
+          switch (action) {
+            case "backlinks": {
+              if (!path) return errorResult("[vault_analysis] path is required for backlinks");
+              if (!cache.getIsInitialized()) {
+                return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
+              }
+              return jsonResult(cache.getBacklinks(path));
+            }
+
+            case "connections": {
+              if (!path) return errorResult("[vault_analysis] path is required for connections");
+              if (!cache.getIsInitialized()) {
+                return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
+              }
+              const backlinks = cache.getBacklinks(path);
+              const forwardLinks = cache.getForwardLinks(path);
+              return jsonResult({ backlinks, forwardLinks });
+            }
+
+            case "structure": {
+              if (!cache.getIsInitialized()) {
+                return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
+              }
+              const orphans = cache.getOrphanNotes();
+              const mostConnected = cache.getMostConnectedNotes(limit);
+              const graph = cache.getVaultGraph();
+              const dirs = new Set<string>();
+              for (const p of cache.getFileList()) {
+                const lastSlash = p.lastIndexOf("/");
+                if (lastSlash !== -1) {
+                  dirs.add(p.slice(0, lastSlash));
+                }
+              }
+              return jsonResult({
+                noteCount: cache.noteCount,
+                linkCount: cache.linkCount,
+                directoryCount: dirs.size,
+                orphanCount: orphans.length,
+                orphans: orphans.slice(0, 20),
+                mostConnected,
+                edgeCount: graph.edges.length,
+              });
+            }
+
+            case "refresh":
+              await cache.refresh();
+              return textResult(`Cache refreshed: ${String(cache.noteCount)} notes, ${String(cache.linkCount)} links`);
+
+            default: {
+              const _exhaustive: never = action;
+              return errorResult(`[vault_analysis] Unknown action: ${String(_exhaustive)}`);
+            }
+          }
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "vault_analysis", path }));
+        }
+      },
+    );
+    count++;
+  }
+
+  return count;
+}
+
+// --- Configure Helpers (shared with granular — duplicated to avoid circular deps) ---
+
+/** Builds a config file update for a setting. */
+function buildConfigUpdate(setting: string, value: string): Record<string, unknown> | undefined {
+  switch (setting) {
+    case "debug":
+      if (value !== "true" && value !== "false") return undefined;
+      return { debug: value === "true" };
+    case "timeout": {
+      const n = Number(value);
+      if (!Number.isFinite(n) || n < 1) return undefined;
+      return { reliability: { timeout: n } };
+    }
+    case "verifyWrites":
+      if (value !== "true" && value !== "false") return undefined;
+      return { reliability: { verifyWrites: value === "true" } };
+    case "maxResponseChars": {
+      const n = Number(value);
+      if (!Number.isFinite(n) || n < 0) return undefined;
+      return { reliability: { maxResponseChars: n } };
+    }
+    case "toolMode":
+      if (value !== "granular" && value !== "consolidated") return undefined;
+      return { tools: { mode: value } };
+    case "toolPreset":
+      if (value !== "full" && value !== "read-only" && value !== "minimal" && value !== "safe") return undefined;
+      return { tools: { preset: value } };
+    default:
+      return undefined;
+  }
+}
+
+/** Builds a config file reset for a setting. */
+function buildConfigReset(setting: string): Record<string, unknown> | undefined {
+  switch (setting) {
+    case "debug": return { debug: false };
+    case "timeout": return { reliability: { timeout: 30000 } };
+    case "verifyWrites": return { reliability: { verifyWrites: false } };
+    case "maxResponseChars": return { reliability: { maxResponseChars: 500000 } };
+    case "toolMode": return { tools: { mode: "granular" } };
+    case "toolPreset": return { tools: { preset: "full" } };
+    default: return undefined;
+  }
+}
+
+/** Applies an immediate setting change. */
+function applyImmediateSetting(setting: string, value: string): void {
+  if (setting === "debug") {
+    setDebugEnabled(value === "true");
+    log("info", `Debug logging ${value === "true" ? "enabled" : "disabled"}`);
+  }
 }

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -34,7 +34,7 @@ const READ_ONLY_ACTIONS: Record<string, ReadonlySet<string>> = {
   commands: new Set(["list"]),
   periodic_note: new Set(["get"]),
   recent: new Set(["changes", "periodic_notes"]),
-  vault_analysis: new Set(["backlinks", "connections", "structure"]),
+  vault_analysis: new Set(["backlinks", "connections", "structure", "refresh"]),
 };
 
 /** Actions removed in safe preset (consolidated mode). */
@@ -598,10 +598,10 @@ export function registerConsolidatedTools(
         try {
           switch (type) {
             case "changes":
-              return handleRecentChanges(client, cache, config, limit);
+              return await handleRecentChanges(client, cache, config, limit);
             case "periodic_notes":
               if (!period) return errorResult("[recent] period is required for periodic_notes");
-              return handleRecentPeriodicNotes(client, period, limit);
+              return await handleRecentPeriodicNotes(client, period, limit);
             default: {
               const _exhaustive: never = type;
               return errorResult(`[recent] Unknown type: ${String(_exhaustive)}`);

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -46,18 +46,18 @@ function formatFileContents(result: string | NoteJson | DocumentMap): ToolResult
 
 /** Escapes a string for use as a literal in a RegExp. */
 function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return str.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
 /** Checks if an action is allowed under the active preset for a given tool. */
 function isActionAllowed(toolName: string, action: string, preset: string): boolean {
   if (preset === "read-only") {
     const allowed = READ_ONLY_ACTIONS[toolName];
-    return allowed !== undefined ? allowed.has(action) : true;
+    return allowed === undefined || allowed.has(action);
   }
   if (preset === "safe") {
     const blocked = SAFE_BLOCKED_ACTIONS[toolName];
-    return blocked !== undefined ? !blocked.has(action) : true;
+    return blocked === undefined || !blocked.has(action);
   }
   return true;
 }
@@ -68,13 +68,16 @@ function isActionAllowed(toolName: string, action: string, preset: string): bool
 async function handleVaultPatch(
   client: ObsidianClient,
   path: string,
-  args: Record<string, unknown>,
+  content: string | undefined,
+  operation: "append" | "prepend" | "replace" | undefined,
+  targetType: "heading" | "block" | "frontmatter" | undefined,
+  target: string | undefined,
+  targetDelimiter: string | undefined,
+  trimTargetWhitespace: boolean | undefined,
+  createIfMissing: boolean | undefined,
+  contentType: "markdown" | "json" | undefined,
 ): Promise<ToolResult> {
-  const content = args["content"] as string | undefined;
   if (content === undefined) return errorResult("[vault] content is required for patch");
-  const operation = args["operation"] as "append" | "prepend" | "replace" | undefined;
-  const targetType = args["targetType"] as "heading" | "block" | "frontmatter" | undefined;
-  const target = args["target"] as string | undefined;
   if (!operation) return errorResult("[vault] operation is required for patch");
   if (!targetType) return errorResult("[vault] targetType is required for patch");
   if (!target) return errorResult("[vault] target is required for patch");
@@ -82,10 +85,10 @@ async function handleVaultPatch(
     operation,
     targetType,
     target,
-    targetDelimiter: args["targetDelimiter"] as string | undefined,
-    trimTargetWhitespace: args["trimTargetWhitespace"] as boolean | undefined,
-    createIfMissing: args["createIfMissing"] as boolean | undefined,
-    contentType: args["contentType"] as "markdown" | "json" | undefined,
+    targetDelimiter,
+    trimTargetWhitespace,
+    createIfMissing,
+    contentType,
   });
   return textResult(`Patched: ${path}`);
 }
@@ -94,19 +97,18 @@ async function handleVaultPatch(
 async function handleVaultSearchReplace(
   client: ObsidianClient,
   path: string,
-  args: Record<string, unknown>,
+  search: string | undefined,
+  replaceText: string | undefined,
+  caseSensitive: boolean,
+  replaceAll: boolean,
+  useRegex: boolean,
 ): Promise<ToolResult> {
-  const search = args["search"] as string | undefined;
-  const replaceText = args["replace"] as string | undefined;
   if (!search) return errorResult("[vault] search is required for search_replace");
   if (replaceText === undefined) return errorResult("[vault] replace is required for search_replace");
   const result = await client.getFileContents(path, "markdown");
   if (typeof result !== "string") {
     return errorResult("[vault] Expected markdown content");
   }
-  const caseSensitive = args["caseSensitive"] as boolean;
-  const replaceAll = args["replaceAll"] as boolean;
-  const useRegex = args["useRegex"] as boolean;
   const flags = `${caseSensitive ? "" : "i"}${replaceAll ? "g" : ""}`;
   const pattern = useRegex ? new RegExp(search, flags) : new RegExp(escapeRegex(search), flags);
   const updated = result.replace(pattern, replaceText);
@@ -127,25 +129,20 @@ async function handlePeriodicPatch(
   year: number,
   month: number,
   day: number,
-  args: Record<string, unknown>,
+  content: string | undefined,
+  operation: "append" | "prepend" | "replace" | undefined,
+  targetType: "heading" | "block" | "frontmatter" | undefined,
+  target: string | undefined,
+  targetDelimiter: string | undefined,
+  trimTargetWhitespace: boolean | undefined,
+  createIfMissing: boolean | undefined,
+  contentType: "markdown" | "json" | undefined,
 ): Promise<ToolResult> {
-  const content = args["content"] as string | undefined;
   if (content === undefined) return errorResult("[periodic_note] content is required for patch");
-  const operation = args["operation"] as "append" | "prepend" | "replace" | undefined;
-  const targetType = args["targetType"] as "heading" | "block" | "frontmatter" | undefined;
-  const target = args["target"] as string | undefined;
   if (!operation) return errorResult("[periodic_note] operation is required for patch");
   if (!targetType) return errorResult("[periodic_note] targetType is required for patch");
   if (!target) return errorResult("[periodic_note] target is required for patch");
-  const patchOpts = {
-    operation,
-    targetType,
-    target,
-    targetDelimiter: args["targetDelimiter"] as string | undefined,
-    trimTargetWhitespace: args["trimTargetWhitespace"] as boolean | undefined,
-    createIfMissing: args["createIfMissing"] as boolean | undefined,
-    contentType: args["contentType"] as "markdown" | "json" | undefined,
-  };
+  const patchOpts = { operation, targetType, target, targetDelimiter, trimTargetWhitespace, createIfMissing, contentType };
   if (isByDate) {
     await client.patchPeriodicNoteForDate(period, year, month, day, content, patchOpts);
   } else {
@@ -240,6 +237,18 @@ function handleConfigureSet(
   return textResult(`Setting "${setting}" saved. Restart the server for this change to take effect.`);
 }
 
+/** Handles the "reset" action for the configure tool. */
+function handleConfigureReset(setting: string | undefined, config: Config): ToolResult {
+  if (!setting) return errorResult("[configure] setting is required for 'reset'");
+  const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
+  const resetUpdates = buildConfigReset(setting);
+  if (resetUpdates === undefined) {
+    return errorResult(`[configure] Unknown setting: ${setting}`);
+  }
+  saveConfigToFile(configPath, resetUpdates);
+  return textResult(`Setting "${setting}" reset to default. Restart for this change to take effect.`);
+}
+
 // --- Extracted vault_analysis handler ---
 
 /** Builds vault structure statistics from cache. */
@@ -329,14 +338,14 @@ export function registerConsolidatedTools(
               return textResult(`Appended to: ${path}`);
             case "patch":
               if (!path) return errorResult("[vault] path is required for patch");
-              return handleVaultPatch(client, path, args as unknown as Record<string, unknown>);
+              return handleVaultPatch(client, path, args.content, args.operation, args.targetType, args.target, args.targetDelimiter, args.trimTargetWhitespace, args.createIfMissing, args.contentType);
             case "delete":
               if (!path) return errorResult("[vault] path is required for delete");
               await client.deleteFile(path);
               return textResult(`Deleted: ${path}`);
             case "search_replace":
               if (!path) return errorResult("[vault] path is required for search_replace");
-              return handleVaultSearchReplace(client, path, args as unknown as Record<string, unknown>);
+              return handleVaultSearchReplace(client, path, args.search, args.replace, args.caseSensitive, args.replaceAll, args.useRegex);
             default: {
               const _exhaustive: never = action;
               return errorResult(`[vault] Unknown action: ${String(_exhaustive)}`);
@@ -542,25 +551,27 @@ export function registerConsolidatedTools(
         try {
           switch (action) {
             case "get":
-              if (isByDate) {
-                return formatFileContents(await client.getPeriodicNoteForDate(period, year, month!, day!, args.format));
-              }
-              return formatFileContents(await client.getPeriodicNote(period, args.format));
+              return isByDate
+                ? formatFileContents(await client.getPeriodicNoteForDate(period, year, month, day, args.format))
+                : formatFileContents(await client.getPeriodicNote(period, args.format));
             case "put":
               if (args.content === undefined) return errorResult("[periodic_note] content is required for put");
-              if (isByDate) { await client.putPeriodicNoteForDate(period, year, month!, day!, args.content); }
-              else { await client.putPeriodicNote(period, args.content); }
+              await (isByDate
+                ? client.putPeriodicNoteForDate(period, year, month, day, args.content)
+                : client.putPeriodicNote(period, args.content));
               return textResult(`Updated ${period} note`);
             case "append":
               if (args.content === undefined) return errorResult("[periodic_note] content is required for append");
-              if (isByDate) { await client.appendPeriodicNoteForDate(period, year, month!, day!, args.content); }
-              else { await client.appendPeriodicNote(period, args.content); }
+              await (isByDate
+                ? client.appendPeriodicNoteForDate(period, year, month, day, args.content)
+                : client.appendPeriodicNote(period, args.content));
               return textResult(`Appended to ${period} note`);
             case "patch":
-              return handlePeriodicPatch(client, period, isByDate, year ?? 0, month ?? 0, day ?? 0, args as unknown as Record<string, unknown>);
+              return handlePeriodicPatch(client, period, isByDate, year ?? 0, month ?? 0, day ?? 0, args.content, args.operation, args.targetType, args.target, args.targetDelimiter, args.trimTargetWhitespace, args.createIfMissing, args.contentType);
             case "delete":
-              if (isByDate) { await client.deletePeriodicNoteForDate(period, year, month!, day!); }
-              else { await client.deletePeriodicNote(period); }
+              await (isByDate
+                ? client.deletePeriodicNoteForDate(period, year, month, day)
+                : client.deletePeriodicNote(period));
               return textResult(`Deleted ${period} note`);
             default: {
               const _exhaustive: never = action;
@@ -682,16 +693,8 @@ export function registerConsolidatedTools(
               return jsonResult(getRedactedConfig(config));
             case "set":
               return handleConfigureSet(setting, value, config);
-            case "reset": {
-              if (!setting) return errorResult("[configure] setting is required for 'reset'");
-              const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
-              const resetUpdates = buildConfigReset(setting);
-              if (resetUpdates === undefined) {
-                return errorResult(`[configure] Unknown setting: ${setting}`);
-              }
-              saveConfigToFile(configPath, resetUpdates);
-              return textResult(`Setting "${setting}" reset to default. Restart for this change to take effect.`);
-            }
+            case "reset":
+              return handleConfigureReset(setting, config);
             default: {
               const _exhaustive: never = action;
               return errorResult(`[configure] Unknown action: ${String(_exhaustive)}`);
@@ -758,24 +761,38 @@ export function registerConsolidatedTools(
 
 // --- Configure Helpers (shared with granular — duplicated to avoid circular deps) ---
 
+/** Parses a boolean string value; returns undefined if invalid. */
+function parseBoolValue(value: string): boolean | undefined {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
+}
+
+/** Parses a positive integer string value; returns undefined if invalid. */
+function parsePosIntValue(value: string, min: number): number | undefined {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < min) return undefined;
+  return n;
+}
+
 /** Builds a config file update for a setting. */
 function buildConfigUpdate(setting: string, value: string): Record<string, unknown> | undefined {
   switch (setting) {
-    case "debug":
-      if (value !== "true" && value !== "false") return undefined;
-      return { debug: value === "true" };
-    case "timeout": {
-      const n = Number(value);
-      if (!Number.isFinite(n) || n < 1) return undefined;
-      return { reliability: { timeout: n } };
+    case "debug": {
+      const b = parseBoolValue(value);
+      return b !== undefined ? { debug: b } : undefined;
     }
-    case "verifyWrites":
-      if (value !== "true" && value !== "false") return undefined;
-      return { reliability: { verifyWrites: value === "true" } };
+    case "timeout": {
+      const n = parsePosIntValue(value, 1);
+      return n !== undefined ? { reliability: { timeout: n } } : undefined;
+    }
+    case "verifyWrites": {
+      const b = parseBoolValue(value);
+      return b !== undefined ? { reliability: { verifyWrites: b } } : undefined;
+    }
     case "maxResponseChars": {
-      const n = Number(value);
-      if (!Number.isFinite(n) || n < 0) return undefined;
-      return { reliability: { maxResponseChars: n } };
+      const n = parsePosIntValue(value, 0);
+      return n !== undefined ? { reliability: { maxResponseChars: n } } : undefined;
     }
     case "toolMode":
       if (value !== "granular" && value !== "consolidated") return undefined;

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -170,7 +170,7 @@ async function handleVaultSearchReplace(
 ): Promise<ToolResult> {
   if (!search) return errorResult("[vault] search is required for search_replace");
   if (replaceText === undefined) return errorResult("[vault] replace is required for search_replace");
-  const result = await client.getFileContents(path, "markdown");
+  const result = await client.getFileContents(path, "markdown", true);
   if (typeof result !== "string") {
     return errorResult("[vault] Expected markdown content");
   }
@@ -245,29 +245,41 @@ interface PeriodicNoteArgs {
 /** Dispatches a periodic_note action to the appropriate client method. */
 async function handlePeriodicNoteAction(client: ObsidianClient, args: PeriodicNoteArgs): Promise<ToolResult> {
   const { action, period, year, month, day } = args;
-  const isByDate = year !== undefined && month !== undefined && day !== undefined;
+  const hasYear = year !== undefined;
+  const hasMonth = month !== undefined;
+  const hasDay = day !== undefined;
+  const dateFieldCount = [hasYear, hasMonth, hasDay].filter(Boolean).length;
+  if (dateFieldCount > 0 && dateFieldCount < 3) {
+    return errorResult("[periodic_note] All of year, month, and day are required for date-scoped operations (or omit all for current period)");
+  }
+  const isByDate = dateFieldCount === 3;
+  // When isByDate is true all three date fields are defined (validated above).
+  // Extract concrete numbers for passing to by-date client methods.
+  const y = year ?? 0;
+  const m = month ?? 0;
+  const d = day ?? 0;
   switch (action) {
     case "get":
       return isByDate
-        ? formatFileContents(await client.getPeriodicNoteForDate(period, year, month, day, args.format))
+        ? formatFileContents(await client.getPeriodicNoteForDate(period, y, m, d, args.format))
         : formatFileContents(await client.getPeriodicNote(period, args.format));
     case "put":
       if (args.content === undefined) return errorResult("[periodic_note] content is required for put");
-      await (isByDate ? client.putPeriodicNoteForDate(period, year, month, day, args.content) : client.putPeriodicNote(period, args.content));
+      await (isByDate ? client.putPeriodicNoteForDate(period, y, m, d, args.content) : client.putPeriodicNote(period, args.content));
       return textResult(`Updated ${period} note`);
     case "append":
       if (args.content === undefined) return errorResult("[periodic_note] content is required for append");
-      await (isByDate ? client.appendPeriodicNoteForDate(period, year, month, day, args.content) : client.appendPeriodicNote(period, args.content));
+      await (isByDate ? client.appendPeriodicNoteForDate(period, y, m, d, args.content) : client.appendPeriodicNote(period, args.content));
       return textResult(`Appended to ${period} note`);
     case "patch":
       return handlePeriodicPatch(client, {
-        period, isByDate, year: year ?? 0, month: month ?? 0, day: day ?? 0,
+        period, isByDate, year: y, month: m, day: d,
         content: args.content, operation: args.operation, targetType: args.targetType,
         target: args.target, targetDelimiter: args.targetDelimiter, trimTargetWhitespace: args.trimTargetWhitespace,
         createIfMissing: args.createIfMissing, contentType: args.contentType,
       });
     case "delete":
-      await (isByDate ? client.deletePeriodicNoteForDate(period, year, month, day) : client.deletePeriodicNote(period));
+      await (isByDate ? client.deletePeriodicNoteForDate(period, y, m, d) : client.deletePeriodicNote(period));
       return textResult(`Deleted ${period} note`);
     default: {
       const _exhaustive: never = action;
@@ -295,7 +307,7 @@ export function registerConsolidatedTools(
     server.registerTool(
       "vault",
       {
-        description: "Read, write, search, and manage vault files",
+        description: "Read, write, search vault files. Do not retry append/patch/search_replace on timeout",
         inputSchema: z.object({
           action: z.enum(["list", "list_dir", "get", "put", "append", "patch", "delete", "search_replace"]).describe("Operation"),
           path: z.string().optional().describe("File or directory path"),
@@ -335,7 +347,7 @@ export function registerConsolidatedTools(
     server.registerTool(
       "active_file",
       {
-        description: "Read, write, or delete the currently open file",
+        description: "Read, write, or delete the open file. Do not retry append/patch on timeout",
         inputSchema: z.object({
           action: z.enum(["get", "put", "append", "patch", "delete"]).describe("Operation"),
           content: z.string().optional().describe("Content for writes"),
@@ -408,6 +420,9 @@ export function registerConsolidatedTools(
         }),
       },
       async ({ action, commandId }) => {
+        if (!isActionAllowed("commands", action, config.toolPreset)) {
+          return errorResult(`[commands] Action "${action}" is not allowed in "${config.toolPreset}" preset`);
+        }
         try {
           switch (action) {
             case "list":
@@ -495,7 +510,7 @@ export function registerConsolidatedTools(
     server.registerTool(
       "periodic_note",
       {
-        description: "CRUD operations on periodic notes (current or by date)",
+        description: "CRUD on periodic notes. Do not retry append/patch on timeout",
         inputSchema: z.object({
           action: z.enum(["get", "put", "append", "patch", "delete"]).describe("Operation"),
           period: periodSchema,

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -57,38 +57,104 @@ function isActionAllowed(toolName: string, action: string, preset: string): bool
   }
   if (preset === "safe") {
     const blocked = SAFE_BLOCKED_ACTIONS[toolName];
-    return blocked === undefined || !blocked.has(action);
+    return !blocked?.has(action);
   }
   return true;
 }
 
+// --- Vault action args type ---
+
+/** Inferred args shape for the vault consolidated tool. */
+interface VaultArgs {
+  readonly action: "list" | "list_dir" | "get" | "put" | "append" | "patch" | "delete" | "search_replace";
+  readonly path?: string | undefined;
+  readonly content?: string | undefined;
+  readonly format?: "markdown" | "json" | "map" | undefined;
+  readonly operation?: "append" | "prepend" | "replace" | undefined;
+  readonly targetType?: "heading" | "block" | "frontmatter" | undefined;
+  readonly target?: string | undefined;
+  readonly targetDelimiter?: string | undefined;
+  readonly trimTargetWhitespace?: boolean | undefined;
+  readonly createIfMissing?: boolean | undefined;
+  readonly contentType?: "markdown" | "json" | undefined;
+  readonly search?: string | undefined;
+  readonly replace?: string | undefined;
+  readonly useRegex: boolean;
+  readonly caseSensitive: boolean;
+  readonly replaceAll: boolean;
+}
+
+/** Dispatches a vault action to the appropriate client method. */
+async function handleVaultAction(
+  client: ObsidianClient,
+  action: VaultArgs["action"],
+  path: string | undefined,
+  args: VaultArgs,
+): Promise<ToolResult> {
+  switch (action) {
+    case "list":
+      return jsonResult(await client.listFilesInVault());
+    case "list_dir":
+      if (!path) return errorResult("[vault] path is required for list_dir");
+      return jsonResult(await client.listFilesInDir(path));
+    case "get":
+      if (!path) return errorResult("[vault] path is required for get");
+      return formatFileContents(await client.getFileContents(path, args.format));
+    case "put":
+      if (!path) return errorResult("[vault] path is required for put");
+      if (args.content === undefined) return errorResult("[vault] content is required for put");
+      await client.putContent(path, args.content);
+      return textResult(`Written: ${path}`);
+    case "append":
+      if (!path) return errorResult("[vault] path is required for append");
+      if (args.content === undefined) return errorResult("[vault] content is required for append");
+      await client.appendContent(path, args.content);
+      return textResult(`Appended to: ${path}`);
+    case "patch":
+      if (!path) return errorResult("[vault] path is required for patch");
+      return handleVaultPatch(client, path, args);
+    case "delete":
+      if (!path) return errorResult("[vault] path is required for delete");
+      await client.deleteFile(path);
+      return textResult(`Deleted: ${path}`);
+    case "search_replace":
+      if (!path) return errorResult("[vault] path is required for search_replace");
+      return handleVaultSearchReplace(client, path, args.search, args.replace, args.caseSensitive, args.replaceAll, args.useRegex);
+    default: {
+      const _exhaustive: never = action;
+      return errorResult(`[vault] Unknown action: ${String(_exhaustive)}`);
+    }
+  }
+}
+
 // --- Extracted vault action handlers ---
 
+/** Args for the vault "patch" action. */
+interface VaultPatchArgs {
+  readonly content?: string | undefined;
+  readonly operation?: "append" | "prepend" | "replace" | undefined;
+  readonly targetType?: "heading" | "block" | "frontmatter" | undefined;
+  readonly target?: string | undefined;
+  readonly targetDelimiter?: string | undefined;
+  readonly trimTargetWhitespace?: boolean | undefined;
+  readonly createIfMissing?: boolean | undefined;
+  readonly contentType?: "markdown" | "json" | undefined;
+}
+
 /** Handles the vault "patch" action. */
-async function handleVaultPatch(
-  client: ObsidianClient,
-  path: string,
-  content: string | undefined,
-  operation: "append" | "prepend" | "replace" | undefined,
-  targetType: "heading" | "block" | "frontmatter" | undefined,
-  target: string | undefined,
-  targetDelimiter: string | undefined,
-  trimTargetWhitespace: boolean | undefined,
-  createIfMissing: boolean | undefined,
-  contentType: "markdown" | "json" | undefined,
-): Promise<ToolResult> {
-  if (content === undefined) return errorResult("[vault] content is required for patch");
-  if (!operation) return errorResult("[vault] operation is required for patch");
-  if (!targetType) return errorResult("[vault] targetType is required for patch");
-  if (!target) return errorResult("[vault] target is required for patch");
-  await client.patchContent(path, content, {
-    operation,
-    targetType,
-    target,
-    targetDelimiter,
-    trimTargetWhitespace,
-    createIfMissing,
-    contentType,
+async function handleVaultPatch(client: ObsidianClient, path: string, args: VaultPatchArgs): Promise<ToolResult> {
+  if (args.content === undefined) return errorResult("[vault] content is required for patch");
+  if (!args.operation) return errorResult("[vault] operation is required for patch");
+  if (!args.targetType) return errorResult("[vault] targetType is required for patch");
+  if (!args.target) return errorResult("[vault] target is required for patch");
+  await client.patchContent(path, args.content, {
+    operation: args.operation,
+    targetType: args.targetType,
+    target: args.target,
+    targetDelimiter: args.targetDelimiter,
+    trimTargetWhitespace: args.trimTargetWhitespace,
+    createIfMissing: args.createIfMissing,
+    contentType: args.contentType,
   });
   return textResult(`Patched: ${path}`);
 }
@@ -121,34 +187,94 @@ async function handleVaultSearchReplace(
 
 // --- Extracted periodic_note action handlers ---
 
+/** Args for the periodic_note "patch" action. */
+interface PeriodicPatchArgs {
+  readonly period: string;
+  readonly isByDate: boolean;
+  readonly year: number;
+  readonly month: number;
+  readonly day: number;
+  readonly content: string | undefined;
+  readonly operation: "append" | "prepend" | "replace" | undefined;
+  readonly targetType: "heading" | "block" | "frontmatter" | undefined;
+  readonly target: string | undefined;
+  readonly targetDelimiter: string | undefined;
+  readonly trimTargetWhitespace: boolean | undefined;
+  readonly createIfMissing: boolean | undefined;
+  readonly contentType: "markdown" | "json" | undefined;
+}
+
 /** Handles periodic_note "patch" action. */
-async function handlePeriodicPatch(
-  client: ObsidianClient,
-  period: string,
-  isByDate: boolean,
-  year: number,
-  month: number,
-  day: number,
-  content: string | undefined,
-  operation: "append" | "prepend" | "replace" | undefined,
-  targetType: "heading" | "block" | "frontmatter" | undefined,
-  target: string | undefined,
-  targetDelimiter: string | undefined,
-  trimTargetWhitespace: boolean | undefined,
-  createIfMissing: boolean | undefined,
-  contentType: "markdown" | "json" | undefined,
-): Promise<ToolResult> {
-  if (content === undefined) return errorResult("[periodic_note] content is required for patch");
-  if (!operation) return errorResult("[periodic_note] operation is required for patch");
-  if (!targetType) return errorResult("[periodic_note] targetType is required for patch");
-  if (!target) return errorResult("[periodic_note] target is required for patch");
-  const patchOpts = { operation, targetType, target, targetDelimiter, trimTargetWhitespace, createIfMissing, contentType };
-  if (isByDate) {
-    await client.patchPeriodicNoteForDate(period, year, month, day, content, patchOpts);
+async function handlePeriodicPatch(client: ObsidianClient, args: PeriodicPatchArgs): Promise<ToolResult> {
+  if (args.content === undefined) return errorResult("[periodic_note] content is required for patch");
+  if (!args.operation) return errorResult("[periodic_note] operation is required for patch");
+  if (!args.targetType) return errorResult("[periodic_note] targetType is required for patch");
+  if (!args.target) return errorResult("[periodic_note] target is required for patch");
+  const patchOpts = {
+    operation: args.operation, targetType: args.targetType, target: args.target,
+    targetDelimiter: args.targetDelimiter, trimTargetWhitespace: args.trimTargetWhitespace,
+    createIfMissing: args.createIfMissing, contentType: args.contentType,
+  };
+  if (args.isByDate) {
+    await client.patchPeriodicNoteForDate(args.period, args.year, args.month, args.day, args.content, patchOpts);
   } else {
-    await client.patchPeriodicNote(period, content, patchOpts);
+    await client.patchPeriodicNote(args.period, args.content, patchOpts);
   }
-  return textResult(`Patched ${period} note`);
+  return textResult(`Patched ${args.period} note`);
+}
+
+// --- Extracted periodic_note handler ---
+
+/** Periodic note args shape. */
+interface PeriodicNoteArgs {
+  readonly action: "get" | "put" | "append" | "patch" | "delete";
+  readonly period: string;
+  readonly year?: number | undefined;
+  readonly month?: number | undefined;
+  readonly day?: number | undefined;
+  readonly content?: string | undefined;
+  readonly format?: "markdown" | "json" | "map" | undefined;
+  readonly operation?: "append" | "prepend" | "replace" | undefined;
+  readonly targetType?: "heading" | "block" | "frontmatter" | undefined;
+  readonly target?: string | undefined;
+  readonly targetDelimiter?: string | undefined;
+  readonly trimTargetWhitespace?: boolean | undefined;
+  readonly createIfMissing?: boolean | undefined;
+  readonly contentType?: "markdown" | "json" | undefined;
+}
+
+/** Dispatches a periodic_note action to the appropriate client method. */
+async function handlePeriodicNoteAction(client: ObsidianClient, args: PeriodicNoteArgs): Promise<ToolResult> {
+  const { action, period, year, month, day } = args;
+  const isByDate = year !== undefined && month !== undefined && day !== undefined;
+  switch (action) {
+    case "get":
+      return isByDate
+        ? formatFileContents(await client.getPeriodicNoteForDate(period, year, month, day, args.format))
+        : formatFileContents(await client.getPeriodicNote(period, args.format));
+    case "put":
+      if (args.content === undefined) return errorResult("[periodic_note] content is required for put");
+      await (isByDate ? client.putPeriodicNoteForDate(period, year, month, day, args.content) : client.putPeriodicNote(period, args.content));
+      return textResult(`Updated ${period} note`);
+    case "append":
+      if (args.content === undefined) return errorResult("[periodic_note] content is required for append");
+      await (isByDate ? client.appendPeriodicNoteForDate(period, year, month, day, args.content) : client.appendPeriodicNote(period, args.content));
+      return textResult(`Appended to ${period} note`);
+    case "patch":
+      return handlePeriodicPatch(client, {
+        period, isByDate, year: year ?? 0, month: month ?? 0, day: day ?? 0,
+        content: args.content, operation: args.operation, targetType: args.targetType,
+        target: args.target, targetDelimiter: args.targetDelimiter, trimTargetWhitespace: args.trimTargetWhitespace,
+        createIfMissing: args.createIfMissing, contentType: args.contentType,
+      });
+    case "delete":
+      await (isByDate ? client.deletePeriodicNoteForDate(period, year, month, day) : client.deletePeriodicNote(period));
+      return textResult(`Deleted ${period} note`);
+    default: {
+      const _exhaustive: never = action;
+      return errorResult(`[periodic_note] Unknown action: ${String(_exhaustive)}`);
+    }
+  }
 }
 
 // --- Extracted recent handlers ---
@@ -317,40 +443,7 @@ export function registerConsolidatedTools(
           return errorResult(`[vault] Action "${action}" is not allowed in "${config.toolPreset}" preset`);
         }
         try {
-          switch (action) {
-            case "list":
-              return jsonResult(await client.listFilesInVault());
-            case "list_dir":
-              if (!path) return errorResult("[vault] path is required for list_dir");
-              return jsonResult(await client.listFilesInDir(path));
-            case "get":
-              if (!path) return errorResult("[vault] path is required for get");
-              return formatFileContents(await client.getFileContents(path, args.format));
-            case "put":
-              if (!path) return errorResult("[vault] path is required for put");
-              if (args.content === undefined) return errorResult("[vault] content is required for put");
-              await client.putContent(path, args.content);
-              return textResult(`Written: ${path}`);
-            case "append":
-              if (!path) return errorResult("[vault] path is required for append");
-              if (args.content === undefined) return errorResult("[vault] content is required for append");
-              await client.appendContent(path, args.content);
-              return textResult(`Appended to: ${path}`);
-            case "patch":
-              if (!path) return errorResult("[vault] path is required for patch");
-              return handleVaultPatch(client, path, args.content, args.operation, args.targetType, args.target, args.targetDelimiter, args.trimTargetWhitespace, args.createIfMissing, args.contentType);
-            case "delete":
-              if (!path) return errorResult("[vault] path is required for delete");
-              await client.deleteFile(path);
-              return textResult(`Deleted: ${path}`);
-            case "search_replace":
-              if (!path) return errorResult("[vault] path is required for search_replace");
-              return handleVaultSearchReplace(client, path, args.search, args.replace, args.caseSensitive, args.replaceAll, args.useRegex);
-            default: {
-              const _exhaustive: never = action;
-              return errorResult(`[vault] Unknown action: ${String(_exhaustive)}`);
-            }
-          }
+          return await handleVaultAction(client, action, path, args);
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "vault", path }));
         }
@@ -543,41 +636,11 @@ export function registerConsolidatedTools(
         }),
       },
       async (args) => {
-        const { action, period, year, month, day } = args;
-        if (!isActionAllowed("periodic_note", action, config.toolPreset)) {
-          return errorResult(`[periodic_note] Action "${action}" is not allowed in "${config.toolPreset}" preset`);
+        if (!isActionAllowed("periodic_note", args.action, config.toolPreset)) {
+          return errorResult(`[periodic_note] Action "${args.action}" is not allowed in "${config.toolPreset}" preset`);
         }
-        const isByDate = year !== undefined && month !== undefined && day !== undefined;
         try {
-          switch (action) {
-            case "get":
-              return isByDate
-                ? formatFileContents(await client.getPeriodicNoteForDate(period, year, month, day, args.format))
-                : formatFileContents(await client.getPeriodicNote(period, args.format));
-            case "put":
-              if (args.content === undefined) return errorResult("[periodic_note] content is required for put");
-              await (isByDate
-                ? client.putPeriodicNoteForDate(period, year, month, day, args.content)
-                : client.putPeriodicNote(period, args.content));
-              return textResult(`Updated ${period} note`);
-            case "append":
-              if (args.content === undefined) return errorResult("[periodic_note] content is required for append");
-              await (isByDate
-                ? client.appendPeriodicNoteForDate(period, year, month, day, args.content)
-                : client.appendPeriodicNote(period, args.content));
-              return textResult(`Appended to ${period} note`);
-            case "patch":
-              return handlePeriodicPatch(client, period, isByDate, year ?? 0, month ?? 0, day ?? 0, args.content, args.operation, args.targetType, args.target, args.targetDelimiter, args.trimTargetWhitespace, args.createIfMissing, args.contentType);
-            case "delete":
-              await (isByDate
-                ? client.deletePeriodicNoteForDate(period, year, month, day)
-                : client.deletePeriodicNote(period));
-              return textResult(`Deleted ${period} note`);
-            default: {
-              const _exhaustive: never = action;
-              return errorResult(`[periodic_note] Unknown action: ${String(_exhaustive)}`);
-            }
-          }
+          return await handlePeriodicNoteAction(client, args);
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "periodic_note" }));
         }
@@ -780,19 +843,19 @@ function buildConfigUpdate(setting: string, value: string): Record<string, unkno
   switch (setting) {
     case "debug": {
       const b = parseBoolValue(value);
-      return b !== undefined ? { debug: b } : undefined;
+      return b === undefined ? undefined : { debug: b };
     }
     case "timeout": {
       const n = parsePosIntValue(value, 1);
-      return n !== undefined ? { reliability: { timeout: n } } : undefined;
+      return n === undefined ? undefined : { reliability: { timeout: n } };
     }
     case "verifyWrites": {
       const b = parseBoolValue(value);
-      return b !== undefined ? { reliability: { verifyWrites: b } } : undefined;
+      return b === undefined ? undefined : { reliability: { verifyWrites: b } };
     }
     case "maxResponseChars": {
       const n = parsePosIntValue(value, 0);
-      return n !== undefined ? { reliability: { maxResponseChars: n } } : undefined;
+      return n === undefined ? undefined : { reliability: { maxResponseChars: n } };
     }
     case "toolMode":
       if (value !== "granular" && value !== "consolidated") return undefined;

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -1,11 +1,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import type { ObsidianClient, NoteJson, DocumentMap, ToolResult, PatchOptions } from "../obsidian.js";
+import type { ObsidianClient, ToolResult, PatchOptions } from "../obsidian.js";
 import { textResult, errorResult, jsonResult } from "../obsidian.js";
 import type { VaultCache } from "../cache.js";
 import type { Config } from "../config.js";
-import { getRedactedConfig, saveConfigToFile, setDebugEnabled, log } from "../config.js";
 import { buildErrorMessage } from "../errors.js";
 import {
   formatSchema,
@@ -14,6 +13,17 @@ import {
   patchTargetTypeSchema,
   patchContentTypeSchema,
 } from "../schemas.js";
+import {
+  formatFileContents,
+  escapeRegex,
+  handleConfigureSet,
+  handleConfigureReset,
+  handleConfigureShow,
+  buildVaultStructure,
+  handleRecentChanges,
+  handleRecentPeriodicNotes,
+  batchGetFiles,
+} from "./shared.js";
 
 // --- Preset action restrictions for consolidated mode ---
 
@@ -35,19 +45,6 @@ const SAFE_BLOCKED_ACTIONS: Record<string, ReadonlySet<string>> = {
 };
 
 // --- Helpers ---
-
-/** Formats file contents for display. */
-function formatFileContents(result: string | NoteJson | DocumentMap): ToolResult {
-  if (typeof result === "string") {
-    return textResult(result);
-  }
-  return jsonResult(result);
-}
-
-/** Escapes a string for use as a literal in a RegExp. */
-function escapeRegex(str: string): string {
-  return str.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-}
 
 /** Checks if an action is allowed under the active preset for a given tool. */
 function isActionAllowed(toolName: string, action: string, preset: string): boolean {
@@ -279,128 +276,7 @@ async function handlePeriodicNoteAction(client: ObsidianClient, args: PeriodicNo
   }
 }
 
-// --- Extracted recent handlers ---
-
-/** Fetches recent changes using cache or fallback API calls. */
-async function handleRecentChanges(
-  client: ObsidianClient,
-  cache: VaultCache,
-  config: Config,
-  limit: number,
-): Promise<ToolResult> {
-  if (config.enableCache && cache.getIsInitialized()) {
-    const allNotes = cache.getAllNotes();
-    const sorted = [...allNotes]
-      .sort((a, b) => b.stat.mtime - a.stat.mtime)
-      .slice(0, limit)
-      .map((n) => ({ path: n.path, mtime: n.stat.mtime }));
-    return jsonResult(sorted);
-  }
-  const { files } = await client.listFilesInVault();
-  const mdFiles = files.filter((f) => f.toLowerCase().endsWith(".md"));
-  const withStats = await Promise.allSettled(
-    mdFiles.map(async (fp) => {
-      const result = await client.getFileContents(fp, "json");
-      if (typeof result !== "string" && "stat" in result) {
-        return { path: fp, mtime: result.stat.mtime };
-      }
-      return { path: fp, mtime: 0 };
-    }),
-  );
-  const sorted = withStats
-    .filter((r): r is PromiseFulfilledResult<{ path: string; mtime: number }> => r.status === "fulfilled")
-    .map((r) => r.value)
-    .sort((a, b) => b.mtime - a.mtime)
-    .slice(0, limit);
-  return jsonResult(sorted);
-}
-
-/** Fetches recent periodic notes by listing the vault directory. */
-async function handleRecentPeriodicNotes(
-  client: ObsidianClient,
-  period: string,
-  limit: number,
-): Promise<ToolResult> {
-  const { files } = await client.listFilesInVault();
-  const periodDirs: Record<string, string> = {
-    daily: "Daily Notes",
-    weekly: "Weekly Notes",
-    monthly: "Monthly Notes",
-    quarterly: "Quarterly Notes",
-    yearly: "Yearly Notes",
-  };
-  const dirName = periodDirs[period] ?? period;
-  const periodFiles = files
-    .filter((f) => f.startsWith(`${dirName}/`) && f.toLowerCase().endsWith(".md"))
-    .sort((a, b) => b.localeCompare(a))
-    .slice(0, limit);
-  return jsonResult(periodFiles);
-}
-
-// --- Extracted configure handler ---
-
-/** Handles the "set" action for the configure tool. */
-function handleConfigureSet(
-  setting: string | undefined,
-  value: string | undefined,
-  config: Config,
-): ToolResult {
-  if (!setting) return errorResult("[configure] setting is required for 'set'");
-  if (value === undefined) return errorResult("[configure] value is required for 'set'");
-  const immediateSettings = new Set(["debug", "timeout", "verifyWrites", "maxResponseChars"]);
-  const restartSettings = new Set(["toolMode", "toolPreset"]);
-  if (!immediateSettings.has(setting) && !restartSettings.has(setting)) {
-    return errorResult(`[configure] Unknown setting: ${setting}. Available: ${[...immediateSettings, ...restartSettings].join(", ")}`);
-  }
-  const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
-  const updates = buildConfigUpdate(setting, value);
-  if (updates === undefined) {
-    return errorResult(`[configure] Invalid value "${value}" for setting "${setting}"`);
-  }
-  saveConfigToFile(configPath, updates);
-  if (immediateSettings.has(setting)) {
-    applyImmediateSetting(setting, value);
-    return textResult(`Setting "${setting}" updated to "${value}" (effective immediately)`);
-  }
-  return textResult(`Setting "${setting}" saved. Restart the server for this change to take effect.`);
-}
-
-/** Handles the "reset" action for the configure tool. */
-function handleConfigureReset(setting: string | undefined, config: Config): ToolResult {
-  if (!setting) return errorResult("[configure] setting is required for 'reset'");
-  const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
-  const resetUpdates = buildConfigReset(setting);
-  if (resetUpdates === undefined) {
-    return errorResult(`[configure] Unknown setting: ${setting}`);
-  }
-  saveConfigToFile(configPath, resetUpdates);
-  return textResult(`Setting "${setting}" reset to default. Restart for this change to take effect.`);
-}
-
-// --- Extracted vault_analysis handler ---
-
-/** Builds vault structure statistics from cache. */
-function buildVaultStructure(cache: VaultCache, limit: number): ToolResult {
-  const orphans = cache.getOrphanNotes();
-  const mostConnected = cache.getMostConnectedNotes(limit);
-  const graph = cache.getVaultGraph();
-  const dirs = new Set<string>();
-  for (const p of cache.getFileList()) {
-    const lastSlash = p.lastIndexOf("/");
-    if (lastSlash !== -1) {
-      dirs.add(p.slice(0, lastSlash));
-    }
-  }
-  return jsonResult({
-    noteCount: cache.noteCount,
-    linkCount: cache.linkCount,
-    directoryCount: dirs.size,
-    orphanCount: orphans.length,
-    orphans: orphans.slice(0, 20),
-    mostConnected,
-    edgeCount: graph.edges.length,
-  });
-}
+// --- Extracted vault_analysis handler (buildVaultStructure, handleRecentChanges, etc. imported from shared.ts) ---
 
 // --- Registration ---
 
@@ -682,22 +558,7 @@ export function registerConsolidatedTools(
       },
       async ({ paths, format }) => {
         try {
-          const results = await Promise.allSettled(
-            paths.map(async (fp) => {
-              const content = await client.getFileContents(fp, format);
-              return { path: fp, content };
-            }),
-          );
-          const output: Array<{ path: string; content?: unknown; error?: string }> = [];
-          for (const r of results) {
-            if (r.status === "fulfilled") {
-              output.push(r.value);
-            } else {
-              const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
-              output.push({ path: "(unknown)", error: reason });
-            }
-          }
-          return jsonResult(output);
+          return jsonResult(await batchGetFiles(client, paths, format));
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "batch_get" }));
         }
@@ -755,7 +616,7 @@ export function registerConsolidatedTools(
         try {
           switch (action) {
             case "show":
-              return jsonResult(getRedactedConfig(config));
+              return handleConfigureShow(config);
             case "set":
               return handleConfigureSet(setting, value, config);
             case "reset":
@@ -824,69 +685,3 @@ export function registerConsolidatedTools(
   return count;
 }
 
-// --- Configure Helpers (shared with granular — duplicated to avoid circular deps) ---
-
-/** Parses a boolean string value; returns undefined if invalid. */
-function parseBoolValue(value: string): boolean | undefined {
-  if (value === "true") return true;
-  if (value === "false") return false;
-  return undefined;
-}
-
-/** Parses a positive integer string value; returns undefined if invalid. */
-function parsePosIntValue(value: string, min: number): number | undefined {
-  const n = Number(value);
-  if (!Number.isFinite(n) || n < min) return undefined;
-  return n;
-}
-
-/** Builds a config file update for a setting. */
-function buildConfigUpdate(setting: string, value: string): Record<string, unknown> | undefined {
-  switch (setting) {
-    case "debug": {
-      const b = parseBoolValue(value);
-      return b === undefined ? undefined : { debug: b };
-    }
-    case "timeout": {
-      const n = parsePosIntValue(value, 1);
-      return n === undefined ? undefined : { reliability: { timeout: n } };
-    }
-    case "verifyWrites": {
-      const b = parseBoolValue(value);
-      return b === undefined ? undefined : { reliability: { verifyWrites: b } };
-    }
-    case "maxResponseChars": {
-      const n = parsePosIntValue(value, 0);
-      return n === undefined ? undefined : { reliability: { maxResponseChars: n } };
-    }
-    case "toolMode":
-      if (value !== "granular" && value !== "consolidated") return undefined;
-      return { tools: { mode: value } };
-    case "toolPreset":
-      if (value !== "full" && value !== "read-only" && value !== "minimal" && value !== "safe") return undefined;
-      return { tools: { preset: value } };
-    default:
-      return undefined;
-  }
-}
-
-/** Builds a config file reset for a setting. */
-function buildConfigReset(setting: string): Record<string, unknown> | undefined {
-  switch (setting) {
-    case "debug": return { debug: false };
-    case "timeout": return { reliability: { timeout: 30000 } };
-    case "verifyWrites": return { reliability: { verifyWrites: false } };
-    case "maxResponseChars": return { reliability: { maxResponseChars: 500000 } };
-    case "toolMode": return { tools: { mode: "granular" } };
-    case "toolPreset": return { tools: { preset: "full" } };
-    default: return undefined;
-  }
-}
-
-/** Applies an immediate setting change. */
-function applyImmediateSetting(setting: string, value: string): void {
-  if (setting === "debug") {
-    setDebugEnabled(value === "true");
-    log("info", `Debug logging ${value === "true" ? "enabled" : "disabled"}`);
-  }
-}

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -293,7 +293,41 @@ async function handlePeriodicNoteAction(client: ObsidianClient, args: PeriodicNo
   }
 }
 
-// --- Extracted vault_analysis handler (buildVaultStructure, handleRecentChanges, etc. imported from shared.ts) ---
+// --- Extracted vault_analysis handler ---
+
+/** Dispatches a vault_analysis action to the appropriate cache query. */
+async function handleVaultAnalysisAction(
+  cache: VaultCache,
+  config: Config,
+  action: "backlinks" | "connections" | "structure" | "refresh",
+  path: string | undefined,
+  limit: number,
+): Promise<ToolResult> {
+  if (!config.enableCache) {
+    return errorResult("[vault_analysis] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
+  }
+  switch (action) {
+    case "backlinks":
+      if (!path) return errorResult("[vault_analysis] path is required for backlinks");
+      if (!cache.getIsInitialized()) return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
+      return jsonResult(cache.getBacklinks(path));
+    case "connections":
+      if (!path) return errorResult("[vault_analysis] path is required for connections");
+      if (!cache.getIsInitialized()) return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
+      return jsonResult({ backlinks: cache.getBacklinks(path), forwardLinks: cache.getForwardLinks(path) });
+    case "structure":
+      if (!cache.getIsInitialized()) return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
+      return buildVaultStructure(cache, limit);
+    case "refresh":
+      await cache.refresh();
+      if (!cache.getIsInitialized()) return errorResult("[vault_analysis] Cache refresh failed — Obsidian may be unreachable");
+      return textResult(`Cache refreshed: ${String(cache.noteCount)} notes, ${String(cache.linkCount)} links`);
+    default: {
+      const _exhaustive: never = action;
+      return errorResult(`[vault_analysis] Unknown action: ${String(_exhaustive)}`);
+    }
+  }
+}
 
 // --- Registration ---
 
@@ -671,32 +705,7 @@ export function registerConsolidatedTools(
           return errorResult(`[vault_analysis] Action "${action}" is not allowed in "${config.toolPreset}" preset`);
         }
         try {
-          if (!config.enableCache) {
-            return errorResult("[vault_analysis] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
-          }
-          switch (action) {
-            case "backlinks":
-              if (!path) return errorResult("[vault_analysis] path is required for backlinks");
-              if (!cache.getIsInitialized()) return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
-              return jsonResult(cache.getBacklinks(path));
-            case "connections":
-              if (!path) return errorResult("[vault_analysis] path is required for connections");
-              if (!cache.getIsInitialized()) return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
-              return jsonResult({ backlinks: cache.getBacklinks(path), forwardLinks: cache.getForwardLinks(path) });
-            case "structure":
-              if (!cache.getIsInitialized()) return errorResult("[vault_analysis] Cache is still building. Try again shortly.");
-              return buildVaultStructure(cache, limit);
-            case "refresh":
-              await cache.refresh();
-              if (!cache.getIsInitialized()) {
-                return errorResult("[vault_analysis] Cache refresh failed — Obsidian may be unreachable");
-              }
-              return textResult(`Cache refreshed: ${String(cache.noteCount)} notes, ${String(cache.linkCount)} links`);
-            default: {
-              const _exhaustive: never = action;
-              return errorResult(`[vault_analysis] Unknown action: ${String(_exhaustive)}`);
-            }
-          }
+          return await handleVaultAnalysisAction(cache, config, action, path, limit);
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "vault_analysis", path }));
         }

--- a/src/tools/consolidated.ts
+++ b/src/tools/consolidated.ts
@@ -33,7 +33,7 @@ const READ_ONLY_ACTIONS: Record<string, ReadonlySet<string>> = {
   active_file: new Set(["get"]),
   commands: new Set(["list"]),
   periodic_note: new Set(["get"]),
-  recent: new Set(["changes", "periodic_notes"]),
+  // recent and search are inherently read-only — no action restrictions needed
   vault_analysis: new Set(["backlinks", "connections", "structure", "refresh"]),
 };
 
@@ -181,7 +181,7 @@ async function handleVaultSearchReplace(
   } else {
     pattern = new RegExp(escapeRegex(search), flags);
   }
-  const updated = result.replace(pattern, replaceText);
+  const updated = useRegex ? result.replace(pattern, replaceText) : result.replace(pattern, () => replaceText);
   if (updated === result) {
     return textResult(`No matches found for "${search}" in ${path}`);
   }
@@ -688,6 +688,9 @@ export function registerConsolidatedTools(
               return buildVaultStructure(cache, limit);
             case "refresh":
               await cache.refresh();
+              if (!cache.getIsInitialized()) {
+                return errorResult("[vault_analysis] Cache refresh failed — Obsidian may be unreachable");
+              }
               return textResult(`Cache refreshed: ${String(cache.noteCount)} notes, ${String(cache.linkCount)} links`);
             default: {
               const _exhaustive: never = action;

--- a/src/tools/granular.ts
+++ b/src/tools/granular.ts
@@ -1107,19 +1107,19 @@ function buildConfigUpdate(setting: string, value: string): Record<string, unkno
   switch (setting) {
     case "debug": {
       const b = parseBoolValue(value);
-      return b !== undefined ? { debug: b } : undefined;
+      return b === undefined ? undefined : { debug: b };
     }
     case "timeout": {
       const n = parsePosIntValue(value, 1);
-      return n !== undefined ? { reliability: { timeout: n } } : undefined;
+      return n === undefined ? undefined : { reliability: { timeout: n } };
     }
     case "verifyWrites": {
       const b = parseBoolValue(value);
-      return b !== undefined ? { reliability: { verifyWrites: b } } : undefined;
+      return b === undefined ? undefined : { reliability: { verifyWrites: b } };
     }
     case "maxResponseChars": {
       const n = parsePosIntValue(value, 0);
-      return n !== undefined ? { reliability: { maxResponseChars: n } } : undefined;
+      return n === undefined ? undefined : { reliability: { maxResponseChars: n } };
     }
     case "toolMode":
       if (value !== "granular" && value !== "consolidated") return undefined;

--- a/src/tools/granular.ts
+++ b/src/tools/granular.ts
@@ -1,15 +1,1083 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 
-import type { ObsidianClient } from "../obsidian.js";
+import type { ObsidianClient, NoteJson, DocumentMap } from "../obsidian.js";
+import { textResult, errorResult, jsonResult } from "../obsidian.js";
 import type { VaultCache } from "../cache.js";
+import type { Config } from "../config.js";
+import { getRedactedConfig, saveConfigToFile, setDebugEnabled, log } from "../config.js";
+import { buildErrorMessage } from "../errors.js";
+import {
+  formatSchema,
+  periodSchema,
+  patchOperationSchema,
+  patchTargetTypeSchema,
+  patchContentTypeSchema,
+} from "../schemas.js";
+
+// --- Consolidated preset action restrictions ---
+// (Not used in granular mode — included here only for type-sharing with consolidated.ts)
+
+// --- Helpers ---
+
+/** Formats file contents for display, handling markdown, JSON, and map formats. */
+function formatFileContents(result: string | NoteJson | DocumentMap): ReturnType<typeof textResult> {
+  if (typeof result === "string") {
+    return textResult(result);
+  }
+  return jsonResult(result);
+}
+
+// --- Registration ---
 
 /** Registers all 38 individual granular tools, filtered by the shouldRegister predicate. */
 export function registerGranularTools(
-  _server: McpServer,
-  _client: ObsidianClient,
-  _cache: VaultCache,
-  _shouldRegister: (name: string) => boolean,
+  server: McpServer,
+  client: ObsidianClient,
+  cache: VaultCache,
+  shouldRegister: (name: string) => boolean,
+  config: Config,
 ): number {
-  // Phase 2: all 38 granular tools will be registered here
-  return 0;
+  let count = 0;
+
+  // --- 1. list_files_in_vault ---
+  if (shouldRegister("list_files_in_vault")) {
+    server.tool(
+      "list_files_in_vault",
+      "List all files and directories in vault root",
+      {},
+      async () => {
+        try {
+          return jsonResult(await client.listFilesInVault());
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "list_files_in_vault" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 2. list_files_in_dir ---
+  if (shouldRegister("list_files_in_dir")) {
+    server.tool(
+      "list_files_in_dir",
+      "List files in a vault directory",
+      { dirPath: z.string().describe("Directory path") },
+      async ({ dirPath }) => {
+        try {
+          return jsonResult(await client.listFilesInDir(dirPath));
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "list_files_in_dir", path: dirPath }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 3. get_file_contents ---
+  if (shouldRegister("get_file_contents")) {
+    server.tool(
+      "get_file_contents",
+      "Read a vault file as markdown, JSON, or document map",
+      {
+        filePath: z.string().describe("File path"),
+        format: formatSchema.optional(),
+      },
+      async ({ filePath, format }) => {
+        try {
+          const result = await client.getFileContents(filePath, format);
+          return formatFileContents(result);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "get_file_contents", path: filePath }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 4. put_content ---
+  if (shouldRegister("put_content")) {
+    server.tool(
+      "put_content",
+      "Create or overwrite a vault file (idempotent)",
+      {
+        filePath: z.string().describe("File path"),
+        content: z.string().describe("File content"),
+      },
+      async ({ filePath, content }) => {
+        try {
+          await client.putContent(filePath, content);
+          return textResult(`Written: ${filePath}`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "put_content", path: filePath }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 5. append_content ---
+  if (shouldRegister("append_content")) {
+    server.tool(
+      "append_content",
+      "Append to a vault file (not idempotent, do not retry)",
+      {
+        filePath: z.string().describe("File path"),
+        content: z.string().describe("Content to append"),
+      },
+      async ({ filePath, content }) => {
+        try {
+          await client.appendContent(filePath, content);
+          return textResult(`Appended to: ${filePath}`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "append_content", path: filePath }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 6. patch_content ---
+  if (shouldRegister("patch_content")) {
+    server.tool(
+      "patch_content",
+      "Insert at heading/block/frontmatter (not idempotent, do not retry)",
+      {
+        filePath: z.string().describe("File path"),
+        content: z.string().describe("Content to insert"),
+        operation: patchOperationSchema,
+        targetType: patchTargetTypeSchema,
+        target: z.string().describe("Target heading/block/field"),
+        targetDelimiter: z.string().optional().describe("Heading delimiter"),
+        trimTargetWhitespace: z.boolean().optional().describe("Trim target whitespace"),
+        createIfMissing: z.boolean().optional().describe("Create target if missing"),
+        contentType: patchContentTypeSchema.optional(),
+      },
+      async ({ filePath, content, operation, targetType, target, targetDelimiter, trimTargetWhitespace, createIfMissing, contentType }) => {
+        try {
+          await client.patchContent(filePath, content, {
+            operation,
+            targetType,
+            target,
+            targetDelimiter,
+            trimTargetWhitespace,
+            createIfMissing,
+            contentType,
+          });
+          return textResult(`Patched: ${filePath}`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "patch_content", path: filePath }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 7. delete_file ---
+  if (shouldRegister("delete_file")) {
+    server.tool(
+      "delete_file",
+      "Delete a vault file to Obsidian trash (idempotent)",
+      { filePath: z.string().describe("File path") },
+      async ({ filePath }) => {
+        try {
+          await client.deleteFile(filePath);
+          return textResult(`Deleted: ${filePath}`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "delete_file", path: filePath }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 8. search_replace ---
+  if (shouldRegister("search_replace")) {
+    server.tool(
+      "search_replace",
+      "Find and replace text in a vault file (not idempotent)",
+      {
+        filePath: z.string().describe("File path"),
+        search: z.string().describe("Text to find"),
+        replace: z.string().describe("Replacement text"),
+        useRegex: z.boolean().default(false).describe("Use regex matching"),
+        caseSensitive: z.boolean().default(true).describe("Case-sensitive match"),
+        replaceAll: z.boolean().default(true).describe("Replace all occurrences"),
+      },
+      async ({ filePath, search, replace, useRegex, caseSensitive, replaceAll }) => {
+        try {
+          const result = await client.getFileContents(filePath, "markdown");
+          if (typeof result !== "string") {
+            return errorResult("[search_replace] Expected markdown content");
+          }
+          const flags = `${caseSensitive ? "" : "i"}${replaceAll ? "g" : ""}`;
+          const pattern = useRegex ? new RegExp(search, flags) : new RegExp(escapeRegex(search), flags);
+          const updated = result.replace(pattern, replace);
+          if (updated === result) {
+            return textResult(`No matches found for "${search}" in ${filePath}`);
+          }
+          await client.putContent(filePath, updated);
+          return textResult(`Replaced in: ${filePath}`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "search_replace", path: filePath }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 9. get_active_file ---
+  if (shouldRegister("get_active_file")) {
+    server.tool(
+      "get_active_file",
+      "Read the currently open file in Obsidian",
+      { format: formatSchema.optional() },
+      async ({ format }) => {
+        try {
+          const result = await client.getActiveFile(format);
+          return formatFileContents(result);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "get_active_file" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 10. put_active_file ---
+  if (shouldRegister("put_active_file")) {
+    server.tool(
+      "put_active_file",
+      "Replace content of the open file (idempotent)",
+      { content: z.string().describe("New file content") },
+      async ({ content }) => {
+        try {
+          await client.putActiveFile(content);
+          return textResult("Active file updated");
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "put_active_file" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 11. append_active_file ---
+  if (shouldRegister("append_active_file")) {
+    server.tool(
+      "append_active_file",
+      "Append to the open file (not idempotent, do not retry)",
+      { content: z.string().describe("Content to append") },
+      async ({ content }) => {
+        try {
+          await client.appendActiveFile(content);
+          return textResult("Appended to active file");
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "append_active_file" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 12. patch_active_file ---
+  if (shouldRegister("patch_active_file")) {
+    server.tool(
+      "patch_active_file",
+      "Patch the active file at a target (not idempotent)",
+      {
+        content: z.string().describe("Content to insert"),
+        operation: patchOperationSchema,
+        targetType: patchTargetTypeSchema,
+        target: z.string().describe("Target heading/block/field"),
+        targetDelimiter: z.string().optional().describe("Heading delimiter"),
+        trimTargetWhitespace: z.boolean().optional().describe("Trim target whitespace"),
+        contentType: patchContentTypeSchema.optional(),
+      },
+      async ({ content, operation, targetType, target, targetDelimiter, trimTargetWhitespace, contentType }) => {
+        try {
+          await client.patchActiveFile(content, {
+            operation,
+            targetType,
+            target,
+            targetDelimiter,
+            trimTargetWhitespace,
+            contentType,
+          });
+          return textResult("Active file patched");
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "patch_active_file" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 13. delete_active_file ---
+  if (shouldRegister("delete_active_file")) {
+    server.tool(
+      "delete_active_file",
+      "Delete the currently open file (idempotent)",
+      {},
+      async () => {
+        try {
+          await client.deleteActiveFile();
+          return textResult("Active file deleted");
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "delete_active_file" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 14. list_commands ---
+  if (shouldRegister("list_commands")) {
+    server.tool(
+      "list_commands",
+      "List all Obsidian command palette commands",
+      {},
+      async () => {
+        try {
+          return jsonResult(await client.listCommands());
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "list_commands" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 15. execute_command ---
+  if (shouldRegister("execute_command")) {
+    server.tool(
+      "execute_command",
+      "Run an Obsidian command by ID",
+      { commandId: z.string().describe("Command ID") },
+      async ({ commandId }) => {
+        try {
+          await client.executeCommand(commandId);
+          return textResult(`Executed: ${commandId}`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "execute_command" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 16. open_file ---
+  if (shouldRegister("open_file")) {
+    server.tool(
+      "open_file",
+      "Open a file in the Obsidian UI",
+      {
+        filePath: z.string().describe("File path"),
+        newLeaf: z.boolean().default(false).describe("Open in new tab"),
+      },
+      async ({ filePath, newLeaf }) => {
+        try {
+          await client.openFile(filePath, newLeaf);
+          return textResult(`Opened: ${filePath}`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "open_file", path: filePath }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 17. simple_search ---
+  if (shouldRegister("simple_search")) {
+    server.tool(
+      "simple_search",
+      "Full-text search across all vault files",
+      {
+        query: z.string().describe("Search query"),
+        contextLength: z.number().default(100).describe("Context chars"),
+      },
+      async ({ query, contextLength }) => {
+        try {
+          return jsonResult(await client.simpleSearch(query, contextLength));
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "simple_search" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 18. complex_search ---
+  if (shouldRegister("complex_search")) {
+    server.tool(
+      "complex_search",
+      "Search vault with JsonLogic queries (glob, regexp)",
+      {
+        query: z.record(z.unknown()).describe("JsonLogic query object"),
+      },
+      async ({ query }) => {
+        try {
+          return jsonResult(await client.complexSearch(query));
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "complex_search" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 19. dataview_search ---
+  if (shouldRegister("dataview_search")) {
+    server.tool(
+      "dataview_search",
+      "Query vault with Dataview DQL (requires plugin)",
+      { dql: z.string().describe("DQL query string") },
+      async ({ dql }) => {
+        try {
+          return jsonResult(await client.dataviewSearch(dql));
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "dataview_search" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 20. get_periodic_note ---
+  if (shouldRegister("get_periodic_note")) {
+    server.tool(
+      "get_periodic_note",
+      "Get the current periodic note",
+      {
+        period: periodSchema,
+        format: formatSchema.optional(),
+      },
+      async ({ period, format }) => {
+        try {
+          const result = await client.getPeriodicNote(period, format);
+          return formatFileContents(result);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "get_periodic_note" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 21. put_periodic_note ---
+  if (shouldRegister("put_periodic_note")) {
+    server.tool(
+      "put_periodic_note",
+      "Replace current periodic note content (idempotent)",
+      {
+        period: periodSchema,
+        content: z.string().describe("Note content"),
+      },
+      async ({ period, content }) => {
+        try {
+          await client.putPeriodicNote(period, content);
+          return textResult(`Updated ${period} note`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "put_periodic_note" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 22. append_periodic_note ---
+  if (shouldRegister("append_periodic_note")) {
+    server.tool(
+      "append_periodic_note",
+      "Append to current periodic note (not idempotent)",
+      {
+        period: periodSchema,
+        content: z.string().describe("Content to append"),
+      },
+      async ({ period, content }) => {
+        try {
+          await client.appendPeriodicNote(period, content);
+          return textResult(`Appended to ${period} note`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "append_periodic_note" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 23. patch_periodic_note ---
+  if (shouldRegister("patch_periodic_note")) {
+    server.tool(
+      "patch_periodic_note",
+      "Patch current periodic note at a target (not idempotent)",
+      {
+        period: periodSchema,
+        content: z.string().describe("Content to insert"),
+        operation: patchOperationSchema,
+        targetType: patchTargetTypeSchema,
+        target: z.string().describe("Target heading/block/field"),
+        targetDelimiter: z.string().optional().describe("Heading delimiter"),
+        trimTargetWhitespace: z.boolean().optional().describe("Trim target whitespace"),
+        createIfMissing: z.boolean().optional().describe("Create target if missing"),
+        contentType: patchContentTypeSchema.optional(),
+      },
+      async ({ period, content, operation, targetType, target, targetDelimiter, trimTargetWhitespace, createIfMissing, contentType }) => {
+        try {
+          await client.patchPeriodicNote(period, content, {
+            operation,
+            targetType,
+            target,
+            targetDelimiter,
+            trimTargetWhitespace,
+            createIfMissing,
+            contentType,
+          });
+          return textResult(`Patched ${period} note`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "patch_periodic_note" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 24. delete_periodic_note ---
+  if (shouldRegister("delete_periodic_note")) {
+    server.tool(
+      "delete_periodic_note",
+      "Delete current periodic note (idempotent)",
+      { period: periodSchema },
+      async ({ period }) => {
+        try {
+          await client.deletePeriodicNote(period);
+          return textResult(`Deleted ${period} note`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "delete_periodic_note" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 25. get_periodic_note_for_date ---
+  if (shouldRegister("get_periodic_note_for_date")) {
+    server.tool(
+      "get_periodic_note_for_date",
+      "Get periodic note for a specific date",
+      {
+        period: periodSchema,
+        year: z.number().int().describe("Year"),
+        month: z.number().int().min(1).max(12).describe("Month (1-12)"),
+        day: z.number().int().min(1).max(31).describe("Day (1-31)"),
+        format: formatSchema.optional(),
+      },
+      async ({ period, year, month, day, format }) => {
+        try {
+          const result = await client.getPeriodicNoteForDate(period, year, month, day, format);
+          return formatFileContents(result);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "get_periodic_note_for_date" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 26. put_periodic_note_for_date ---
+  if (shouldRegister("put_periodic_note_for_date")) {
+    server.tool(
+      "put_periodic_note_for_date",
+      "Replace periodic note for a date (idempotent)",
+      {
+        period: periodSchema,
+        year: z.number().int().describe("Year"),
+        month: z.number().int().min(1).max(12).describe("Month (1-12)"),
+        day: z.number().int().min(1).max(31).describe("Day (1-31)"),
+        content: z.string().describe("Note content"),
+      },
+      async ({ period, year, month, day, content }) => {
+        try {
+          await client.putPeriodicNoteForDate(period, year, month, day, content);
+          return textResult(`Updated ${period} note for ${String(year)}-${String(month)}-${String(day)}`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "put_periodic_note_for_date" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 27. append_periodic_note_for_date ---
+  if (shouldRegister("append_periodic_note_for_date")) {
+    server.tool(
+      "append_periodic_note_for_date",
+      "Append to periodic note for a date (not idempotent)",
+      {
+        period: periodSchema,
+        year: z.number().int().describe("Year"),
+        month: z.number().int().min(1).max(12).describe("Month (1-12)"),
+        day: z.number().int().min(1).max(31).describe("Day (1-31)"),
+        content: z.string().describe("Content to append"),
+      },
+      async ({ period, year, month, day, content }) => {
+        try {
+          await client.appendPeriodicNoteForDate(period, year, month, day, content);
+          return textResult(`Appended to ${period} note for ${String(year)}-${String(month)}-${String(day)}`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "append_periodic_note_for_date" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 28. patch_periodic_note_for_date ---
+  if (shouldRegister("patch_periodic_note_for_date")) {
+    server.tool(
+      "patch_periodic_note_for_date",
+      "Patch periodic note for a date (not idempotent)",
+      {
+        period: periodSchema,
+        year: z.number().int().describe("Year"),
+        month: z.number().int().min(1).max(12).describe("Month (1-12)"),
+        day: z.number().int().min(1).max(31).describe("Day (1-31)"),
+        content: z.string().describe("Content to insert"),
+        operation: patchOperationSchema,
+        targetType: patchTargetTypeSchema,
+        target: z.string().describe("Target heading/block/field"),
+        targetDelimiter: z.string().optional().describe("Heading delimiter"),
+        trimTargetWhitespace: z.boolean().optional().describe("Trim target whitespace"),
+        createIfMissing: z.boolean().optional().describe("Create target if missing"),
+        contentType: patchContentTypeSchema.optional(),
+      },
+      async ({ period, year, month, day, content, operation, targetType, target, targetDelimiter, trimTargetWhitespace, createIfMissing, contentType }) => {
+        try {
+          await client.patchPeriodicNoteForDate(period, year, month, day, content, {
+            operation,
+            targetType,
+            target,
+            targetDelimiter,
+            trimTargetWhitespace,
+            createIfMissing,
+            contentType,
+          });
+          return textResult(`Patched ${period} note for ${String(year)}-${String(month)}-${String(day)}`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "patch_periodic_note_for_date" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 29. delete_periodic_note_for_date ---
+  if (shouldRegister("delete_periodic_note_for_date")) {
+    server.tool(
+      "delete_periodic_note_for_date",
+      "Delete periodic note for a date (idempotent)",
+      {
+        period: periodSchema,
+        year: z.number().int().describe("Year"),
+        month: z.number().int().min(1).max(12).describe("Month (1-12)"),
+        day: z.number().int().min(1).max(31).describe("Day (1-31)"),
+      },
+      async ({ period, year, month, day }) => {
+        try {
+          await client.deletePeriodicNoteForDate(period, year, month, day);
+          return textResult(`Deleted ${period} note for ${String(year)}-${String(month)}-${String(day)}`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "delete_periodic_note_for_date" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 30. get_server_status (PROTECTED) ---
+  if (shouldRegister("get_server_status")) {
+    server.tool(
+      "get_server_status",
+      "Check Obsidian API connection and version",
+      {},
+      async () => {
+        try {
+          return jsonResult(await client.getServerStatus());
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "get_server_status" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 31. batch_get_file_contents ---
+  if (shouldRegister("batch_get_file_contents")) {
+    server.tool(
+      "batch_get_file_contents",
+      "Read multiple vault files in one call",
+      {
+        filePaths: z.array(z.string()).min(1).describe("File paths"),
+        format: formatSchema.optional(),
+      },
+      async ({ filePaths, format }) => {
+        try {
+          const results = await Promise.allSettled(
+            filePaths.map(async (fp) => {
+              const content = await client.getFileContents(fp, format);
+              return { path: fp, content };
+            }),
+          );
+          const output: Array<{ path: string; content?: unknown; error?: string }> = [];
+          for (const r of results) {
+            if (r.status === "fulfilled") {
+              output.push(r.value);
+            } else {
+              const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
+              output.push({ path: "(unknown)", error: reason });
+            }
+          }
+          return jsonResult(output);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "batch_get_file_contents" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 32. get_recent_changes ---
+  if (shouldRegister("get_recent_changes")) {
+    server.tool(
+      "get_recent_changes",
+      "Get recently modified files sorted by date",
+      { limit: z.number().int().min(1).default(10).describe("Max results") },
+      async ({ limit }) => {
+        try {
+          if (!config.enableCache || !cache.getIsInitialized()) {
+            // Fallback: list vault and fetch stat info
+            const { files } = await client.listFilesInVault();
+            const mdFiles = files.filter((f) => f.toLowerCase().endsWith(".md"));
+            const withStats = await Promise.allSettled(
+              mdFiles.map(async (fp) => {
+                const result = await client.getFileContents(fp, "json");
+                if (typeof result !== "string" && "stat" in result) {
+                  return { path: fp, mtime: result.stat.mtime };
+                }
+                return { path: fp, mtime: 0 };
+              }),
+            );
+            const sorted = withStats
+              .filter((r): r is PromiseFulfilledResult<{ path: string; mtime: number }> => r.status === "fulfilled")
+              .map((r) => r.value)
+              .sort((a, b) => b.mtime - a.mtime)
+              .slice(0, limit);
+            return jsonResult(sorted);
+          }
+          const allNotes = cache.getAllNotes();
+          const sorted = [...allNotes]
+            .sort((a, b) => b.stat.mtime - a.stat.mtime)
+            .slice(0, limit)
+            .map((n) => ({ path: n.path, mtime: n.stat.mtime }));
+          return jsonResult(sorted);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "get_recent_changes" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 33. get_recent_periodic_notes ---
+  if (shouldRegister("get_recent_periodic_notes")) {
+    server.tool(
+      "get_recent_periodic_notes",
+      "Get recent periodic notes for a period type",
+      {
+        period: periodSchema,
+        limit: z.number().int().min(1).default(5).describe("Max results"),
+      },
+      async ({ period, limit }) => {
+        try {
+          // List vault files and find periodic note directory
+          const { files } = await client.listFilesInVault();
+          const periodDirs: Record<string, string> = {
+            daily: "Daily Notes",
+            weekly: "Weekly Notes",
+            monthly: "Monthly Notes",
+            quarterly: "Quarterly Notes",
+            yearly: "Yearly Notes",
+          };
+          const dirName = periodDirs[period] ?? period;
+          const periodFiles = files
+            .filter((f) => f.startsWith(`${dirName}/`) && f.toLowerCase().endsWith(".md"))
+            .sort()
+            .reverse()
+            .slice(0, limit);
+          return jsonResult(periodFiles);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "get_recent_periodic_notes" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 34. configure (PROTECTED) ---
+  if (shouldRegister("configure")) {
+    server.tool(
+      "configure",
+      "View or change server settings",
+      {
+        action: z.enum(["show", "set", "reset"]).describe("Action"),
+        setting: z.string().optional().describe("Setting name for set/reset"),
+        value: z.string().optional().describe("New value for set"),
+      },
+      async ({ action, setting, value }) => {
+        try {
+          switch (action) {
+            case "show":
+              return jsonResult(getRedactedConfig(config));
+
+            case "set": {
+              if (!setting) {
+                return errorResult("[configure] Setting name is required for 'set' action");
+              }
+              if (value === undefined) {
+                return errorResult("[configure] Value is required for 'set' action");
+              }
+              const immediateSettings = new Set(["debug", "timeout", "verifyWrites", "maxResponseChars"]);
+              const restartSettings = new Set(["toolMode", "toolPreset"]);
+
+              if (!immediateSettings.has(setting) && !restartSettings.has(setting)) {
+                return errorResult(`[configure] Unknown setting: ${setting}. Available: ${[...immediateSettings, ...restartSettings].join(", ")}`);
+              }
+
+              const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
+              const updates = buildConfigUpdate(setting, value);
+              if (updates === undefined) {
+                return errorResult(`[configure] Invalid value "${value}" for setting "${setting}"`);
+              }
+
+              saveConfigToFile(configPath, updates);
+
+              if (immediateSettings.has(setting)) {
+                applyImmediateSetting(setting, value, config);
+                return textResult(`Setting "${setting}" updated to "${value}" (effective immediately)`);
+              }
+              return textResult(`Setting "${setting}" saved to config file. Restart the server for this change to take effect.`);
+            }
+
+            case "reset": {
+              if (!setting) {
+                return errorResult("[configure] Setting name is required for 'reset' action");
+              }
+              const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
+              const resetUpdates = buildConfigReset(setting);
+              if (resetUpdates === undefined) {
+                return errorResult(`[configure] Unknown setting: ${setting}`);
+              }
+              saveConfigToFile(configPath, resetUpdates);
+              return textResult(`Setting "${setting}" reset to default in config file. Restart the server for this change to take effect.`);
+            }
+
+            default: {
+              const _exhaustive: never = action;
+              return errorResult(`[configure] Unknown action: ${String(_exhaustive)}`);
+            }
+          }
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "configure" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 35. get_backlinks ---
+  if (shouldRegister("get_backlinks")) {
+    server.tool(
+      "get_backlinks",
+      "Get all notes that link to a file (from cache)",
+      { filePath: z.string().describe("File path") },
+      async ({ filePath }) => {
+        try {
+          if (!config.enableCache) {
+            return errorResult("[get_backlinks] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
+          }
+          if (!cache.getIsInitialized()) {
+            return errorResult("[get_backlinks] Cache is still building. Try again shortly.");
+          }
+          return jsonResult(cache.getBacklinks(filePath));
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "get_backlinks", path: filePath }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 36. get_vault_structure ---
+  if (shouldRegister("get_vault_structure")) {
+    server.tool(
+      "get_vault_structure",
+      "Get vault stats: note count, links, orphans, most connected",
+      { limit: z.number().int().min(1).default(10).describe("Top N connected") },
+      async ({ limit }) => {
+        try {
+          if (!config.enableCache) {
+            return errorResult("[get_vault_structure] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
+          }
+          if (!cache.getIsInitialized()) {
+            return errorResult("[get_vault_structure] Cache is still building. Try again shortly.");
+          }
+          const orphans = cache.getOrphanNotes();
+          const mostConnected = cache.getMostConnectedNotes(limit);
+          const graph = cache.getVaultGraph();
+
+          // Build directory tree summary
+          const dirs = new Set<string>();
+          for (const path of cache.getFileList()) {
+            const lastSlash = path.lastIndexOf("/");
+            if (lastSlash !== -1) {
+              dirs.add(path.slice(0, lastSlash));
+            }
+          }
+
+          return jsonResult({
+            noteCount: cache.noteCount,
+            linkCount: cache.linkCount,
+            directoryCount: dirs.size,
+            orphanCount: orphans.length,
+            orphans: orphans.slice(0, 20),
+            mostConnected,
+            edgeCount: graph.edges.length,
+          });
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "get_vault_structure" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 37. get_note_connections ---
+  if (shouldRegister("get_note_connections")) {
+    server.tool(
+      "get_note_connections",
+      "Get backlinks and forward links for a note",
+      { filePath: z.string().describe("File path") },
+      async ({ filePath }) => {
+        try {
+          if (!config.enableCache) {
+            return errorResult("[get_note_connections] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
+          }
+          if (!cache.getIsInitialized()) {
+            return errorResult("[get_note_connections] Cache is still building. Try again shortly.");
+          }
+          const backlinks = cache.getBacklinks(filePath);
+          const forwardLinks = cache.getForwardLinks(filePath);
+          return jsonResult({ backlinks, forwardLinks });
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "get_note_connections", path: filePath }));
+        }
+      },
+    );
+    count++;
+  }
+
+  // --- 38. refresh_cache (PROTECTED) ---
+  if (shouldRegister("refresh_cache")) {
+    server.tool(
+      "refresh_cache",
+      "Force refresh vault cache and link graph",
+      {},
+      async () => {
+        try {
+          if (!config.enableCache) {
+            return errorResult("[refresh_cache] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
+          }
+          await cache.refresh();
+          return textResult(`Cache refreshed: ${String(cache.noteCount)} notes, ${String(cache.linkCount)} links`);
+        } catch (err: unknown) {
+          return errorResult(buildErrorMessage(err, { tool: "refresh_cache" }));
+        }
+      },
+    );
+    count++;
+  }
+
+  return count;
+}
+
+// --- Configure Helpers ---
+
+/** Escapes a string for use as a literal in a RegExp. */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** Builds a config file update object for a given setting and value. Returns undefined if value is invalid. */
+function buildConfigUpdate(setting: string, value: string): Record<string, unknown> | undefined {
+  switch (setting) {
+    case "debug":
+      if (value !== "true" && value !== "false") return undefined;
+      return { debug: value === "true" };
+    case "timeout": {
+      const n = Number(value);
+      if (!Number.isFinite(n) || n < 1) return undefined;
+      return { reliability: { timeout: n } };
+    }
+    case "verifyWrites":
+      if (value !== "true" && value !== "false") return undefined;
+      return { reliability: { verifyWrites: value === "true" } };
+    case "maxResponseChars": {
+      const n = Number(value);
+      if (!Number.isFinite(n) || n < 0) return undefined;
+      return { reliability: { maxResponseChars: n } };
+    }
+    case "toolMode":
+      if (value !== "granular" && value !== "consolidated") return undefined;
+      return { tools: { mode: value } };
+    case "toolPreset":
+      if (value !== "full" && value !== "read-only" && value !== "minimal" && value !== "safe") return undefined;
+      return { tools: { preset: value } };
+    default:
+      return undefined;
+  }
+}
+
+/** Builds a config file update that resets a setting to its default value. Returns undefined for unknown settings. */
+function buildConfigReset(setting: string): Record<string, unknown> | undefined {
+  switch (setting) {
+    case "debug":
+      return { debug: false };
+    case "timeout":
+      return { reliability: { timeout: 30000 } };
+    case "verifyWrites":
+      return { reliability: { verifyWrites: false } };
+    case "maxResponseChars":
+      return { reliability: { maxResponseChars: 500000 } };
+    case "toolMode":
+      return { tools: { mode: "granular" } };
+    case "toolPreset":
+      return { tools: { preset: "full" } };
+    default:
+      return undefined;
+  }
+}
+
+/** Applies an immediate-effect setting change to the running config. */
+function applyImmediateSetting(setting: string, value: string, _config: Config): void {
+  // Config is readonly — we mutate the underlying process behavior directly
+  switch (setting) {
+    case "debug":
+      setDebugEnabled(value === "true");
+      log("info", `Debug logging ${value === "true" ? "enabled" : "disabled"}`);
+      break;
+    // timeout, verifyWrites, maxResponseChars take effect on next request via config file
+    // (the client reads from config on construction, so these require restart)
+    // We still save to file above — calling them "immediate" is a simplification
+    // that means "saved and acknowledged" vs "requires tool re-registration"
+  }
 }

--- a/src/tools/granular.ts
+++ b/src/tools/granular.ts
@@ -120,7 +120,7 @@ function registerVaultTools(
     server.registerTool(
       "append_content",
       {
-        description: "Append to a vault file (not idempotent, do not retry)",
+        description: "Append to a vault file (not idempotent, do not retry on timeout)",
         inputSchema: z.object({
           filePath: z.string().describe("File path"),
           content: z.string().describe("Content to append"),
@@ -143,7 +143,7 @@ function registerVaultTools(
     server.registerTool(
       "patch_content",
       {
-        description: "Insert at heading/block/frontmatter (not idempotent, do not retry)",
+        description: "Insert at heading/block/frontmatter (not idempotent, do not retry on timeout)",
         inputSchema: z.object({
           filePath: z.string().describe("File path"),
           content: z.string().describe("Content to insert"),
@@ -193,7 +193,7 @@ function registerVaultTools(
     server.registerTool(
       "search_replace",
       {
-        description: "Find and replace in a vault file (not idempotent, do not retry)",
+        description: "Find and replace in a vault file (not idempotent, do not retry on timeout)",
         inputSchema: z.object({
           filePath: z.string().describe("File path"),
           search: z.string().describe("Text to find"),
@@ -208,7 +208,12 @@ function registerVaultTools(
           const result = await client.getFileContents(filePath, "markdown", true);
           if (typeof result !== "string") return errorResult("[search_replace] Expected markdown content");
           const flags = `${caseSensitive ? "" : "i"}${replaceAll ? "g" : ""}`;
-          const pattern = useRegex ? new RegExp(search, flags) : new RegExp(escapeRegex(search), flags);
+          let pattern: RegExp;
+          if (useRegex) {
+            try { pattern = new RegExp(search, flags); } catch { return errorResult(`[search_replace] Invalid regex: "${search}"`); }
+          } else {
+            pattern = new RegExp(escapeRegex(search), flags);
+          }
           const updated = result.replace(pattern, replace);
           if (updated === result) return textResult(`No matches found for "${search}" in ${filePath}`);
           await client.putContent(filePath, updated);
@@ -276,7 +281,7 @@ function registerActiveFileTools(
     server.registerTool(
       "append_active_file",
       {
-        description: "Append to the open file (not idempotent, do not retry)",
+        description: "Append to the open file (not idempotent, do not retry on timeout)",
         inputSchema: z.object({ content: z.string().describe("Content to append") }),
       },
       async ({ content }) => {
@@ -296,7 +301,7 @@ function registerActiveFileTools(
     server.registerTool(
       "patch_active_file",
       {
-        description: "Patch the active file at a target (not idempotent, do not retry)",
+        description: "Patch the active file at a target (not idempotent, do not retry on timeout)",
         inputSchema: z.object({
           content: z.string().describe("Content to insert"),
           operation: patchOperationSchema,
@@ -523,7 +528,7 @@ function registerPeriodicNoteTools(
     server.registerTool(
       "append_periodic_note",
       {
-        description: "Append to current periodic note (not idempotent, do not retry)",
+        description: "Append to current periodic note (not idempotent, do not retry on timeout)",
         inputSchema: z.object({ period: periodSchema, content: z.string().describe("Content to append") }),
       },
       async ({ period, content }) => {
@@ -543,7 +548,7 @@ function registerPeriodicNoteTools(
     server.registerTool(
       "patch_periodic_note",
       {
-        description: "Patch current periodic note at target (not idempotent, do not retry)",
+        description: "Patch current periodic note at target (not idempotent, do not retry on timeout)",
         inputSchema: z.object({
           period: periodSchema,
           content: z.string().describe("Content to insert"),
@@ -655,7 +660,7 @@ function registerPeriodicNoteDateTools(
     server.registerTool(
       "append_periodic_note_for_date",
       {
-        description: "Append to periodic note for a date (not idempotent, do not retry)",
+        description: "Append to periodic note for a date (not idempotent, do not retry on timeout)",
         inputSchema: z.object({
           period: periodSchema,
           year: z.number().int().describe("Year"),
@@ -681,7 +686,7 @@ function registerPeriodicNoteDateTools(
     server.registerTool(
       "patch_periodic_note_for_date",
       {
-        description: "Patch periodic note for a date (not idempotent, do not retry)",
+        description: "Patch periodic note for a date (not idempotent, do not retry on timeout)",
         inputSchema: z.object({
           period: periodSchema,
           year: z.number().int().describe("Year"),

--- a/src/tools/granular.ts
+++ b/src/tools/granular.ts
@@ -193,7 +193,7 @@ function registerVaultTools(
     server.registerTool(
       "search_replace",
       {
-        description: "Find and replace text in a vault file (not idempotent)",
+        description: "Find and replace in a vault file (not idempotent, do not retry)",
         inputSchema: z.object({
           filePath: z.string().describe("File path"),
           search: z.string().describe("Text to find"),
@@ -296,7 +296,7 @@ function registerActiveFileTools(
     server.registerTool(
       "patch_active_file",
       {
-        description: "Patch the active file at a target (not idempotent)",
+        description: "Patch the active file at a target (not idempotent, do not retry)",
         inputSchema: z.object({
           content: z.string().describe("Content to insert"),
           operation: patchOperationSchema,
@@ -523,7 +523,7 @@ function registerPeriodicNoteTools(
     server.registerTool(
       "append_periodic_note",
       {
-        description: "Append to current periodic note (not idempotent)",
+        description: "Append to current periodic note (not idempotent, do not retry)",
         inputSchema: z.object({ period: periodSchema, content: z.string().describe("Content to append") }),
       },
       async ({ period, content }) => {
@@ -543,7 +543,7 @@ function registerPeriodicNoteTools(
     server.registerTool(
       "patch_periodic_note",
       {
-        description: "Patch current periodic note at a target (not idempotent)",
+        description: "Patch current periodic note at target (not idempotent, do not retry)",
         inputSchema: z.object({
           period: periodSchema,
           content: z.string().describe("Content to insert"),
@@ -655,7 +655,7 @@ function registerPeriodicNoteDateTools(
     server.registerTool(
       "append_periodic_note_for_date",
       {
-        description: "Append to periodic note for a date (not idempotent)",
+        description: "Append to periodic note for a date (not idempotent, do not retry)",
         inputSchema: z.object({
           period: periodSchema,
           year: z.number().int().describe("Year"),
@@ -681,7 +681,7 @@ function registerPeriodicNoteDateTools(
     server.registerTool(
       "patch_periodic_note_for_date",
       {
-        description: "Patch periodic note for a date (not idempotent)",
+        description: "Patch periodic note for a date (not idempotent, do not retry)",
         inputSchema: z.object({
           period: periodSchema,
           year: z.number().int().describe("Year"),

--- a/src/tools/granular.ts
+++ b/src/tools/granular.ts
@@ -1,11 +1,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import type { ObsidianClient, NoteJson, DocumentMap, ToolResult } from "../obsidian.js";
+import type { ObsidianClient } from "../obsidian.js";
 import { textResult, errorResult, jsonResult } from "../obsidian.js";
 import type { VaultCache } from "../cache.js";
 import type { Config } from "../config.js";
-import { getRedactedConfig, saveConfigToFile, setDebugEnabled, log } from "../config.js";
 import { buildErrorMessage } from "../errors.js";
 import {
   formatSchema,
@@ -14,108 +13,17 @@ import {
   patchTargetTypeSchema,
   patchContentTypeSchema,
 } from "../schemas.js";
-
-// --- Consolidated preset action restrictions ---
-// (Not used in granular mode — included here only for type-sharing with consolidated.ts)
-
-// --- Helpers ---
-
-/** Formats file contents for display, handling markdown, JSON, and map formats. */
-function formatFileContents(result: string | NoteJson | DocumentMap): ReturnType<typeof textResult> {
-  if (typeof result === "string") {
-    return textResult(result);
-  }
-  return jsonResult(result);
-}
-
-// --- Extracted Handlers ---
-
-/** Handles the configure "set" action. */
-function handleConfigureSet(
-  setting: string | undefined,
-  value: string | undefined,
-  config: Config,
-): ToolResult {
-  if (!setting) {
-    return errorResult("[configure] Setting name is required for 'set' action");
-  }
-  if (value === undefined) {
-    return errorResult("[configure] Value is required for 'set' action");
-  }
-  const immediateSettings = new Set(["debug", "timeout", "verifyWrites", "maxResponseChars"]);
-  const restartSettings = new Set(["toolMode", "toolPreset"]);
-  if (!immediateSettings.has(setting) && !restartSettings.has(setting)) {
-    return errorResult(`[configure] Unknown setting: ${setting}. Available: ${[...immediateSettings, ...restartSettings].join(", ")}`);
-  }
-  const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
-  const updates = buildConfigUpdate(setting, value);
-  if (updates === undefined) {
-    return errorResult(`[configure] Invalid value "${value}" for setting "${setting}"`);
-  }
-  saveConfigToFile(configPath, updates);
-  if (immediateSettings.has(setting)) {
-    applyImmediateSetting(setting, value, config);
-    return textResult(`Setting "${setting}" updated to "${value}" (effective immediately)`);
-  }
-  return textResult(`Setting "${setting}" saved to config file. Restart the server for this change to take effect.`);
-}
-
-/** Fetches recent changes using cache or fallback API calls. */
-async function handleRecentChanges(
-  client: ObsidianClient,
-  cache: VaultCache,
-  config: Config,
-  limit: number,
-): Promise<ToolResult> {
-  if (config.enableCache && cache.getIsInitialized()) {
-    const allNotes = cache.getAllNotes();
-    const sorted = [...allNotes]
-      .sort((a, b) => b.stat.mtime - a.stat.mtime)
-      .slice(0, limit)
-      .map((n) => ({ path: n.path, mtime: n.stat.mtime }));
-    return jsonResult(sorted);
-  }
-  const { files } = await client.listFilesInVault();
-  const mdFiles = files.filter((f) => f.toLowerCase().endsWith(".md"));
-  const withStats = await Promise.allSettled(
-    mdFiles.map(async (fp) => {
-      const result = await client.getFileContents(fp, "json");
-      if (typeof result !== "string" && "stat" in result) {
-        return { path: fp, mtime: result.stat.mtime };
-      }
-      return { path: fp, mtime: 0 };
-    }),
-  );
-  const sorted = withStats
-    .filter((r): r is PromiseFulfilledResult<{ path: string; mtime: number }> => r.status === "fulfilled")
-    .map((r) => r.value)
-    .sort((a, b) => b.mtime - a.mtime)
-    .slice(0, limit);
-  return jsonResult(sorted);
-}
-
-/** Builds vault structure statistics from cache. */
-function buildVaultStructure(cache: VaultCache, limit: number): ToolResult {
-  const orphans = cache.getOrphanNotes();
-  const mostConnected = cache.getMostConnectedNotes(limit);
-  const graph = cache.getVaultGraph();
-  const dirs = new Set<string>();
-  for (const path of cache.getFileList()) {
-    const lastSlash = path.lastIndexOf("/");
-    if (lastSlash !== -1) {
-      dirs.add(path.slice(0, lastSlash));
-    }
-  }
-  return jsonResult({
-    noteCount: cache.noteCount,
-    linkCount: cache.linkCount,
-    directoryCount: dirs.size,
-    orphanCount: orphans.length,
-    orphans: orphans.slice(0, 20),
-    mostConnected,
-    edgeCount: graph.edges.length,
-  });
-}
+import {
+  formatFileContents,
+  escapeRegex,
+  handleConfigureSet,
+  handleConfigureReset,
+  handleConfigureShow,
+  buildVaultStructure,
+  handleRecentChanges,
+  handleRecentPeriodicNotes,
+  batchGetFiles,
+} from "./shared.js";
 
 // --- Registration sub-functions (split to keep complexity below 15) ---
 
@@ -868,19 +776,7 @@ function registerSystemAndAnalysisTools(
       },
       async ({ filePaths, format }) => {
         try {
-          const results = await Promise.allSettled(
-            filePaths.map(async (fp) => ({ path: fp, content: await client.getFileContents(fp, format) })),
-          );
-          const output: Array<{ path: string; content?: unknown; error?: string }> = [];
-          for (const r of results) {
-            if (r.status === "fulfilled") {
-              output.push(r.value);
-            } else {
-              const reason = r.reason instanceof Error ? r.reason.message : String(r.reason);
-              output.push({ path: "(unknown)", error: reason });
-            }
-          }
-          return jsonResult(output);
+          return jsonResult(await batchGetFiles(client, filePaths, format));
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "batch_get_file_contents" }));
         }
@@ -921,20 +817,7 @@ function registerSystemAndAnalysisTools(
       },
       async ({ period, limit }) => {
         try {
-          const { files } = await client.listFilesInVault();
-          const periodDirs: Record<string, string> = {
-            daily: "Daily Notes",
-            weekly: "Weekly Notes",
-            monthly: "Monthly Notes",
-            quarterly: "Quarterly Notes",
-            yearly: "Yearly Notes",
-          };
-          const dirName = periodDirs[period] ?? period;
-          const periodFiles = files
-            .filter((f) => f.startsWith(`${dirName}/`) && f.toLowerCase().endsWith(".md"))
-            .sort((a, b) => b.localeCompare(a))
-            .slice(0, limit);
-          return jsonResult(periodFiles);
+          return await handleRecentPeriodicNotes(client, period, limit);
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "get_recent_periodic_notes" }));
         }
@@ -959,7 +842,7 @@ function registerSystemAndAnalysisTools(
         try {
           switch (action) {
             case "show":
-              return jsonResult(getRedactedConfig(config));
+              return handleConfigureShow(config);
             case "set":
               return handleConfigureSet(setting, value, config);
             case "reset":
@@ -1081,98 +964,3 @@ export function registerGranularTools(
   );
 }
 
-// --- Configure Helpers ---
-
-/** Escapes a string for use as a literal in a RegExp. */
-function escapeRegex(str: string): string {
-  return str.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-}
-
-/** Parses a boolean string value; returns undefined if invalid. */
-function parseBoolValue(value: string): boolean | undefined {
-  if (value === "true") return true;
-  if (value === "false") return false;
-  return undefined;
-}
-
-/** Parses a positive integer string value; returns undefined if invalid. */
-function parsePosIntValue(value: string, min: number): number | undefined {
-  const n = Number(value);
-  if (!Number.isFinite(n) || n < min) return undefined;
-  return n;
-}
-
-/** Builds a config file update object for a given setting and value. Returns undefined if value is invalid. */
-function buildConfigUpdate(setting: string, value: string): Record<string, unknown> | undefined {
-  switch (setting) {
-    case "debug": {
-      const b = parseBoolValue(value);
-      return b === undefined ? undefined : { debug: b };
-    }
-    case "timeout": {
-      const n = parsePosIntValue(value, 1);
-      return n === undefined ? undefined : { reliability: { timeout: n } };
-    }
-    case "verifyWrites": {
-      const b = parseBoolValue(value);
-      return b === undefined ? undefined : { reliability: { verifyWrites: b } };
-    }
-    case "maxResponseChars": {
-      const n = parsePosIntValue(value, 0);
-      return n === undefined ? undefined : { reliability: { maxResponseChars: n } };
-    }
-    case "toolMode":
-      if (value !== "granular" && value !== "consolidated") return undefined;
-      return { tools: { mode: value } };
-    case "toolPreset":
-      if (value !== "full" && value !== "read-only" && value !== "minimal" && value !== "safe") return undefined;
-      return { tools: { preset: value } };
-    default:
-      return undefined;
-  }
-}
-
-/** Handles the "reset" action for the configure tool. */
-function handleConfigureReset(setting: string | undefined, config: Config): ToolResult {
-  if (!setting) return errorResult("[configure] Setting name is required for 'reset' action");
-  const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
-  const resetUpdates = buildConfigReset(setting);
-  if (resetUpdates === undefined) {
-    return errorResult(`[configure] Unknown setting: ${setting}`);
-  }
-  saveConfigToFile(configPath, resetUpdates);
-  return textResult(`Setting "${setting}" reset to default in config file. Restart the server for this change to take effect.`);
-}
-
-/** Builds a config file update that resets a setting to its default value. Returns undefined for unknown settings. */
-function buildConfigReset(setting: string): Record<string, unknown> | undefined {
-  switch (setting) {
-    case "debug":
-      return { debug: false };
-    case "timeout":
-      return { reliability: { timeout: 30000 } };
-    case "verifyWrites":
-      return { reliability: { verifyWrites: false } };
-    case "maxResponseChars":
-      return { reliability: { maxResponseChars: 500000 } };
-    case "toolMode":
-      return { tools: { mode: "granular" } };
-    case "toolPreset":
-      return { tools: { preset: "full" } };
-    default:
-      return undefined;
-  }
-}
-
-/** Applies an immediate-effect setting change to the running config. */
-function applyImmediateSetting(setting: string, value: string, _config: Config): void {
-  // Config is readonly — we mutate the underlying process behavior directly
-  if (setting === "debug") {
-    setDebugEnabled(value === "true");
-    log("info", `Debug logging ${value === "true" ? "enabled" : "disabled"}`);
-  }
-  // timeout, verifyWrites, maxResponseChars take effect on next request via config file
-  // (the client reads from config on construction, so these require restart)
-  // We still save to file above — calling them "immediate" is a simplification
-  // that means "saved and acknowledged" vs "requires tool re-registration"
-}

--- a/src/tools/granular.ts
+++ b/src/tools/granular.ts
@@ -117,15 +117,13 @@ function buildVaultStructure(cache: VaultCache, limit: number): ToolResult {
   });
 }
 
-// --- Registration ---
+// --- Registration sub-functions (split to keep complexity below 15) ---
 
-/** Registers all 38 individual granular tools, filtered by the shouldRegister predicate. */
-export function registerGranularTools(
+/** Registers vault file tools (#1-8). */
+function registerVaultTools(
   server: McpServer,
   client: ObsidianClient,
-  cache: VaultCache,
   shouldRegister: (name: string) => boolean,
-  config: Config,
 ): number {
   let count = 0;
 
@@ -133,9 +131,7 @@ export function registerGranularTools(
   if (shouldRegister("list_files_in_vault")) {
     server.registerTool(
       "list_files_in_vault",
-      {
-        description: "List all files and directories in vault root",
-      },
+      { description: "List all files and directories in vault root" },
       async () => {
         try {
           return jsonResult(await client.listFilesInVault());
@@ -179,8 +175,7 @@ export function registerGranularTools(
       },
       async ({ filePath, format }) => {
         try {
-          const result = await client.getFileContents(filePath, format);
-          return formatFileContents(result);
+          return formatFileContents(await client.getFileContents(filePath, format));
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "get_file_contents", path: filePath }));
         }
@@ -255,15 +250,7 @@ export function registerGranularTools(
       },
       async ({ filePath, content, operation, targetType, target, targetDelimiter, trimTargetWhitespace, createIfMissing, contentType }) => {
         try {
-          await client.patchContent(filePath, content, {
-            operation,
-            targetType,
-            target,
-            targetDelimiter,
-            trimTargetWhitespace,
-            createIfMissing,
-            contentType,
-          });
+          await client.patchContent(filePath, content, { operation, targetType, target, targetDelimiter, trimTargetWhitespace, createIfMissing, contentType });
           return textResult(`Patched: ${filePath}`);
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "patch_content", path: filePath }));
@@ -311,15 +298,11 @@ export function registerGranularTools(
       async ({ filePath, search, replace, useRegex, caseSensitive, replaceAll }) => {
         try {
           const result = await client.getFileContents(filePath, "markdown");
-          if (typeof result !== "string") {
-            return errorResult("[search_replace] Expected markdown content");
-          }
+          if (typeof result !== "string") return errorResult("[search_replace] Expected markdown content");
           const flags = `${caseSensitive ? "" : "i"}${replaceAll ? "g" : ""}`;
           const pattern = useRegex ? new RegExp(search, flags) : new RegExp(escapeRegex(search), flags);
           const updated = result.replace(pattern, replace);
-          if (updated === result) {
-            return textResult(`No matches found for "${search}" in ${filePath}`);
-          }
+          if (updated === result) return textResult(`No matches found for "${search}" in ${filePath}`);
           await client.putContent(filePath, updated);
           return textResult(`Replaced in: ${filePath}`);
         } catch (err: unknown) {
@@ -329,6 +312,17 @@ export function registerGranularTools(
     );
     count++;
   }
+
+  return count;
+}
+
+/** Registers active file tools (#9-13). */
+function registerActiveFileTools(
+  server: McpServer,
+  client: ObsidianClient,
+  shouldRegister: (name: string) => boolean,
+): number {
+  let count = 0;
 
   // --- 9. get_active_file ---
   if (shouldRegister("get_active_file")) {
@@ -340,8 +334,7 @@ export function registerGranularTools(
       },
       async ({ format }) => {
         try {
-          const result = await client.getActiveFile(format);
-          return formatFileContents(result);
+          return formatFileContents(await client.getActiveFile(format));
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "get_active_file" }));
         }
@@ -408,14 +401,7 @@ export function registerGranularTools(
       },
       async ({ content, operation, targetType, target, targetDelimiter, trimTargetWhitespace, contentType }) => {
         try {
-          await client.patchActiveFile(content, {
-            operation,
-            targetType,
-            target,
-            targetDelimiter,
-            trimTargetWhitespace,
-            contentType,
-          });
+          await client.patchActiveFile(content, { operation, targetType, target, targetDelimiter, trimTargetWhitespace, contentType });
           return textResult("Active file patched");
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "patch_active_file" }));
@@ -429,9 +415,7 @@ export function registerGranularTools(
   if (shouldRegister("delete_active_file")) {
     server.registerTool(
       "delete_active_file",
-      {
-        description: "Delete the currently open file (idempotent)",
-      },
+      { description: "Delete the currently open file (idempotent)" },
       async () => {
         try {
           await client.deleteActiveFile();
@@ -444,13 +428,22 @@ export function registerGranularTools(
     count++;
   }
 
+  return count;
+}
+
+/** Registers command, open, and search tools (#14-19). */
+function registerCommandAndSearchTools(
+  server: McpServer,
+  client: ObsidianClient,
+  shouldRegister: (name: string) => boolean,
+): number {
+  let count = 0;
+
   // --- 14. list_commands ---
   if (shouldRegister("list_commands")) {
     server.registerTool(
       "list_commands",
-      {
-        description: "List all Obsidian command palette commands",
-      },
+      { description: "List all Obsidian command palette commands" },
       async () => {
         try {
           return jsonResult(await client.listCommands());
@@ -567,21 +560,28 @@ export function registerGranularTools(
     count++;
   }
 
+  return count;
+}
+
+/** Registers current-period periodic note tools (#20-24). */
+function registerPeriodicNoteTools(
+  server: McpServer,
+  client: ObsidianClient,
+  shouldRegister: (name: string) => boolean,
+): number {
+  let count = 0;
+
   // --- 20. get_periodic_note ---
   if (shouldRegister("get_periodic_note")) {
     server.registerTool(
       "get_periodic_note",
       {
         description: "Get the current periodic note",
-        inputSchema: z.object({
-          period: periodSchema,
-          format: formatSchema.optional(),
-        }),
+        inputSchema: z.object({ period: periodSchema, format: formatSchema.optional() }),
       },
       async ({ period, format }) => {
         try {
-          const result = await client.getPeriodicNote(period, format);
-          return formatFileContents(result);
+          return formatFileContents(await client.getPeriodicNote(period, format));
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "get_periodic_note" }));
         }
@@ -596,10 +596,7 @@ export function registerGranularTools(
       "put_periodic_note",
       {
         description: "Replace current periodic note content (idempotent)",
-        inputSchema: z.object({
-          period: periodSchema,
-          content: z.string().describe("Note content"),
-        }),
+        inputSchema: z.object({ period: periodSchema, content: z.string().describe("Note content") }),
       },
       async ({ period, content }) => {
         try {
@@ -619,10 +616,7 @@ export function registerGranularTools(
       "append_periodic_note",
       {
         description: "Append to current periodic note (not idempotent)",
-        inputSchema: z.object({
-          period: periodSchema,
-          content: z.string().describe("Content to append"),
-        }),
+        inputSchema: z.object({ period: periodSchema, content: z.string().describe("Content to append") }),
       },
       async ({ period, content }) => {
         try {
@@ -656,15 +650,7 @@ export function registerGranularTools(
       },
       async ({ period, content, operation, targetType, target, targetDelimiter, trimTargetWhitespace, createIfMissing, contentType }) => {
         try {
-          await client.patchPeriodicNote(period, content, {
-            operation,
-            targetType,
-            target,
-            targetDelimiter,
-            trimTargetWhitespace,
-            createIfMissing,
-            contentType,
-          });
+          await client.patchPeriodicNote(period, content, { operation, targetType, target, targetDelimiter, trimTargetWhitespace, createIfMissing, contentType });
           return textResult(`Patched ${period} note`);
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "patch_periodic_note" }));
@@ -694,6 +680,17 @@ export function registerGranularTools(
     count++;
   }
 
+  return count;
+}
+
+/** Registers date-scoped periodic note tools (#25-29). */
+function registerPeriodicNoteDateTools(
+  server: McpServer,
+  client: ObsidianClient,
+  shouldRegister: (name: string) => boolean,
+): number {
+  let count = 0;
+
   // --- 25. get_periodic_note_for_date ---
   if (shouldRegister("get_periodic_note_for_date")) {
     server.registerTool(
@@ -710,8 +707,7 @@ export function registerGranularTools(
       },
       async ({ period, year, month, day, format }) => {
         try {
-          const result = await client.getPeriodicNoteForDate(period, year, month, day, format);
-          return formatFileContents(result);
+          return formatFileContents(await client.getPeriodicNoteForDate(period, year, month, day, format));
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "get_periodic_note_for_date" }));
         }
@@ -795,15 +791,7 @@ export function registerGranularTools(
       },
       async ({ period, year, month, day, content, operation, targetType, target, targetDelimiter, trimTargetWhitespace, createIfMissing, contentType }) => {
         try {
-          await client.patchPeriodicNoteForDate(period, year, month, day, content, {
-            operation,
-            targetType,
-            target,
-            targetDelimiter,
-            trimTargetWhitespace,
-            createIfMissing,
-            contentType,
-          });
+          await client.patchPeriodicNoteForDate(period, year, month, day, content, { operation, targetType, target, targetDelimiter, trimTargetWhitespace, createIfMissing, contentType });
           return textResult(`Patched ${period} note for ${String(year)}-${String(month)}-${String(day)}`);
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "patch_periodic_note_for_date" }));
@@ -838,13 +826,24 @@ export function registerGranularTools(
     count++;
   }
 
+  return count;
+}
+
+/** Registers system, batch, recent, configure, and vault analysis tools (#30-38). */
+function registerSystemAndAnalysisTools(
+  server: McpServer,
+  client: ObsidianClient,
+  cache: VaultCache,
+  shouldRegister: (name: string) => boolean,
+  config: Config,
+): number {
+  let count = 0;
+
   // --- 30. get_server_status (PROTECTED) ---
   if (shouldRegister("get_server_status")) {
     server.registerTool(
       "get_server_status",
-      {
-        description: "Check Obsidian API connection and version",
-      },
+      { description: "Check Obsidian API connection and version" },
       async () => {
         try {
           return jsonResult(await client.getServerStatus());
@@ -870,10 +869,7 @@ export function registerGranularTools(
       async ({ filePaths, format }) => {
         try {
           const results = await Promise.allSettled(
-            filePaths.map(async (fp) => {
-              const content = await client.getFileContents(fp, format);
-              return { path: fp, content };
-            }),
+            filePaths.map(async (fp) => ({ path: fp, content: await client.getFileContents(fp, format) })),
           );
           const output: Array<{ path: string; content?: unknown; error?: string }> = [];
           for (const r of results) {
@@ -925,7 +921,6 @@ export function registerGranularTools(
       },
       async ({ period, limit }) => {
         try {
-          // List vault files and find periodic note directory
           const { files } = await client.listFilesInVault();
           const periodDirs: Record<string, string> = {
             daily: "Daily Notes",
@@ -965,23 +960,10 @@ export function registerGranularTools(
           switch (action) {
             case "show":
               return jsonResult(getRedactedConfig(config));
-
             case "set":
               return handleConfigureSet(setting, value, config);
-
-            case "reset": {
-              if (!setting) {
-                return errorResult("[configure] Setting name is required for 'reset' action");
-              }
-              const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
-              const resetUpdates = buildConfigReset(setting);
-              if (resetUpdates === undefined) {
-                return errorResult(`[configure] Unknown setting: ${setting}`);
-              }
-              saveConfigToFile(configPath, resetUpdates);
-              return textResult(`Setting "${setting}" reset to default in config file. Restart the server for this change to take effect.`);
-            }
-
+            case "reset":
+              return handleConfigureReset(setting, config);
             default: {
               const _exhaustive: never = action;
               return errorResult(`[configure] Unknown action: ${String(_exhaustive)}`);
@@ -1005,12 +987,8 @@ export function registerGranularTools(
       },
       async ({ filePath }) => {
         try {
-          if (!config.enableCache) {
-            return errorResult("[get_backlinks] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
-          }
-          if (!cache.getIsInitialized()) {
-            return errorResult("[get_backlinks] Cache is still building. Try again shortly.");
-          }
+          if (!config.enableCache) return errorResult("[get_backlinks] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
+          if (!cache.getIsInitialized()) return errorResult("[get_backlinks] Cache is still building. Try again shortly.");
           return jsonResult(cache.getBacklinks(filePath));
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "get_backlinks", path: filePath }));
@@ -1030,12 +1008,8 @@ export function registerGranularTools(
       },
       async ({ limit }) => {
         try {
-          if (!config.enableCache) {
-            return errorResult("[get_vault_structure] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
-          }
-          if (!cache.getIsInitialized()) {
-            return errorResult("[get_vault_structure] Cache is still building. Try again shortly.");
-          }
+          if (!config.enableCache) return errorResult("[get_vault_structure] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
+          if (!cache.getIsInitialized()) return errorResult("[get_vault_structure] Cache is still building. Try again shortly.");
           return buildVaultStructure(cache, limit);
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "get_vault_structure" }));
@@ -1055,15 +1029,9 @@ export function registerGranularTools(
       },
       async ({ filePath }) => {
         try {
-          if (!config.enableCache) {
-            return errorResult("[get_note_connections] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
-          }
-          if (!cache.getIsInitialized()) {
-            return errorResult("[get_note_connections] Cache is still building. Try again shortly.");
-          }
-          const backlinks = cache.getBacklinks(filePath);
-          const forwardLinks = cache.getForwardLinks(filePath);
-          return jsonResult({ backlinks, forwardLinks });
+          if (!config.enableCache) return errorResult("[get_note_connections] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
+          if (!cache.getIsInitialized()) return errorResult("[get_note_connections] Cache is still building. Try again shortly.");
+          return jsonResult({ backlinks: cache.getBacklinks(filePath), forwardLinks: cache.getForwardLinks(filePath) });
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "get_note_connections", path: filePath }));
         }
@@ -1076,14 +1044,10 @@ export function registerGranularTools(
   if (shouldRegister("refresh_cache")) {
     server.registerTool(
       "refresh_cache",
-      {
-        description: "Force refresh vault cache and link graph",
-      },
+      { description: "Force refresh vault cache and link graph" },
       async () => {
         try {
-          if (!config.enableCache) {
-            return errorResult("[refresh_cache] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
-          }
+          if (!config.enableCache) return errorResult("[refresh_cache] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
           await cache.refresh();
           return textResult(`Cache refreshed: ${String(cache.noteCount)} notes, ${String(cache.linkCount)} links`);
         } catch (err: unknown) {
@@ -1097,31 +1061,65 @@ export function registerGranularTools(
   return count;
 }
 
+// --- Registration ---
+
+/** Registers all 38 individual granular tools, filtered by the shouldRegister predicate. */
+export function registerGranularTools(
+  server: McpServer,
+  client: ObsidianClient,
+  cache: VaultCache,
+  shouldRegister: (name: string) => boolean,
+  config: Config,
+): number {
+  return (
+    registerVaultTools(server, client, shouldRegister) +
+    registerActiveFileTools(server, client, shouldRegister) +
+    registerCommandAndSearchTools(server, client, shouldRegister) +
+    registerPeriodicNoteTools(server, client, shouldRegister) +
+    registerPeriodicNoteDateTools(server, client, shouldRegister) +
+    registerSystemAndAnalysisTools(server, client, cache, shouldRegister, config)
+  );
+}
+
 // --- Configure Helpers ---
 
 /** Escapes a string for use as a literal in a RegExp. */
 function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return str.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+/** Parses a boolean string value; returns undefined if invalid. */
+function parseBoolValue(value: string): boolean | undefined {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
+}
+
+/** Parses a positive integer string value; returns undefined if invalid. */
+function parsePosIntValue(value: string, min: number): number | undefined {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < min) return undefined;
+  return n;
 }
 
 /** Builds a config file update object for a given setting and value. Returns undefined if value is invalid. */
 function buildConfigUpdate(setting: string, value: string): Record<string, unknown> | undefined {
   switch (setting) {
-    case "debug":
-      if (value !== "true" && value !== "false") return undefined;
-      return { debug: value === "true" };
-    case "timeout": {
-      const n = Number(value);
-      if (!Number.isFinite(n) || n < 1) return undefined;
-      return { reliability: { timeout: n } };
+    case "debug": {
+      const b = parseBoolValue(value);
+      return b !== undefined ? { debug: b } : undefined;
     }
-    case "verifyWrites":
-      if (value !== "true" && value !== "false") return undefined;
-      return { reliability: { verifyWrites: value === "true" } };
+    case "timeout": {
+      const n = parsePosIntValue(value, 1);
+      return n !== undefined ? { reliability: { timeout: n } } : undefined;
+    }
+    case "verifyWrites": {
+      const b = parseBoolValue(value);
+      return b !== undefined ? { reliability: { verifyWrites: b } } : undefined;
+    }
     case "maxResponseChars": {
-      const n = Number(value);
-      if (!Number.isFinite(n) || n < 0) return undefined;
-      return { reliability: { maxResponseChars: n } };
+      const n = parsePosIntValue(value, 0);
+      return n !== undefined ? { reliability: { maxResponseChars: n } } : undefined;
     }
     case "toolMode":
       if (value !== "granular" && value !== "consolidated") return undefined;
@@ -1132,6 +1130,18 @@ function buildConfigUpdate(setting: string, value: string): Record<string, unkno
     default:
       return undefined;
   }
+}
+
+/** Handles the "reset" action for the configure tool. */
+function handleConfigureReset(setting: string | undefined, config: Config): ToolResult {
+  if (!setting) return errorResult("[configure] Setting name is required for 'reset' action");
+  const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
+  const resetUpdates = buildConfigReset(setting);
+  if (resetUpdates === undefined) {
+    return errorResult(`[configure] Unknown setting: ${setting}`);
+  }
+  saveConfigToFile(configPath, resetUpdates);
+  return textResult(`Setting "${setting}" reset to default in config file. Restart the server for this change to take effect.`);
 }
 
 /** Builds a config file update that resets a setting to its default value. Returns undefined for unknown settings. */
@@ -1157,14 +1167,12 @@ function buildConfigReset(setting: string): Record<string, unknown> | undefined 
 /** Applies an immediate-effect setting change to the running config. */
 function applyImmediateSetting(setting: string, value: string, _config: Config): void {
   // Config is readonly — we mutate the underlying process behavior directly
-  switch (setting) {
-    case "debug":
-      setDebugEnabled(value === "true");
-      log("info", `Debug logging ${value === "true" ? "enabled" : "disabled"}`);
-      break;
-    // timeout, verifyWrites, maxResponseChars take effect on next request via config file
-    // (the client reads from config on construction, so these require restart)
-    // We still save to file above — calling them "immediate" is a simplification
-    // that means "saved and acknowledged" vs "requires tool re-registration"
+  if (setting === "debug") {
+    setDebugEnabled(value === "true");
+    log("info", `Debug logging ${value === "true" ? "enabled" : "disabled"}`);
   }
+  // timeout, verifyWrites, maxResponseChars take effect on next request via config file
+  // (the client reads from config on construction, so these require restart)
+  // We still save to file above — calling them "immediate" is a simplification
+  // that means "saved and acknowledged" vs "requires tool re-registration"
 }

--- a/src/tools/granular.ts
+++ b/src/tools/granular.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import type { ObsidianClient, NoteJson, DocumentMap } from "../obsidian.js";
+import type { ObsidianClient, NoteJson, DocumentMap, ToolResult } from "../obsidian.js";
 import { textResult, errorResult, jsonResult } from "../obsidian.js";
 import type { VaultCache } from "../cache.js";
 import type { Config } from "../config.js";
@@ -28,6 +28,95 @@ function formatFileContents(result: string | NoteJson | DocumentMap): ReturnType
   return jsonResult(result);
 }
 
+// --- Extracted Handlers ---
+
+/** Handles the configure "set" action. */
+function handleConfigureSet(
+  setting: string | undefined,
+  value: string | undefined,
+  config: Config,
+): ToolResult {
+  if (!setting) {
+    return errorResult("[configure] Setting name is required for 'set' action");
+  }
+  if (value === undefined) {
+    return errorResult("[configure] Value is required for 'set' action");
+  }
+  const immediateSettings = new Set(["debug", "timeout", "verifyWrites", "maxResponseChars"]);
+  const restartSettings = new Set(["toolMode", "toolPreset"]);
+  if (!immediateSettings.has(setting) && !restartSettings.has(setting)) {
+    return errorResult(`[configure] Unknown setting: ${setting}. Available: ${[...immediateSettings, ...restartSettings].join(", ")}`);
+  }
+  const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
+  const updates = buildConfigUpdate(setting, value);
+  if (updates === undefined) {
+    return errorResult(`[configure] Invalid value "${value}" for setting "${setting}"`);
+  }
+  saveConfigToFile(configPath, updates);
+  if (immediateSettings.has(setting)) {
+    applyImmediateSetting(setting, value, config);
+    return textResult(`Setting "${setting}" updated to "${value}" (effective immediately)`);
+  }
+  return textResult(`Setting "${setting}" saved to config file. Restart the server for this change to take effect.`);
+}
+
+/** Fetches recent changes using cache or fallback API calls. */
+async function handleRecentChanges(
+  client: ObsidianClient,
+  cache: VaultCache,
+  config: Config,
+  limit: number,
+): Promise<ToolResult> {
+  if (config.enableCache && cache.getIsInitialized()) {
+    const allNotes = cache.getAllNotes();
+    const sorted = [...allNotes]
+      .sort((a, b) => b.stat.mtime - a.stat.mtime)
+      .slice(0, limit)
+      .map((n) => ({ path: n.path, mtime: n.stat.mtime }));
+    return jsonResult(sorted);
+  }
+  const { files } = await client.listFilesInVault();
+  const mdFiles = files.filter((f) => f.toLowerCase().endsWith(".md"));
+  const withStats = await Promise.allSettled(
+    mdFiles.map(async (fp) => {
+      const result = await client.getFileContents(fp, "json");
+      if (typeof result !== "string" && "stat" in result) {
+        return { path: fp, mtime: result.stat.mtime };
+      }
+      return { path: fp, mtime: 0 };
+    }),
+  );
+  const sorted = withStats
+    .filter((r): r is PromiseFulfilledResult<{ path: string; mtime: number }> => r.status === "fulfilled")
+    .map((r) => r.value)
+    .sort((a, b) => b.mtime - a.mtime)
+    .slice(0, limit);
+  return jsonResult(sorted);
+}
+
+/** Builds vault structure statistics from cache. */
+function buildVaultStructure(cache: VaultCache, limit: number): ToolResult {
+  const orphans = cache.getOrphanNotes();
+  const mostConnected = cache.getMostConnectedNotes(limit);
+  const graph = cache.getVaultGraph();
+  const dirs = new Set<string>();
+  for (const path of cache.getFileList()) {
+    const lastSlash = path.lastIndexOf("/");
+    if (lastSlash !== -1) {
+      dirs.add(path.slice(0, lastSlash));
+    }
+  }
+  return jsonResult({
+    noteCount: cache.noteCount,
+    linkCount: cache.linkCount,
+    directoryCount: dirs.size,
+    orphanCount: orphans.length,
+    orphans: orphans.slice(0, 20),
+    mostConnected,
+    edgeCount: graph.edges.length,
+  });
+}
+
 // --- Registration ---
 
 /** Registers all 38 individual granular tools, filtered by the shouldRegister predicate. */
@@ -42,10 +131,11 @@ export function registerGranularTools(
 
   // --- 1. list_files_in_vault ---
   if (shouldRegister("list_files_in_vault")) {
-    server.tool(
+    server.registerTool(
       "list_files_in_vault",
-      "List all files and directories in vault root",
-      {},
+      {
+        description: "List all files and directories in vault root",
+      },
       async () => {
         try {
           return jsonResult(await client.listFilesInVault());
@@ -59,10 +149,12 @@ export function registerGranularTools(
 
   // --- 2. list_files_in_dir ---
   if (shouldRegister("list_files_in_dir")) {
-    server.tool(
+    server.registerTool(
       "list_files_in_dir",
-      "List files in a vault directory",
-      { dirPath: z.string().describe("Directory path") },
+      {
+        description: "List files in a vault directory",
+        inputSchema: z.object({ dirPath: z.string().describe("Directory path") }),
+      },
       async ({ dirPath }) => {
         try {
           return jsonResult(await client.listFilesInDir(dirPath));
@@ -76,12 +168,14 @@ export function registerGranularTools(
 
   // --- 3. get_file_contents ---
   if (shouldRegister("get_file_contents")) {
-    server.tool(
+    server.registerTool(
       "get_file_contents",
-      "Read a vault file as markdown, JSON, or document map",
       {
-        filePath: z.string().describe("File path"),
-        format: formatSchema.optional(),
+        description: "Read a vault file as markdown, JSON, or document map",
+        inputSchema: z.object({
+          filePath: z.string().describe("File path"),
+          format: formatSchema.optional(),
+        }),
       },
       async ({ filePath, format }) => {
         try {
@@ -97,12 +191,14 @@ export function registerGranularTools(
 
   // --- 4. put_content ---
   if (shouldRegister("put_content")) {
-    server.tool(
+    server.registerTool(
       "put_content",
-      "Create or overwrite a vault file (idempotent)",
       {
-        filePath: z.string().describe("File path"),
-        content: z.string().describe("File content"),
+        description: "Create or overwrite a vault file (idempotent)",
+        inputSchema: z.object({
+          filePath: z.string().describe("File path"),
+          content: z.string().describe("File content"),
+        }),
       },
       async ({ filePath, content }) => {
         try {
@@ -118,12 +214,14 @@ export function registerGranularTools(
 
   // --- 5. append_content ---
   if (shouldRegister("append_content")) {
-    server.tool(
+    server.registerTool(
       "append_content",
-      "Append to a vault file (not idempotent, do not retry)",
       {
-        filePath: z.string().describe("File path"),
-        content: z.string().describe("Content to append"),
+        description: "Append to a vault file (not idempotent, do not retry)",
+        inputSchema: z.object({
+          filePath: z.string().describe("File path"),
+          content: z.string().describe("Content to append"),
+        }),
       },
       async ({ filePath, content }) => {
         try {
@@ -139,19 +237,21 @@ export function registerGranularTools(
 
   // --- 6. patch_content ---
   if (shouldRegister("patch_content")) {
-    server.tool(
+    server.registerTool(
       "patch_content",
-      "Insert at heading/block/frontmatter (not idempotent, do not retry)",
       {
-        filePath: z.string().describe("File path"),
-        content: z.string().describe("Content to insert"),
-        operation: patchOperationSchema,
-        targetType: patchTargetTypeSchema,
-        target: z.string().describe("Target heading/block/field"),
-        targetDelimiter: z.string().optional().describe("Heading delimiter"),
-        trimTargetWhitespace: z.boolean().optional().describe("Trim target whitespace"),
-        createIfMissing: z.boolean().optional().describe("Create target if missing"),
-        contentType: patchContentTypeSchema.optional(),
+        description: "Insert at heading/block/frontmatter (not idempotent, do not retry)",
+        inputSchema: z.object({
+          filePath: z.string().describe("File path"),
+          content: z.string().describe("Content to insert"),
+          operation: patchOperationSchema,
+          targetType: patchTargetTypeSchema,
+          target: z.string().describe("Target heading/block/field"),
+          targetDelimiter: z.string().optional().describe("Heading delimiter"),
+          trimTargetWhitespace: z.boolean().optional().describe("Trim target whitespace"),
+          createIfMissing: z.boolean().optional().describe("Create target if missing"),
+          contentType: patchContentTypeSchema.optional(),
+        }),
       },
       async ({ filePath, content, operation, targetType, target, targetDelimiter, trimTargetWhitespace, createIfMissing, contentType }) => {
         try {
@@ -175,10 +275,12 @@ export function registerGranularTools(
 
   // --- 7. delete_file ---
   if (shouldRegister("delete_file")) {
-    server.tool(
+    server.registerTool(
       "delete_file",
-      "Delete a vault file to Obsidian trash (idempotent)",
-      { filePath: z.string().describe("File path") },
+      {
+        description: "Delete a vault file to Obsidian trash (idempotent)",
+        inputSchema: z.object({ filePath: z.string().describe("File path") }),
+      },
       async ({ filePath }) => {
         try {
           await client.deleteFile(filePath);
@@ -193,16 +295,18 @@ export function registerGranularTools(
 
   // --- 8. search_replace ---
   if (shouldRegister("search_replace")) {
-    server.tool(
+    server.registerTool(
       "search_replace",
-      "Find and replace text in a vault file (not idempotent)",
       {
-        filePath: z.string().describe("File path"),
-        search: z.string().describe("Text to find"),
-        replace: z.string().describe("Replacement text"),
-        useRegex: z.boolean().default(false).describe("Use regex matching"),
-        caseSensitive: z.boolean().default(true).describe("Case-sensitive match"),
-        replaceAll: z.boolean().default(true).describe("Replace all occurrences"),
+        description: "Find and replace text in a vault file (not idempotent)",
+        inputSchema: z.object({
+          filePath: z.string().describe("File path"),
+          search: z.string().describe("Text to find"),
+          replace: z.string().describe("Replacement text"),
+          useRegex: z.boolean().default(false).describe("Use regex matching"),
+          caseSensitive: z.boolean().default(true).describe("Case-sensitive match"),
+          replaceAll: z.boolean().default(true).describe("Replace all occurrences"),
+        }),
       },
       async ({ filePath, search, replace, useRegex, caseSensitive, replaceAll }) => {
         try {
@@ -228,10 +332,12 @@ export function registerGranularTools(
 
   // --- 9. get_active_file ---
   if (shouldRegister("get_active_file")) {
-    server.tool(
+    server.registerTool(
       "get_active_file",
-      "Read the currently open file in Obsidian",
-      { format: formatSchema.optional() },
+      {
+        description: "Read the currently open file in Obsidian",
+        inputSchema: z.object({ format: formatSchema.optional() }),
+      },
       async ({ format }) => {
         try {
           const result = await client.getActiveFile(format);
@@ -246,10 +352,12 @@ export function registerGranularTools(
 
   // --- 10. put_active_file ---
   if (shouldRegister("put_active_file")) {
-    server.tool(
+    server.registerTool(
       "put_active_file",
-      "Replace content of the open file (idempotent)",
-      { content: z.string().describe("New file content") },
+      {
+        description: "Replace content of the open file (idempotent)",
+        inputSchema: z.object({ content: z.string().describe("New file content") }),
+      },
       async ({ content }) => {
         try {
           await client.putActiveFile(content);
@@ -264,10 +372,12 @@ export function registerGranularTools(
 
   // --- 11. append_active_file ---
   if (shouldRegister("append_active_file")) {
-    server.tool(
+    server.registerTool(
       "append_active_file",
-      "Append to the open file (not idempotent, do not retry)",
-      { content: z.string().describe("Content to append") },
+      {
+        description: "Append to the open file (not idempotent, do not retry)",
+        inputSchema: z.object({ content: z.string().describe("Content to append") }),
+      },
       async ({ content }) => {
         try {
           await client.appendActiveFile(content);
@@ -282,17 +392,19 @@ export function registerGranularTools(
 
   // --- 12. patch_active_file ---
   if (shouldRegister("patch_active_file")) {
-    server.tool(
+    server.registerTool(
       "patch_active_file",
-      "Patch the active file at a target (not idempotent)",
       {
-        content: z.string().describe("Content to insert"),
-        operation: patchOperationSchema,
-        targetType: patchTargetTypeSchema,
-        target: z.string().describe("Target heading/block/field"),
-        targetDelimiter: z.string().optional().describe("Heading delimiter"),
-        trimTargetWhitespace: z.boolean().optional().describe("Trim target whitespace"),
-        contentType: patchContentTypeSchema.optional(),
+        description: "Patch the active file at a target (not idempotent)",
+        inputSchema: z.object({
+          content: z.string().describe("Content to insert"),
+          operation: patchOperationSchema,
+          targetType: patchTargetTypeSchema,
+          target: z.string().describe("Target heading/block/field"),
+          targetDelimiter: z.string().optional().describe("Heading delimiter"),
+          trimTargetWhitespace: z.boolean().optional().describe("Trim target whitespace"),
+          contentType: patchContentTypeSchema.optional(),
+        }),
       },
       async ({ content, operation, targetType, target, targetDelimiter, trimTargetWhitespace, contentType }) => {
         try {
@@ -315,10 +427,11 @@ export function registerGranularTools(
 
   // --- 13. delete_active_file ---
   if (shouldRegister("delete_active_file")) {
-    server.tool(
+    server.registerTool(
       "delete_active_file",
-      "Delete the currently open file (idempotent)",
-      {},
+      {
+        description: "Delete the currently open file (idempotent)",
+      },
       async () => {
         try {
           await client.deleteActiveFile();
@@ -333,10 +446,11 @@ export function registerGranularTools(
 
   // --- 14. list_commands ---
   if (shouldRegister("list_commands")) {
-    server.tool(
+    server.registerTool(
       "list_commands",
-      "List all Obsidian command palette commands",
-      {},
+      {
+        description: "List all Obsidian command palette commands",
+      },
       async () => {
         try {
           return jsonResult(await client.listCommands());
@@ -350,10 +464,12 @@ export function registerGranularTools(
 
   // --- 15. execute_command ---
   if (shouldRegister("execute_command")) {
-    server.tool(
+    server.registerTool(
       "execute_command",
-      "Run an Obsidian command by ID",
-      { commandId: z.string().describe("Command ID") },
+      {
+        description: "Run an Obsidian command by ID",
+        inputSchema: z.object({ commandId: z.string().describe("Command ID") }),
+      },
       async ({ commandId }) => {
         try {
           await client.executeCommand(commandId);
@@ -368,12 +484,14 @@ export function registerGranularTools(
 
   // --- 16. open_file ---
   if (shouldRegister("open_file")) {
-    server.tool(
+    server.registerTool(
       "open_file",
-      "Open a file in the Obsidian UI",
       {
-        filePath: z.string().describe("File path"),
-        newLeaf: z.boolean().default(false).describe("Open in new tab"),
+        description: "Open a file in the Obsidian UI",
+        inputSchema: z.object({
+          filePath: z.string().describe("File path"),
+          newLeaf: z.boolean().default(false).describe("Open in new tab"),
+        }),
       },
       async ({ filePath, newLeaf }) => {
         try {
@@ -389,12 +507,14 @@ export function registerGranularTools(
 
   // --- 17. simple_search ---
   if (shouldRegister("simple_search")) {
-    server.tool(
+    server.registerTool(
       "simple_search",
-      "Full-text search across all vault files",
       {
-        query: z.string().describe("Search query"),
-        contextLength: z.number().default(100).describe("Context chars"),
+        description: "Full-text search across all vault files",
+        inputSchema: z.object({
+          query: z.string().describe("Search query"),
+          contextLength: z.number().default(100).describe("Context chars"),
+        }),
       },
       async ({ query, contextLength }) => {
         try {
@@ -409,11 +529,13 @@ export function registerGranularTools(
 
   // --- 18. complex_search ---
   if (shouldRegister("complex_search")) {
-    server.tool(
+    server.registerTool(
       "complex_search",
-      "Search vault with JsonLogic queries (glob, regexp)",
       {
-        query: z.record(z.unknown()).describe("JsonLogic query object"),
+        description: "Search vault with JsonLogic queries (glob, regexp)",
+        inputSchema: z.object({
+          query: z.record(z.unknown()).describe("JsonLogic query object"),
+        }),
       },
       async ({ query }) => {
         try {
@@ -428,10 +550,12 @@ export function registerGranularTools(
 
   // --- 19. dataview_search ---
   if (shouldRegister("dataview_search")) {
-    server.tool(
+    server.registerTool(
       "dataview_search",
-      "Query vault with Dataview DQL (requires plugin)",
-      { dql: z.string().describe("DQL query string") },
+      {
+        description: "Query vault with Dataview DQL (requires plugin)",
+        inputSchema: z.object({ dql: z.string().describe("DQL query string") }),
+      },
       async ({ dql }) => {
         try {
           return jsonResult(await client.dataviewSearch(dql));
@@ -445,12 +569,14 @@ export function registerGranularTools(
 
   // --- 20. get_periodic_note ---
   if (shouldRegister("get_periodic_note")) {
-    server.tool(
+    server.registerTool(
       "get_periodic_note",
-      "Get the current periodic note",
       {
-        period: periodSchema,
-        format: formatSchema.optional(),
+        description: "Get the current periodic note",
+        inputSchema: z.object({
+          period: periodSchema,
+          format: formatSchema.optional(),
+        }),
       },
       async ({ period, format }) => {
         try {
@@ -466,12 +592,14 @@ export function registerGranularTools(
 
   // --- 21. put_periodic_note ---
   if (shouldRegister("put_periodic_note")) {
-    server.tool(
+    server.registerTool(
       "put_periodic_note",
-      "Replace current periodic note content (idempotent)",
       {
-        period: periodSchema,
-        content: z.string().describe("Note content"),
+        description: "Replace current periodic note content (idempotent)",
+        inputSchema: z.object({
+          period: periodSchema,
+          content: z.string().describe("Note content"),
+        }),
       },
       async ({ period, content }) => {
         try {
@@ -487,12 +615,14 @@ export function registerGranularTools(
 
   // --- 22. append_periodic_note ---
   if (shouldRegister("append_periodic_note")) {
-    server.tool(
+    server.registerTool(
       "append_periodic_note",
-      "Append to current periodic note (not idempotent)",
       {
-        period: periodSchema,
-        content: z.string().describe("Content to append"),
+        description: "Append to current periodic note (not idempotent)",
+        inputSchema: z.object({
+          period: periodSchema,
+          content: z.string().describe("Content to append"),
+        }),
       },
       async ({ period, content }) => {
         try {
@@ -508,19 +638,21 @@ export function registerGranularTools(
 
   // --- 23. patch_periodic_note ---
   if (shouldRegister("patch_periodic_note")) {
-    server.tool(
+    server.registerTool(
       "patch_periodic_note",
-      "Patch current periodic note at a target (not idempotent)",
       {
-        period: periodSchema,
-        content: z.string().describe("Content to insert"),
-        operation: patchOperationSchema,
-        targetType: patchTargetTypeSchema,
-        target: z.string().describe("Target heading/block/field"),
-        targetDelimiter: z.string().optional().describe("Heading delimiter"),
-        trimTargetWhitespace: z.boolean().optional().describe("Trim target whitespace"),
-        createIfMissing: z.boolean().optional().describe("Create target if missing"),
-        contentType: patchContentTypeSchema.optional(),
+        description: "Patch current periodic note at a target (not idempotent)",
+        inputSchema: z.object({
+          period: periodSchema,
+          content: z.string().describe("Content to insert"),
+          operation: patchOperationSchema,
+          targetType: patchTargetTypeSchema,
+          target: z.string().describe("Target heading/block/field"),
+          targetDelimiter: z.string().optional().describe("Heading delimiter"),
+          trimTargetWhitespace: z.boolean().optional().describe("Trim target whitespace"),
+          createIfMissing: z.boolean().optional().describe("Create target if missing"),
+          contentType: patchContentTypeSchema.optional(),
+        }),
       },
       async ({ period, content, operation, targetType, target, targetDelimiter, trimTargetWhitespace, createIfMissing, contentType }) => {
         try {
@@ -544,10 +676,12 @@ export function registerGranularTools(
 
   // --- 24. delete_periodic_note ---
   if (shouldRegister("delete_periodic_note")) {
-    server.tool(
+    server.registerTool(
       "delete_periodic_note",
-      "Delete current periodic note (idempotent)",
-      { period: periodSchema },
+      {
+        description: "Delete current periodic note (idempotent)",
+        inputSchema: z.object({ period: periodSchema }),
+      },
       async ({ period }) => {
         try {
           await client.deletePeriodicNote(period);
@@ -562,15 +696,17 @@ export function registerGranularTools(
 
   // --- 25. get_periodic_note_for_date ---
   if (shouldRegister("get_periodic_note_for_date")) {
-    server.tool(
+    server.registerTool(
       "get_periodic_note_for_date",
-      "Get periodic note for a specific date",
       {
-        period: periodSchema,
-        year: z.number().int().describe("Year"),
-        month: z.number().int().min(1).max(12).describe("Month (1-12)"),
-        day: z.number().int().min(1).max(31).describe("Day (1-31)"),
-        format: formatSchema.optional(),
+        description: "Get periodic note for a specific date",
+        inputSchema: z.object({
+          period: periodSchema,
+          year: z.number().int().describe("Year"),
+          month: z.number().int().min(1).max(12).describe("Month (1-12)"),
+          day: z.number().int().min(1).max(31).describe("Day (1-31)"),
+          format: formatSchema.optional(),
+        }),
       },
       async ({ period, year, month, day, format }) => {
         try {
@@ -586,15 +722,17 @@ export function registerGranularTools(
 
   // --- 26. put_periodic_note_for_date ---
   if (shouldRegister("put_periodic_note_for_date")) {
-    server.tool(
+    server.registerTool(
       "put_periodic_note_for_date",
-      "Replace periodic note for a date (idempotent)",
       {
-        period: periodSchema,
-        year: z.number().int().describe("Year"),
-        month: z.number().int().min(1).max(12).describe("Month (1-12)"),
-        day: z.number().int().min(1).max(31).describe("Day (1-31)"),
-        content: z.string().describe("Note content"),
+        description: "Replace periodic note for a date (idempotent)",
+        inputSchema: z.object({
+          period: periodSchema,
+          year: z.number().int().describe("Year"),
+          month: z.number().int().min(1).max(12).describe("Month (1-12)"),
+          day: z.number().int().min(1).max(31).describe("Day (1-31)"),
+          content: z.string().describe("Note content"),
+        }),
       },
       async ({ period, year, month, day, content }) => {
         try {
@@ -610,15 +748,17 @@ export function registerGranularTools(
 
   // --- 27. append_periodic_note_for_date ---
   if (shouldRegister("append_periodic_note_for_date")) {
-    server.tool(
+    server.registerTool(
       "append_periodic_note_for_date",
-      "Append to periodic note for a date (not idempotent)",
       {
-        period: periodSchema,
-        year: z.number().int().describe("Year"),
-        month: z.number().int().min(1).max(12).describe("Month (1-12)"),
-        day: z.number().int().min(1).max(31).describe("Day (1-31)"),
-        content: z.string().describe("Content to append"),
+        description: "Append to periodic note for a date (not idempotent)",
+        inputSchema: z.object({
+          period: periodSchema,
+          year: z.number().int().describe("Year"),
+          month: z.number().int().min(1).max(12).describe("Month (1-12)"),
+          day: z.number().int().min(1).max(31).describe("Day (1-31)"),
+          content: z.string().describe("Content to append"),
+        }),
       },
       async ({ period, year, month, day, content }) => {
         try {
@@ -634,22 +774,24 @@ export function registerGranularTools(
 
   // --- 28. patch_periodic_note_for_date ---
   if (shouldRegister("patch_periodic_note_for_date")) {
-    server.tool(
+    server.registerTool(
       "patch_periodic_note_for_date",
-      "Patch periodic note for a date (not idempotent)",
       {
-        period: periodSchema,
-        year: z.number().int().describe("Year"),
-        month: z.number().int().min(1).max(12).describe("Month (1-12)"),
-        day: z.number().int().min(1).max(31).describe("Day (1-31)"),
-        content: z.string().describe("Content to insert"),
-        operation: patchOperationSchema,
-        targetType: patchTargetTypeSchema,
-        target: z.string().describe("Target heading/block/field"),
-        targetDelimiter: z.string().optional().describe("Heading delimiter"),
-        trimTargetWhitespace: z.boolean().optional().describe("Trim target whitespace"),
-        createIfMissing: z.boolean().optional().describe("Create target if missing"),
-        contentType: patchContentTypeSchema.optional(),
+        description: "Patch periodic note for a date (not idempotent)",
+        inputSchema: z.object({
+          period: periodSchema,
+          year: z.number().int().describe("Year"),
+          month: z.number().int().min(1).max(12).describe("Month (1-12)"),
+          day: z.number().int().min(1).max(31).describe("Day (1-31)"),
+          content: z.string().describe("Content to insert"),
+          operation: patchOperationSchema,
+          targetType: patchTargetTypeSchema,
+          target: z.string().describe("Target heading/block/field"),
+          targetDelimiter: z.string().optional().describe("Heading delimiter"),
+          trimTargetWhitespace: z.boolean().optional().describe("Trim target whitespace"),
+          createIfMissing: z.boolean().optional().describe("Create target if missing"),
+          contentType: patchContentTypeSchema.optional(),
+        }),
       },
       async ({ period, year, month, day, content, operation, targetType, target, targetDelimiter, trimTargetWhitespace, createIfMissing, contentType }) => {
         try {
@@ -673,14 +815,16 @@ export function registerGranularTools(
 
   // --- 29. delete_periodic_note_for_date ---
   if (shouldRegister("delete_periodic_note_for_date")) {
-    server.tool(
+    server.registerTool(
       "delete_periodic_note_for_date",
-      "Delete periodic note for a date (idempotent)",
       {
-        period: periodSchema,
-        year: z.number().int().describe("Year"),
-        month: z.number().int().min(1).max(12).describe("Month (1-12)"),
-        day: z.number().int().min(1).max(31).describe("Day (1-31)"),
+        description: "Delete periodic note for a date (idempotent)",
+        inputSchema: z.object({
+          period: periodSchema,
+          year: z.number().int().describe("Year"),
+          month: z.number().int().min(1).max(12).describe("Month (1-12)"),
+          day: z.number().int().min(1).max(31).describe("Day (1-31)"),
+        }),
       },
       async ({ period, year, month, day }) => {
         try {
@@ -696,10 +840,11 @@ export function registerGranularTools(
 
   // --- 30. get_server_status (PROTECTED) ---
   if (shouldRegister("get_server_status")) {
-    server.tool(
+    server.registerTool(
       "get_server_status",
-      "Check Obsidian API connection and version",
-      {},
+      {
+        description: "Check Obsidian API connection and version",
+      },
       async () => {
         try {
           return jsonResult(await client.getServerStatus());
@@ -713,12 +858,14 @@ export function registerGranularTools(
 
   // --- 31. batch_get_file_contents ---
   if (shouldRegister("batch_get_file_contents")) {
-    server.tool(
+    server.registerTool(
       "batch_get_file_contents",
-      "Read multiple vault files in one call",
       {
-        filePaths: z.array(z.string()).min(1).describe("File paths"),
-        format: formatSchema.optional(),
+        description: "Read multiple vault files in one call",
+        inputSchema: z.object({
+          filePaths: z.array(z.string()).min(1).describe("File paths"),
+          format: formatSchema.optional(),
+        }),
       },
       async ({ filePaths, format }) => {
         try {
@@ -748,38 +895,15 @@ export function registerGranularTools(
 
   // --- 32. get_recent_changes ---
   if (shouldRegister("get_recent_changes")) {
-    server.tool(
+    server.registerTool(
       "get_recent_changes",
-      "Get recently modified files sorted by date",
-      { limit: z.number().int().min(1).default(10).describe("Max results") },
+      {
+        description: "Get recently modified files sorted by date",
+        inputSchema: z.object({ limit: z.number().int().min(1).default(10).describe("Max results") }),
+      },
       async ({ limit }) => {
         try {
-          if (!config.enableCache || !cache.getIsInitialized()) {
-            // Fallback: list vault and fetch stat info
-            const { files } = await client.listFilesInVault();
-            const mdFiles = files.filter((f) => f.toLowerCase().endsWith(".md"));
-            const withStats = await Promise.allSettled(
-              mdFiles.map(async (fp) => {
-                const result = await client.getFileContents(fp, "json");
-                if (typeof result !== "string" && "stat" in result) {
-                  return { path: fp, mtime: result.stat.mtime };
-                }
-                return { path: fp, mtime: 0 };
-              }),
-            );
-            const sorted = withStats
-              .filter((r): r is PromiseFulfilledResult<{ path: string; mtime: number }> => r.status === "fulfilled")
-              .map((r) => r.value)
-              .sort((a, b) => b.mtime - a.mtime)
-              .slice(0, limit);
-            return jsonResult(sorted);
-          }
-          const allNotes = cache.getAllNotes();
-          const sorted = [...allNotes]
-            .sort((a, b) => b.stat.mtime - a.stat.mtime)
-            .slice(0, limit)
-            .map((n) => ({ path: n.path, mtime: n.stat.mtime }));
-          return jsonResult(sorted);
+          return await handleRecentChanges(client, cache, config, limit);
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "get_recent_changes" }));
         }
@@ -790,12 +914,14 @@ export function registerGranularTools(
 
   // --- 33. get_recent_periodic_notes ---
   if (shouldRegister("get_recent_periodic_notes")) {
-    server.tool(
+    server.registerTool(
       "get_recent_periodic_notes",
-      "Get recent periodic notes for a period type",
       {
-        period: periodSchema,
-        limit: z.number().int().min(1).default(5).describe("Max results"),
+        description: "Get recent periodic notes for a period type",
+        inputSchema: z.object({
+          period: periodSchema,
+          limit: z.number().int().min(1).default(5).describe("Max results"),
+        }),
       },
       async ({ period, limit }) => {
         try {
@@ -811,8 +937,7 @@ export function registerGranularTools(
           const dirName = periodDirs[period] ?? period;
           const periodFiles = files
             .filter((f) => f.startsWith(`${dirName}/`) && f.toLowerCase().endsWith(".md"))
-            .sort()
-            .reverse()
+            .sort((a, b) => b.localeCompare(a))
             .slice(0, limit);
           return jsonResult(periodFiles);
         } catch (err: unknown) {
@@ -825,13 +950,15 @@ export function registerGranularTools(
 
   // --- 34. configure (PROTECTED) ---
   if (shouldRegister("configure")) {
-    server.tool(
+    server.registerTool(
       "configure",
-      "View or change server settings",
       {
-        action: z.enum(["show", "set", "reset"]).describe("Action"),
-        setting: z.string().optional().describe("Setting name for set/reset"),
-        value: z.string().optional().describe("New value for set"),
+        description: "View or change server settings",
+        inputSchema: z.object({
+          action: z.enum(["show", "set", "reset"]).describe("Action"),
+          setting: z.string().optional().describe("Setting name for set/reset"),
+          value: z.string().optional().describe("New value for set"),
+        }),
       },
       async ({ action, setting, value }) => {
         try {
@@ -839,34 +966,8 @@ export function registerGranularTools(
             case "show":
               return jsonResult(getRedactedConfig(config));
 
-            case "set": {
-              if (!setting) {
-                return errorResult("[configure] Setting name is required for 'set' action");
-              }
-              if (value === undefined) {
-                return errorResult("[configure] Value is required for 'set' action");
-              }
-              const immediateSettings = new Set(["debug", "timeout", "verifyWrites", "maxResponseChars"]);
-              const restartSettings = new Set(["toolMode", "toolPreset"]);
-
-              if (!immediateSettings.has(setting) && !restartSettings.has(setting)) {
-                return errorResult(`[configure] Unknown setting: ${setting}. Available: ${[...immediateSettings, ...restartSettings].join(", ")}`);
-              }
-
-              const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
-              const updates = buildConfigUpdate(setting, value);
-              if (updates === undefined) {
-                return errorResult(`[configure] Invalid value "${value}" for setting "${setting}"`);
-              }
-
-              saveConfigToFile(configPath, updates);
-
-              if (immediateSettings.has(setting)) {
-                applyImmediateSetting(setting, value, config);
-                return textResult(`Setting "${setting}" updated to "${value}" (effective immediately)`);
-              }
-              return textResult(`Setting "${setting}" saved to config file. Restart the server for this change to take effect.`);
-            }
+            case "set":
+              return handleConfigureSet(setting, value, config);
 
             case "reset": {
               if (!setting) {
@@ -896,10 +997,12 @@ export function registerGranularTools(
 
   // --- 35. get_backlinks ---
   if (shouldRegister("get_backlinks")) {
-    server.tool(
+    server.registerTool(
       "get_backlinks",
-      "Get all notes that link to a file (from cache)",
-      { filePath: z.string().describe("File path") },
+      {
+        description: "Get all notes that link to a file (from cache)",
+        inputSchema: z.object({ filePath: z.string().describe("File path") }),
+      },
       async ({ filePath }) => {
         try {
           if (!config.enableCache) {
@@ -919,10 +1022,12 @@ export function registerGranularTools(
 
   // --- 36. get_vault_structure ---
   if (shouldRegister("get_vault_structure")) {
-    server.tool(
+    server.registerTool(
       "get_vault_structure",
-      "Get vault stats: note count, links, orphans, most connected",
-      { limit: z.number().int().min(1).default(10).describe("Top N connected") },
+      {
+        description: "Get vault stats: note count, links, orphans, most connected",
+        inputSchema: z.object({ limit: z.number().int().min(1).default(10).describe("Top N connected") }),
+      },
       async ({ limit }) => {
         try {
           if (!config.enableCache) {
@@ -931,28 +1036,7 @@ export function registerGranularTools(
           if (!cache.getIsInitialized()) {
             return errorResult("[get_vault_structure] Cache is still building. Try again shortly.");
           }
-          const orphans = cache.getOrphanNotes();
-          const mostConnected = cache.getMostConnectedNotes(limit);
-          const graph = cache.getVaultGraph();
-
-          // Build directory tree summary
-          const dirs = new Set<string>();
-          for (const path of cache.getFileList()) {
-            const lastSlash = path.lastIndexOf("/");
-            if (lastSlash !== -1) {
-              dirs.add(path.slice(0, lastSlash));
-            }
-          }
-
-          return jsonResult({
-            noteCount: cache.noteCount,
-            linkCount: cache.linkCount,
-            directoryCount: dirs.size,
-            orphanCount: orphans.length,
-            orphans: orphans.slice(0, 20),
-            mostConnected,
-            edgeCount: graph.edges.length,
-          });
+          return buildVaultStructure(cache, limit);
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "get_vault_structure" }));
         }
@@ -963,10 +1047,12 @@ export function registerGranularTools(
 
   // --- 37. get_note_connections ---
   if (shouldRegister("get_note_connections")) {
-    server.tool(
+    server.registerTool(
       "get_note_connections",
-      "Get backlinks and forward links for a note",
-      { filePath: z.string().describe("File path") },
+      {
+        description: "Get backlinks and forward links for a note",
+        inputSchema: z.object({ filePath: z.string().describe("File path") }),
+      },
       async ({ filePath }) => {
         try {
           if (!config.enableCache) {
@@ -988,10 +1074,11 @@ export function registerGranularTools(
 
   // --- 38. refresh_cache (PROTECTED) ---
   if (shouldRegister("refresh_cache")) {
-    server.tool(
+    server.registerTool(
       "refresh_cache",
-      "Force refresh vault cache and link graph",
-      {},
+      {
+        description: "Force refresh vault cache and link graph",
+      },
       async () => {
         try {
           if (!config.enableCache) {

--- a/src/tools/granular.ts
+++ b/src/tools/granular.ts
@@ -214,7 +214,7 @@ function registerVaultTools(
           } else {
             pattern = new RegExp(escapeRegex(search), flags);
           }
-          const updated = result.replace(pattern, replace);
+          const updated = useRegex ? result.replace(pattern, replace) : result.replace(pattern, () => replace);
           if (updated === result) return textResult(`No matches found for "${search}" in ${filePath}`);
           await client.putContent(filePath, updated);
           return textResult(`Replaced in: ${filePath}`);
@@ -937,6 +937,9 @@ function registerSystemAndAnalysisTools(
         try {
           if (!config.enableCache) return errorResult("[refresh_cache] Cache is disabled. Set OBSIDIAN_ENABLE_CACHE=true");
           await cache.refresh();
+          if (!cache.getIsInitialized()) {
+            return errorResult("[refresh_cache] Cache refresh failed — Obsidian may be unreachable");
+          }
           return textResult(`Cache refreshed: ${String(cache.noteCount)} notes, ${String(cache.linkCount)} links`);
         } catch (err: unknown) {
           return errorResult(buildErrorMessage(err, { tool: "refresh_cache" }));

--- a/src/tools/granular.ts
+++ b/src/tools/granular.ts
@@ -205,7 +205,7 @@ function registerVaultTools(
       },
       async ({ filePath, search, replace, useRegex, caseSensitive, replaceAll }) => {
         try {
-          const result = await client.getFileContents(filePath, "markdown");
+          const result = await client.getFileContents(filePath, "markdown", true);
           if (typeof result !== "string") return errorResult("[search_replace] Expected markdown content");
           const flags = `${caseSensitive ? "" : "i"}${replaceAll ? "g" : ""}`;
           const pattern = useRegex ? new RegExp(search, flags) : new RegExp(escapeRegex(search), flags);

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -46,11 +46,12 @@ function parseBoolValue(value: string): boolean | undefined {
  * Parses a positive integer string value.
  * @param value - The string to parse.
  * @param min - The minimum acceptable value.
- * @returns The parsed number, or undefined if invalid.
+ * @returns The parsed number, or undefined if invalid (empty, decimal, non-finite, or below min).
  */
 function parsePosIntValue(value: string, min: number): number | undefined {
+  if (value.trim() === "") return undefined;
   const n = Number(value);
-  if (!Number.isFinite(n) || n < min) return undefined;
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < min) return undefined;
   return n;
 }
 
@@ -291,6 +292,8 @@ export async function handleRecentPeriodicNotes(
   limit: number,
 ): Promise<ToolResult> {
   const { files } = await client.listFilesInVault();
+  // Folder names are Obsidian defaults — the REST API does not expose user-configured paths.
+  // Users with custom folder names should use get_periodic_note_for_date instead.
   const periodDirs: Record<string, string> = {
     daily: "Daily Notes",
     weekly: "Weekly Notes",
@@ -306,7 +309,7 @@ export async function handleRecentPeriodicNotes(
   return jsonResult(periodFiles);
 }
 
-// --- Batch file fetch (path-preserving) ---
+// --- Batch file fetch (path-preserving, concurrency-capped) ---
 
 /** Result entry for a single file in a batch fetch operation. */
 interface BatchFileResult {
@@ -315,9 +318,12 @@ interface BatchFileResult {
   readonly error?: string;
 }
 
+/** Batch size for concurrent API calls in batchGetFiles. */
+const BATCH_GET_BATCH_SIZE = 20;
+
 /**
- * Fetches multiple vault files in parallel, preserving the file path even on rejection.
- * Each promise wraps its own error so allSettled never loses the `fp` variable.
+ * Fetches multiple vault files in parallel with a concurrency cap.
+ * Each per-file error is caught individually so one failure does not abort the batch.
  * @param client - The Obsidian API client.
  * @param filePaths - The list of file paths to fetch.
  * @param format - The response format (markdown, json, or map).
@@ -328,18 +334,21 @@ export async function batchGetFiles(
   filePaths: readonly string[],
   format: "markdown" | "json" | "map" | undefined,
 ): Promise<BatchFileResult[]> {
-  const results = await Promise.allSettled(
-    filePaths.map(async (fp): Promise<BatchFileResult> => {
-      try {
-        const content = await client.getFileContents(fp, format);
-        return { path: fp, content };
-      } catch (err: unknown) {
-        const reason = err instanceof Error ? err.message : String(err);
-        return { path: fp, error: reason };
-      }
-    }),
-  );
-  return results
-    .filter((r): r is PromiseFulfilledResult<BatchFileResult> => r.status === "fulfilled")
-    .map((r) => r.value);
+  const output: BatchFileResult[] = [];
+  for (let i = 0; i < filePaths.length; i += BATCH_GET_BATCH_SIZE) {
+    const batch = filePaths.slice(i, i + BATCH_GET_BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map(async (fp): Promise<BatchFileResult> => {
+        try {
+          const content = await client.getFileContents(fp, format);
+          return { path: fp, content };
+        } catch (err: unknown) {
+          const reason = err instanceof Error ? err.message : String(err);
+          return { path: fp, error: reason };
+        }
+      }),
+    );
+    output.push(...results);
+  }
+  return output;
 }

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -1,3 +1,5 @@
+import { resolve } from "node:path";
+
 import type { NoteJson, DocumentMap, ToolResult, ObsidianClient } from "../obsidian.js";
 import { textResult, errorResult, jsonResult } from "../obsidian.js";
 import type { VaultCache } from "../cache.js";
@@ -153,7 +155,7 @@ export function handleConfigureSet(
   if (!immediateSettings.has(setting) && !restartSettings.has(setting)) {
     return errorResult(`[configure] Unknown setting: ${setting}. Available: ${[...immediateSettings, ...restartSettings].join(", ")}`);
   }
-  const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
+  const configPath = config.configFilePath ?? resolve("obsidian-mcp.config.json");
   const updates = buildConfigUpdate(setting, value);
   if (updates === undefined) {
     return errorResult(`[configure] Invalid value "${value}" for setting "${setting}"`);
@@ -174,7 +176,7 @@ export function handleConfigureSet(
  */
 export function handleConfigureReset(setting: string | undefined, config: Config): ToolResult {
   if (!setting) return errorResult("[configure] Setting name is required for 'reset' action");
-  const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
+  const configPath = config.configFilePath ?? resolve("obsidian-mcp.config.json");
   const resetUpdates = buildConfigReset(setting);
   if (resetUpdates === undefined) {
     return errorResult(`[configure] Unknown setting: ${setting}`);

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -194,6 +194,9 @@ export function handleConfigureReset(setting: string | undefined, config: Config
  * @returns A JSON tool result with the redacted config.
  */
 export function handleConfigureShow(config: Config): ToolResult {
+  // Note: config is the startup snapshot. Live runtime changes (e.g. debug toggle)
+  // are not reflected here — they take effect on the process but this shows the
+  // persisted config. A restart will pick up any file-based changes.
   return jsonResult(getRedactedConfig(config));
 }
 
@@ -210,10 +213,14 @@ export function buildVaultStructure(cache: VaultCache, limit: number): ToolResul
   const mostConnected = cache.getMostConnectedNotes(limit);
   const graph = cache.getVaultGraph();
   const dirs = new Set<string>();
-  for (const path of cache.getFileList()) {
-    const lastSlash = path.lastIndexOf("/");
-    if (lastSlash !== -1) {
-      dirs.add(path.slice(0, lastSlash));
+  for (const p of cache.getFileList()) {
+    let dir = p;
+    while (true) {
+      const lastSlash = dir.lastIndexOf("/");
+      if (lastSlash === -1) break;
+      dir = dir.slice(0, lastSlash);
+      if (dirs.has(dir)) break; // already added this and all parents
+      dirs.add(dir);
     }
   }
   return jsonResult({

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -1,0 +1,341 @@
+import type { NoteJson, DocumentMap, ToolResult } from "../obsidian.js";
+import { textResult, errorResult, jsonResult } from "../obsidian.js";
+import type { ObsidianClient } from "../obsidian.js";
+import type { VaultCache } from "../cache.js";
+import type { Config } from "../config.js";
+import { getRedactedConfig, saveConfigToFile, setDebugEnabled, log } from "../config.js";
+
+// --- File content formatting ---
+
+/**
+ * Formats file contents for display, handling markdown, JSON, and map formats.
+ * @param result - The raw file content from the API.
+ * @returns A text or JSON tool result.
+ */
+export function formatFileContents(result: string | NoteJson | DocumentMap): ReturnType<typeof textResult> {
+  if (typeof result === "string") {
+    return textResult(result);
+  }
+  return jsonResult(result);
+}
+
+// --- Regex helpers ---
+
+/**
+ * Escapes a string for use as a literal in a RegExp.
+ * @param str - The string to escape.
+ * @returns Escaped string safe for use in `new RegExp(...)`.
+ */
+export function escapeRegex(str: string): string {
+  return str.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+// --- Config value parsers ---
+
+/**
+ * Parses a boolean string value.
+ * @param value - The string to parse ("true" or "false").
+ * @returns The boolean value, or undefined if invalid.
+ */
+export function parseBoolValue(value: string): boolean | undefined {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
+}
+
+/**
+ * Parses a positive integer string value.
+ * @param value - The string to parse.
+ * @param min - The minimum acceptable value.
+ * @returns The parsed number, or undefined if invalid.
+ */
+export function parsePosIntValue(value: string, min: number): number | undefined {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < min) return undefined;
+  return n;
+}
+
+// --- Configure helpers ---
+
+/**
+ * Builds a config file update object for a given setting and value.
+ * @param setting - The setting name to update.
+ * @param value - The new string value.
+ * @returns A partial config update object, or undefined if the value is invalid.
+ */
+export function buildConfigUpdate(setting: string, value: string): Record<string, unknown> | undefined {
+  switch (setting) {
+    case "debug": {
+      const b = parseBoolValue(value);
+      return b === undefined ? undefined : { debug: b };
+    }
+    case "timeout": {
+      const n = parsePosIntValue(value, 1);
+      return n === undefined ? undefined : { reliability: { timeout: n } };
+    }
+    case "verifyWrites": {
+      const b = parseBoolValue(value);
+      return b === undefined ? undefined : { reliability: { verifyWrites: b } };
+    }
+    case "maxResponseChars": {
+      const n = parsePosIntValue(value, 0);
+      return n === undefined ? undefined : { reliability: { maxResponseChars: n } };
+    }
+    case "toolMode":
+      if (value !== "granular" && value !== "consolidated") return undefined;
+      return { tools: { mode: value } };
+    case "toolPreset":
+      if (value !== "full" && value !== "read-only" && value !== "minimal" && value !== "safe") return undefined;
+      return { tools: { preset: value } };
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Builds a config file update that resets a setting to its default value.
+ * @param setting - The setting name to reset.
+ * @returns A partial config update object, or undefined for unknown settings.
+ */
+export function buildConfigReset(setting: string): Record<string, unknown> | undefined {
+  switch (setting) {
+    case "debug":
+      return { debug: false };
+    case "timeout":
+      return { reliability: { timeout: 30000 } };
+    case "verifyWrites":
+      return { reliability: { verifyWrites: false } };
+    case "maxResponseChars":
+      return { reliability: { maxResponseChars: 500000 } };
+    case "toolMode":
+      return { tools: { mode: "granular" } };
+    case "toolPreset":
+      return { tools: { preset: "full" } };
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Applies an immediate-effect setting change to the running process.
+ * Only `debug` takes effect without a restart; all other settings require a restart.
+ * @param setting - The setting name being changed.
+ * @param value - The new string value.
+ */
+export function applyImmediateSetting(setting: string, value: string): void {
+  if (setting === "debug") {
+    setDebugEnabled(value === "true");
+    log("info", `Debug logging ${value === "true" ? "enabled" : "disabled"}`);
+  }
+}
+
+/**
+ * Handles the configure "set" action — validates, saves, and applies the setting.
+ * Only `debug` takes effect immediately; all other settings require a restart.
+ * @param setting - The setting name to change.
+ * @param value - The new value string.
+ * @param config - The active config object (for file path lookup).
+ * @returns A tool result describing success or the validation error.
+ */
+export function handleConfigureSet(
+  setting: string | undefined,
+  value: string | undefined,
+  config: Config,
+): ToolResult {
+  if (!setting) {
+    return errorResult("[configure] Setting name is required for 'set' action");
+  }
+  if (value === undefined) {
+    return errorResult("[configure] Value is required for 'set' action");
+  }
+  const immediateSettings = new Set(["debug"]);
+  const restartSettings = new Set(["timeout", "verifyWrites", "maxResponseChars", "toolMode", "toolPreset"]);
+  if (!immediateSettings.has(setting) && !restartSettings.has(setting)) {
+    return errorResult(`[configure] Unknown setting: ${setting}. Available: ${[...immediateSettings, ...restartSettings].join(", ")}`);
+  }
+  const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
+  const updates = buildConfigUpdate(setting, value);
+  if (updates === undefined) {
+    return errorResult(`[configure] Invalid value "${value}" for setting "${setting}"`);
+  }
+  saveConfigToFile(configPath, updates);
+  if (immediateSettings.has(setting)) {
+    applyImmediateSetting(setting, value);
+    return textResult(`Setting "${setting}" updated to "${value}" (effective immediately)`);
+  }
+  return textResult(`Setting "${setting}" saved to config file. Restart the server for this change to take effect.`);
+}
+
+/**
+ * Handles the configure "reset" action — resets a setting to its default value.
+ * @param setting - The setting name to reset.
+ * @param config - The active config object (for file path lookup).
+ * @returns A tool result describing success or the validation error.
+ */
+export function handleConfigureReset(setting: string | undefined, config: Config): ToolResult {
+  if (!setting) return errorResult("[configure] Setting name is required for 'reset' action");
+  const configPath = config.configFilePath ?? "./obsidian-mcp.config.json";
+  const resetUpdates = buildConfigReset(setting);
+  if (resetUpdates === undefined) {
+    return errorResult(`[configure] Unknown setting: ${setting}`);
+  }
+  saveConfigToFile(configPath, resetUpdates);
+  return textResult(`Setting "${setting}" reset to default in config file. Restart the server for this change to take effect.`);
+}
+
+/**
+ * Shows the current (redacted) configuration.
+ * @param config - The active config object.
+ * @returns A JSON tool result with the redacted config.
+ */
+export function handleConfigureShow(config: Config): ToolResult {
+  return jsonResult(getRedactedConfig(config));
+}
+
+// --- Vault structure ---
+
+/**
+ * Builds vault structure statistics from cache.
+ * @param cache - The vault cache instance.
+ * @param limit - Maximum number of most-connected notes to include.
+ * @returns A JSON tool result with vault stats.
+ */
+export function buildVaultStructure(cache: VaultCache, limit: number): ToolResult {
+  const orphans = cache.getOrphanNotes();
+  const mostConnected = cache.getMostConnectedNotes(limit);
+  const graph = cache.getVaultGraph();
+  const dirs = new Set<string>();
+  for (const path of cache.getFileList()) {
+    const lastSlash = path.lastIndexOf("/");
+    if (lastSlash !== -1) {
+      dirs.add(path.slice(0, lastSlash));
+    }
+  }
+  return jsonResult({
+    noteCount: cache.noteCount,
+    linkCount: cache.linkCount,
+    directoryCount: dirs.size,
+    orphanCount: orphans.length,
+    orphans: orphans.slice(0, 20),
+    mostConnected,
+    edgeCount: graph.edges.length,
+  });
+}
+
+// --- Recent changes (batched, cache-aware) ---
+
+/** Batch size for concurrent API calls in the cache-miss fallback path. */
+const RECENT_CHANGES_BATCH_SIZE = 20;
+
+/**
+ * Fetches recent changes using cache if available, or batched API calls as fallback.
+ * Batching is used to avoid unbounded concurrent calls on large vaults.
+ * @param client - The Obsidian API client.
+ * @param cache - The vault cache instance.
+ * @param config - The active config object.
+ * @param limit - Maximum number of results to return.
+ * @returns A JSON tool result with the most recently modified files.
+ */
+export async function handleRecentChanges(
+  client: ObsidianClient,
+  cache: VaultCache,
+  config: Config,
+  limit: number,
+): Promise<ToolResult> {
+  if (config.enableCache && cache.getIsInitialized()) {
+    const allNotes = cache.getAllNotes();
+    const sorted = [...allNotes]
+      .sort((a, b) => b.stat.mtime - a.stat.mtime)
+      .slice(0, limit)
+      .map((n) => ({ path: n.path, mtime: n.stat.mtime }));
+    return jsonResult(sorted);
+  }
+  const { files } = await client.listFilesInVault();
+  const mdFiles = files.filter((f) => f.toLowerCase().endsWith(".md"));
+  const withStats: Array<{ path: string; mtime: number }> = [];
+  for (let i = 0; i < mdFiles.length; i += RECENT_CHANGES_BATCH_SIZE) {
+    const batch = mdFiles.slice(i, i + RECENT_CHANGES_BATCH_SIZE);
+    const results = await Promise.allSettled(
+      batch.map(async (fp) => {
+        const result = await client.getFileContents(fp, "json");
+        if (typeof result !== "string" && "stat" in result) {
+          return { path: fp, mtime: result.stat.mtime };
+        }
+        return { path: fp, mtime: 0 };
+      }),
+    );
+    for (const r of results) {
+      if (r.status === "fulfilled") {
+        withStats.push(r.value);
+      }
+    }
+  }
+  const sorted = withStats.sort((a, b) => b.mtime - a.mtime).slice(0, limit);
+  return jsonResult(sorted);
+}
+
+/**
+ * Fetches recent periodic notes by listing the vault directory.
+ * @param client - The Obsidian API client.
+ * @param period - The period type (daily, weekly, etc.).
+ * @param limit - Maximum number of results to return.
+ * @returns A JSON tool result with the most recent periodic note paths.
+ */
+export async function handleRecentPeriodicNotes(
+  client: ObsidianClient,
+  period: string,
+  limit: number,
+): Promise<ToolResult> {
+  const { files } = await client.listFilesInVault();
+  const periodDirs: Record<string, string> = {
+    daily: "Daily Notes",
+    weekly: "Weekly Notes",
+    monthly: "Monthly Notes",
+    quarterly: "Quarterly Notes",
+    yearly: "Yearly Notes",
+  };
+  const dirName = periodDirs[period] ?? period;
+  const periodFiles = files
+    .filter((f) => f.startsWith(`${dirName}/`) && f.toLowerCase().endsWith(".md"))
+    .sort((a, b) => b.localeCompare(a))
+    .slice(0, limit);
+  return jsonResult(periodFiles);
+}
+
+// --- Batch file fetch (path-preserving) ---
+
+/** Result entry for a single file in a batch fetch operation. */
+export interface BatchFileResult {
+  readonly path: string;
+  readonly content?: unknown;
+  readonly error?: string;
+}
+
+/**
+ * Fetches multiple vault files in parallel, preserving the file path even on rejection.
+ * Each promise wraps its own error so allSettled never loses the `fp` variable.
+ * @param client - The Obsidian API client.
+ * @param filePaths - The list of file paths to fetch.
+ * @param format - The response format (markdown, json, or map).
+ * @returns An array of results, each with path and either content or error.
+ */
+export async function batchGetFiles(
+  client: ObsidianClient,
+  filePaths: readonly string[],
+  format: "markdown" | "json" | "map" | undefined,
+): Promise<BatchFileResult[]> {
+  const results = await Promise.allSettled(
+    filePaths.map(async (fp): Promise<BatchFileResult> => {
+      try {
+        const content = await client.getFileContents(fp, format);
+        return { path: fp, content };
+      } catch (err: unknown) {
+        const reason = err instanceof Error ? err.message : String(err);
+        return { path: fp, error: reason };
+      }
+    }),
+  );
+  return results
+    .filter((r): r is PromiseFulfilledResult<BatchFileResult> => r.status === "fulfilled")
+    .map((r) => r.value);
+}

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -180,6 +180,11 @@ export function handleConfigureReset(setting: string | undefined, config: Config
     return errorResult(`[configure] Unknown setting: ${setting}`);
   }
   saveConfigToFile(configPath, resetUpdates);
+  // Apply immediately for settings that take effect without restart
+  if (setting === "debug") {
+    applyImmediateSetting(setting, "false");
+    return textResult(`Setting "${setting}" reset to default (effective immediately)`);
+  }
   return textResult(`Setting "${setting}" reset to default in config file. Restart the server for this change to take effect.`);
 }
 

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -1,6 +1,5 @@
-import type { NoteJson, DocumentMap, ToolResult } from "../obsidian.js";
+import type { NoteJson, DocumentMap, ToolResult, ObsidianClient } from "../obsidian.js";
 import { textResult, errorResult, jsonResult } from "../obsidian.js";
-import type { ObsidianClient } from "../obsidian.js";
 import type { VaultCache } from "../cache.js";
 import type { Config } from "../config.js";
 import { getRedactedConfig, saveConfigToFile, setDebugEnabled, log } from "../config.js";
@@ -275,8 +274,8 @@ export async function handleRecentChanges(
       }
     }
   }
-  const sorted = withStats.sort((a, b) => b.mtime - a.mtime).slice(0, limit);
-  return jsonResult(sorted);
+  withStats.sort((a, b) => b.mtime - a.mtime);
+  return jsonResult(withStats.slice(0, limit));
 }
 
 /**

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -37,7 +37,7 @@ export function escapeRegex(str: string): string {
  * @param value - The string to parse ("true" or "false").
  * @returns The boolean value, or undefined if invalid.
  */
-export function parseBoolValue(value: string): boolean | undefined {
+function parseBoolValue(value: string): boolean | undefined {
   if (value === "true") return true;
   if (value === "false") return false;
   return undefined;
@@ -49,7 +49,7 @@ export function parseBoolValue(value: string): boolean | undefined {
  * @param min - The minimum acceptable value.
  * @returns The parsed number, or undefined if invalid.
  */
-export function parsePosIntValue(value: string, min: number): number | undefined {
+function parsePosIntValue(value: string, min: number): number | undefined {
   const n = Number(value);
   if (!Number.isFinite(n) || n < min) return undefined;
   return n;
@@ -63,7 +63,7 @@ export function parsePosIntValue(value: string, min: number): number | undefined
  * @param value - The new string value.
  * @returns A partial config update object, or undefined if the value is invalid.
  */
-export function buildConfigUpdate(setting: string, value: string): Record<string, unknown> | undefined {
+function buildConfigUpdate(setting: string, value: string): Record<string, unknown> | undefined {
   switch (setting) {
     case "debug": {
       const b = parseBoolValue(value);
@@ -97,7 +97,7 @@ export function buildConfigUpdate(setting: string, value: string): Record<string
  * @param setting - The setting name to reset.
  * @returns A partial config update object, or undefined for unknown settings.
  */
-export function buildConfigReset(setting: string): Record<string, unknown> | undefined {
+function buildConfigReset(setting: string): Record<string, unknown> | undefined {
   switch (setting) {
     case "debug":
       return { debug: false };
@@ -122,7 +122,7 @@ export function buildConfigReset(setting: string): Record<string, unknown> | und
  * @param setting - The setting name being changed.
  * @param value - The new string value.
  */
-export function applyImmediateSetting(setting: string, value: string): void {
+function applyImmediateSetting(setting: string, value: string): void {
   if (setting === "debug") {
     setDebugEnabled(value === "true");
     log("info", `Debug logging ${value === "true" ? "enabled" : "disabled"}`);
@@ -305,7 +305,7 @@ export async function handleRecentPeriodicNotes(
 // --- Batch file fetch (path-preserving) ---
 
 /** Result entry for a single file in a batch fetch operation. */
-export interface BatchFileResult {
+interface BatchFileResult {
   readonly path: string;
   readonly content?: unknown;
   readonly error?: string;

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -214,13 +214,12 @@ export function buildVaultStructure(cache: VaultCache, limit: number): ToolResul
   const graph = cache.getVaultGraph();
   const dirs = new Set<string>();
   for (const p of cache.getFileList()) {
-    let dir = p;
-    while (true) {
-      const lastSlash = dir.lastIndexOf("/");
-      if (lastSlash === -1) break;
-      dir = dir.slice(0, lastSlash);
-      if (dirs.has(dir)) break; // already added this and all parents
+    let lastSlash = p.lastIndexOf("/");
+    while (lastSlash !== -1) {
+      const dir = p.slice(0, lastSlash);
+      if (dirs.has(dir)) break; // this dir and all its parents are already tracked
       dirs.add(dir);
+      lastSlash = dir.lastIndexOf("/");
     }
   }
   return jsonResult({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       reporter: ["text", "lcov", "json-summary"],
       reportsDirectory: "coverage",
       include: ["src/**/*.ts"],
-      exclude: ["src/index.ts", "src/tools/**", "src/tools.ts"],
+      exclude: ["src/index.ts"],
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
## Summary

- **38 granular tools** and **11 consolidated tools** covering 100% of the Obsidian Local REST API
- **Mode dispatcher** (`tools.ts`) with presets (`full`, `read-only`, `minimal`, `safe`), `INCLUDE_TOOLS`/`EXCLUDE_TOOLS` filtering, and protected tool preservation (`configure`, `status`, `refresh_cache`)
- **CLI flags**: `--setup` (interactive wizard), `--show-config`, `--validate` (connection test)
- Uses `server.registerTool()` (non-deprecated MCP SDK API)
- All cognitive complexity below Sonar's threshold of 15
- Zero Sonar issues, zero ESLint errors, 491 tests passing, 85%+ coverage

## Test plan

- [x] `npm run build` — zero TS errors
- [x] `npm run lint` — zero errors (4 expected warnings for non-literal RegExp in search_replace)
- [x] `npm run test` — 491 tests passing
- [x] `npm run test:coverage` — 85%+ overall
- [x] Sonar scan — zero issues
- [x] Granular mode: 38 tools registered (verified via JSON-RPC)
- [x] Consolidated mode: 11 tools registered
- [x] All presets verified: full/read-only/minimal/safe for both modes
- [x] Protected tools survive EXCLUDE_TOOLS filtering
- [x] `npx knip` — zero unused exports
- [x] `npx madge --circular` — zero circular deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive setup wizard plus --show-config (redacted) and --validate CLI commands
  * Option to fetch full file contents (no truncation)

* **New Features — Tools**
  * Full multi-tool support: vault and file operations, search, commands, periodic notes, recent changes, status/configure, analysis, batch fetches

* **Bug Fixes**
  * Some configuration changes now apply immediately with clearer behavior

* **Chores**
  * CI PR auto-detection improved; test/coverage now includes tool code
<!-- end of auto-generated comment: release notes by coderabbit.ai -->