### PR TITLE
chore: propagate stryker-cache workflow from adder-pipeline-tools@4da91fb

### DIFF
--- a/.adder-pipeline/branch-protection.json
+++ b/.adder-pipeline/branch-protection.json
@@ -3,8 +3,9 @@
     "strict": true,
     "contexts": [
       "Pipeline gate",
-      "CodeRabbit Pull Request Review",
-      "CodeAnt AI"
+      "CodeRabbit",
+      "build (22)",
+      "build (24)"
     ]
   },
   "enforce_admins": false,

--- a/.adder-pipeline/installed.json
+++ b/.adder-pipeline/installed.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
-  "installed_at": "2026-04-23T22:50:26Z",
-  "git_commit": "396bc5dc51e873228bd87464e1b7869fd6f6ade2",
+  "installed_at": "2026-04-24T01:39:30Z",
+  "git_commit": "4da91fb1c3b09613373409c3c3b151cbe2f98788",
   "components": {
     "scripts": true,
     "package_json": true,

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -54,6 +54,29 @@ jobs:
       - name: Tests + coverage
         run: npm test -- --coverage
 
+      # Stryker --incremental reads/writes reports/stryker-incremental.json.
+      # Without this cache, every CI run is cold (~15-20 min on a typical repo)
+      # because the file is gone between runs. Restore-keys fall back to the
+      # base branch cache, then to any cache for the OS, so a feature branch's
+      # first run still benefits from main's most recent cache.
+      - name: Restore Stryker incremental cache
+        id: stryker_cache
+        if: ${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') != '' }}
+        uses: actions/cache@v4
+        with:
+          path: reports/stryker-incremental.json
+          key: stryker-incremental-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            stryker-incremental-${{ runner.os }}-${{ github.ref_name }}-
+            stryker-incremental-${{ runner.os }}-main-
+            stryker-incremental-${{ runner.os }}-
+
+      # Surface cache hit/miss in CI logs — Phase 5 doctor.sh hit-rate
+      # monitoring reads this signal directly from workflow output.
+      - name: Stryker cache stats
+        if: ${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') != '' }}
+        run: 'echo "Stryker incremental cache hit: ${{ steps.stryker_cache.outputs.cache-hit }}"'
+
       - name: Stryker
         if: ${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') != '' }}
         run: npx stryker run --incremental


### PR DESCRIPTION
## **User description**
## Summary

- Propagates the **Stryker incremental cache** workflow change from [adder-pipeline-tools#6](https://github.com/adder-factory/adder-pipeline-tools/pull/6) (`actions/cache@v4` keyed on `runner.os + ref + sha` with fallback chain, plus a `Stryker cache stats` step echoing cache-hit). After this lands and one cold CI run populates the cache, all subsequent CI Stryker runs on this repo should drop from **~16 min** (observed on PR #16's fixup) to **~30s**.
- Pipeline SHA bump in `installed.json`: `396bc5d` → `4da91fb` (covers adder-pipeline-tools PRs #5 and #6 — branch-protection contexts realignment and the Stryker cache template).
- `.adder-pipeline/branch-protection.json` updated by the installer to match the new template (`CodeRabbit` / `build (22)` / `build (24)`) — purely a bookkeeping sync; the live branch protection on `main` already reflects these contexts via the `gh api PUT` applied during Phase 4 pre-flight.

## Installer regression noted (out of scope for this PR)

The installer also re-added `"scripts/**"` to `knip.json` `ignore` — the exact regression PR #16 fixed. Reverted locally in this PR. Upstream fix tracked as a post-Phase-4 follow-up against adder-pipeline-tools to remove the broad ignore from the installer's append-list.

## Local gate results

`npm run pre-pr -- --skip-qwen`:

| Gate | Time | Result |
|---|---:|:---:|
| Prettier | 1s | ✓ |
| ESLint | 1s | ✓ |
| tsc | 1s | ✓ |
| knip | 0s | ✓ |
| Tests + coverage | 8s | ✓ |
| Stryker | 9s | ✓ (mutation score 56.78, ≥ baseline 55) |
| SonarQube | 6s | ✓ |
| Gitleaks | 0s | ✓ |
| Madge | 1s | ✓ |
| Semgrep | 4s | ✓ |
| Qwen review | 0s | SKIP |
| **Total** | **31s** | **PASS** |

## Test plan

- [ ] CI green (`Pipeline gate`, `CodeRabbit`, `build (22)`, `build (24)`)
- [ ] First CI run after merge: cold Stryker (~16-20 min, populates cache)
- [ ] Second CI run after merge: warm Stryker (~30s, demonstrates cache hit)
- [ ] `Stryker cache stats` step shows `cache-hit: true` in second-run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch protection status checks for pull requests
  * Improved CI/CD pipeline performance by implementing caching to retain incremental state between workflow runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Speed up repeated Stryker runs in CI and show cache status in logs

### What Changed
- CI now restores and saves Stryker’s incremental report cache, so repeat runs can reuse prior results instead of starting from scratch
- The cache falls back to the main branch and other recent OS caches, which helps feature branches benefit on their first run
- CI logs now print whether the Stryker cache was a hit or miss
- Pipeline metadata and required check names were updated to match the current workflow setup

### Impact
`✅ Faster Stryker checks in CI`
`✅ Shorter feedback time on repeat builds`
`✅ Clearer cache-hit visibility in logs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=NphvLvhhtlhHsDxg3ZRbA4ZobopoKU46hzHGG0VNkrg&org=adder-factory)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
