### PR TITLE
chore: set process.title for Activity Monitor visibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { ObsidianClient } from "./obsidian.js";
 import { VaultCache } from "./cache.js";
 import { registerAllTools } from "./tools.js";
 
+process.title = "mcp-obsidian-extended";
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg: unknown = JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf-8"));
 const VERSION: string =


### PR DESCRIPTION
## Summary
- Adds `process.title = "mcp-obsidian-extended"` after imports in `src/index.ts`
- Makes the process identifiable in Activity Monitor / `ps` instead of showing as generic `node`

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] All 579 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated process initialization at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->