### PR TITLE
docs: update README for v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D22-brightgreen.svg)](https://nodejs.org/)
 
-Full-featured MCP server for Obsidian — 38 tools covering 100% of the [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api).
+Full-featured MCP server for Obsidian — 39 tools covering 100% of the [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api).
 
 ## Prerequisites
 
@@ -43,7 +43,22 @@ npx mcp-obsidian-extended --setup
 
 Interactive wizard that tests your connection, configures settings, and outputs the Claude Desktop JSON snippet.
 
-### Option 3: Desktop Extension
+### Option 3: Standalone Binary (no Node.js required)
+
+Download the platform binary from [Releases](https://github.com/adder-factory/mcp-obsidian-extended/releases):
+
+```json
+{
+  "mcpServers": {
+    "mcp-obsidian-extended": {
+      "command": "/path/to/mcp-obsidian-extended",
+      "env": { "OBSIDIAN_API_KEY": "your-api-key-here" }
+    }
+  }
+}
+```
+
+### Option 4: Desktop Extension
 
 Download the `.mcpb` file from [Releases](https://github.com/adder-factory/mcp-obsidian-extended/releases) and open it in Claude Desktop for one-click install.
 
@@ -51,10 +66,14 @@ Download the `.mcpb` file from [Releases](https://github.com/adder-factory/mcp-o
 
 This is a TypeScript rewrite of [mcp-obsidian](https://github.com/MarkusPfundstein/mcp-obsidian) with:
 
-- **100% REST API coverage** — 38 tools vs the original 7
-- **Dual tool mode** — granular (38 tools) or consolidated (11 tools, saves tokens)
+- **100% REST API coverage** — 39 tools vs the original 7
+- **Dual tool mode** — granular (39 tools) or consolidated (11 tools, saves tokens)
 - **Tool presets** — full, read-only, minimal, safe
 - **Tool filtering** — INCLUDE_TOOLS / EXCLUDE_TOOLS env vars
+- **LLM Skill resource** — `obsidian://skill` teaches LLMs best practices, adapts to tool mode and compact setting
+- **Compact responses** — abbreviate field names for token savings (`OBSIDIAN_COMPACT_RESPONSES=true`)
+- **Move/rename files** — `move_file` tool with conflict detection and partial-failure recovery
+- **Standalone binary** — `npm run build:sea` produces a binary that doesn't require Node.js
 - **Dataview DQL search** — query vault using the Dataview plugin
 - **Full periodic notes** — CRUD by current period and by specific date
 - **Vault cache + graph analysis** — backlinks, orphan detection, vault structure
@@ -65,7 +84,7 @@ This is a TypeScript rewrite of [mcp-obsidian](https://github.com/MarkusPfundste
 
 ## Tools
 
-### Granular Mode (38 tools, default)
+### Granular Mode (39 tools, default)
 
 | # | Tool | Description |
 |---|------|-------------|
@@ -77,36 +96,37 @@ This is a TypeScript rewrite of [mcp-obsidian](https://github.com/MarkusPfundste
 | 6 | `patch_content` | Insert at a heading, block, or frontmatter target |
 | 7 | `delete_file` | Delete a vault file to Obsidian trash (idempotent) |
 | 8 | `search_replace` | Find and replace text in a vault file |
-| 9 | `get_active_file` | Read the currently open file |
-| 10 | `put_active_file` | Replace content of the currently open file |
-| 11 | `append_active_file` | Append to the currently open file |
-| 12 | `patch_active_file` | Patch the active file at a target |
-| 13 | `delete_active_file` | Delete the currently open file |
-| 14 | `list_commands` | List all Obsidian command palette commands |
-| 15 | `execute_command` | Run an Obsidian command by ID |
-| 16 | `open_file` | Open a file in the Obsidian UI |
-| 17 | `simple_search` | Full-text search across all vault files |
-| 18 | `complex_search` | Search with JsonLogic queries (glob, regexp) |
-| 19 | `dataview_search` | Query vault using Dataview DQL |
-| 20 | `get_periodic_note` | Get the current periodic note |
-| 21 | `put_periodic_note` | Replace current periodic note content |
-| 22 | `append_periodic_note` | Append to current periodic note |
-| 23 | `patch_periodic_note` | Patch current periodic note at a target |
-| 24 | `delete_periodic_note` | Delete current periodic note |
-| 25 | `get_periodic_note_for_date` | Get periodic note for a specific date |
-| 26 | `put_periodic_note_for_date` | Replace periodic note for a date |
-| 27 | `append_periodic_note_for_date` | Append to periodic note for a date |
-| 28 | `patch_periodic_note_for_date` | Patch periodic note for a date |
-| 29 | `delete_periodic_note_for_date` | Delete periodic note for a date |
-| 30 | `get_server_status` | Check Obsidian API connection and version |
-| 31 | `batch_get_file_contents` | Read multiple vault files in one call |
-| 32 | `get_recent_changes` | Get recently modified files sorted by date |
-| 33 | `get_recent_periodic_notes` | Get recent periodic notes for a period type |
-| 34 | `configure` | View or change server settings |
-| 35 | `get_backlinks` | Get all notes that link to a file |
-| 36 | `get_vault_structure` | Vault stats: note count, links, orphans, most connected |
-| 37 | `get_note_connections` | Get backlinks and forward links for a note |
-| 38 | `refresh_cache` | Force refresh vault cache and link graph |
+| 9 | `move_file` | Move or rename a .md vault file |
+| 10 | `get_active_file` | Read the currently open file |
+| 11 | `put_active_file` | Replace content of the currently open file |
+| 12 | `append_active_file` | Append to the currently open file |
+| 13 | `patch_active_file` | Patch the active file at a target |
+| 14 | `delete_active_file` | Delete the currently open file |
+| 15 | `list_commands` | List all Obsidian command palette commands |
+| 16 | `execute_command` | Run an Obsidian command by ID |
+| 17 | `open_file` | Open a file in the Obsidian UI |
+| 18 | `simple_search` | Full-text search across all vault files |
+| 19 | `complex_search` | Search with JsonLogic queries (glob, regexp) |
+| 20 | `dataview_search` | Query vault using Dataview DQL |
+| 21 | `get_periodic_note` | Get the current periodic note |
+| 22 | `put_periodic_note` | Replace current periodic note content |
+| 23 | `append_periodic_note` | Append to current periodic note |
+| 24 | `patch_periodic_note` | Patch current periodic note at a target |
+| 25 | `delete_periodic_note` | Delete current periodic note |
+| 26 | `get_periodic_note_for_date` | Get periodic note for a specific date |
+| 27 | `put_periodic_note_for_date` | Replace periodic note for a date |
+| 28 | `append_periodic_note_for_date` | Append to periodic note for a date |
+| 29 | `patch_periodic_note_for_date` | Patch periodic note for a date |
+| 30 | `delete_periodic_note_for_date` | Delete periodic note for a date |
+| 31 | `get_server_status` | Check Obsidian API connection and version |
+| 32 | `batch_get_file_contents` | Read multiple vault files in one call |
+| 33 | `get_recent_changes` | Get recently modified files sorted by date |
+| 34 | `get_recent_periodic_notes` | Get recent periodic notes for a period type |
+| 35 | `configure` | View or change server settings |
+| 36 | `get_backlinks` | Get all notes that link to a file |
+| 37 | `get_vault_structure` | Vault stats: note count, links, orphans, most connected |
+| 38 | `get_note_connections` | Get backlinks and forward links for a note |
+| 39 | `refresh_cache` | Force refresh vault cache and link graph |
 
 ### Consolidated Mode (11 tools)
 
@@ -114,17 +134,17 @@ Combines related tools into multi-action tools. Reduces the tool list sent to th
 
 | # | Tool | Actions | Replaces |
 |---|------|---------|----------|
-| 1 | `vault` | list, list_dir, get, put, append, patch, delete, search_replace | Tools 1-8 |
-| 2 | `active_file` | get, put, append, patch, delete | Tools 9-13 |
-| 3 | `commands` | list, execute | Tools 14-15 |
-| 4 | `open_file` | — | Tool 16 |
-| 5 | `search` | simple, jsonlogic, dataview | Tools 17-19 |
-| 6 | `periodic_note` | get, put, append, patch, delete | Tools 20-29 |
-| 7 | `status` | — | Tool 30 |
-| 8 | `batch_get` | — | Tool 31 |
-| 9 | `recent` | changes, periodic_notes | Tools 32-33 |
-| 10 | `configure` | show, set, reset | Tool 34 |
-| 11 | `vault_analysis` | backlinks, connections, structure, refresh | Tools 35-38 |
+| 1 | `vault` | list, list_dir, get, put, append, patch, delete, search_replace, move | Tools 1-9 |
+| 2 | `active_file` | get, put, append, patch, delete | Tools 10-14 |
+| 3 | `commands` | list, execute | Tools 15-16 |
+| 4 | `open_file` | — | Tool 17 |
+| 5 | `search` | simple, jsonlogic, dataview | Tools 18-20 |
+| 6 | `periodic_note` | get, put, append, patch, delete | Tools 21-30 |
+| 7 | `status` | — | Tool 31 |
+| 8 | `batch_get` | — | Tool 32 |
+| 9 | `recent` | changes, periodic_notes | Tools 33-34 |
+| 10 | `configure` | show, set, reset | Tool 35 |
+| 11 | `vault_analysis` | backlinks, connections, structure, refresh | Tools 36-39 |
 
 Set `TOOL_MODE=consolidated` to enable.
 
@@ -134,10 +154,10 @@ Control which tools are available. Set via `TOOL_PRESET` env var.
 
 | Preset | Granular | Consolidated | Description |
 |--------|----------|-------------|-------------|
-| `full` | 38 tools | 11 tools, all actions | Everything (default) |
+| `full` | 39 tools | 11 tools, all actions | Everything (default) |
 | `read-only` | 19 tools | 10 tools, read actions only | No writes or deletes |
-| `minimal` | 7 tools | 4 tools | Essentials only |
-| `safe` | 34 tools | 11 tools, no delete action | Everything except deletes |
+| `minimal` | 8 tools | 4 tools | Essentials only |
+| `safe` | 35 tools | 11 tools, no delete action | Everything except deletes |
 
 ### Tool Filtering
 
@@ -178,6 +198,7 @@ Three-tier priority: **Defaults → Config file → Env vars** (env always wins)
 | `EXCLUDE_TOOLS` | — | Blacklist tool names (comma-separated) |
 | `OBSIDIAN_CACHE_TTL` | `600000` | Cache refresh interval ms (10 min) |
 | `OBSIDIAN_ENABLE_CACHE` | `true` | Enable/disable vault cache |
+| `OBSIDIAN_COMPACT_RESPONSES` | `false` | Abbreviate JSON field names for token savings |
 
 ### Config File
 
@@ -236,6 +257,18 @@ Get-Content "$env:APPDATA\Claude\Logs\mcp-server-mcp-obsidian-extended.log" -Wai
 - **Response truncation** — large files capped at 500K chars (configurable)
 - **Vault cache** — in-memory cache with auto-refresh, serves cached reads when offline
 - **Case-insensitive paths** — automatic fallback on 404 for mismatched case
+
+## LLM Skill Resource
+
+The server exposes an MCP resource at `obsidian://skill` — a dynamic usage guide that teaches LLMs how to use the tools effectively. Content adapts based on active tool mode (granular/consolidated) and compact response setting.
+
+Covers: golden rules, step-by-step workflows, error recovery, tool selection guide, known pitfalls, and (when applicable) consolidated action reference and compact field mapping.
+
+Also ships as `.claude/skills/obsidian-mcp/SKILL.md` for Claude Code users.
+
+## Compact Responses
+
+Set `OBSIDIAN_COMPACT_RESPONSES=true` to abbreviate JSON field names (`content`→`c`, `frontmatter`→`fm`, `path`→`p`, etc.) and strip JSON whitespace. Reduces token usage for large vault operations. Toggle at runtime via the `configure` tool without restart.
 
 ## Performance
 
@@ -325,7 +358,7 @@ Totals: 16,360 ops | p50=2ms | p95=37ms | 19.3MB heap stable | 6/6 pass
 |---------|----------------------|------------------------|------------------|-----------------|--------------|
 | Language | TypeScript | Python | TypeScript | TypeScript | TypeScript |
 | Install | npx / .mcpb | uvx (requires Python) | npx | npx | npx |
-| Tools | 38 granular / 11 consolidated | 7 | 8 | 14 (filesystem) | ~15 |
+| Tools | 39 granular / 11 consolidated | 7 | 8 | 14 (filesystem) | ~15 |
 | REST API coverage | 100% | ~20% | ~25% | 0% (filesystem) | ~40% |
 | Tool filtering | INCLUDE/EXCLUDE + presets | — | — | — | INCLUDE only |
 | Dual mode | granular + consolidated | — | — | — | — |
@@ -344,10 +377,11 @@ Totals: 16,360 ops | p50=2ms | p95=37ms | 19.3MB heap stable | 6/6 pass
 | CI/CD | GitHub Actions | — | — | — | — |
 | Known bugs | Fixed (7 upstream) | 50+ open issues | — | — | — |
 
-> mcp-obsidian-extended is a TypeScript rewrite of [mcp-obsidian](https://github.com/MarkusPfundstein/mcp-obsidian) by Markus Pfundstein, which pioneered the MCP server approach for Obsidian. We fix 7 upstream bugs and expand from 7 tools to 38 with full API coverage.
+> mcp-obsidian-extended is a TypeScript rewrite of [mcp-obsidian](https://github.com/MarkusPfundstein/mcp-obsidian) by Markus Pfundstein, which pioneered the MCP server approach for Obsidian. We fix 7 upstream bugs and expand from 7 tools to 39 with full API coverage.
 
 ## Known Limitations
 
+- **move_file is .md only:** Non-markdown files (images, PDFs) cannot be moved via the REST API content endpoint — the text round-trip would corrupt binary data. Wikilinks from other notes pointing to the moved file are not updated automatically.
 - **PATCH under concurrent writes:** When multiple writers restructure headings simultaneously, PATCH operations may fail to find their target. With automatic retry and document map refresh, success rate is 89.5% under extreme concurrent load (up from ~5% without retry). Under normal single-user usage, PATCH success is ~99%+. For heavy concurrent editing scenarios, prefer `search_replace` over `patch_content`.
 - **Dataview queries:** Only `TABLE` queries are supported by the Obsidian Local REST API. `LIST` queries are not supported — this is an upstream API limitation, not a server limitation. Use `TABLE` with column selection as a workaround.
 - **Cache rebuild contention:** During cache rebuilds on large vaults (500+ notes), read operations may experience brief timeouts (~0.05% of requests). The server handles this gracefully with automatic retries. Cache stampede is prevented — 20 concurrent callers share a single build with zero redundant builds.


### PR DESCRIPTION
## Summary

- Update tool count 38→39 throughout (move_file added as #9)
- Add standalone binary install option
- Add LLM Skill Resource and Compact Responses sections
- Add OBSIDIAN_COMPACT_RESPONSES to env var table
- Update consolidated vault tool with move action
- Update preset counts and comparison table
- Add move_file to Known Limitations

🤖 Generated with [Claude Code](https://claude.com/claude-code)