### PR TITLE
test(tools): assert MCP tool metadata (descriptions + Zod .describe()) — closes #15

### DIFF
--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -426,6 +426,138 @@ describe("registerAllTools — consolidated mode", () => {
 });
 
 // ===========================================================================
+// Section 1.5: tool metadata (descriptions + Zod .describe() hints)
+// ===========================================================================
+//
+// Issue #15. Stryker mutation testing surfaced ~25 surviving StringLiteral
+// mutants on src/tools/granular.ts L43–L1079: descriptions + .describe() hints
+// could be mutated to "" without any test catching it. MCP description text
+// and Zod .describe() are the primary signals an LLM uses to pick the right
+// tool and fill its parameters; a blank one ships a tool the model can't find
+// or a parameter it fills wrong. These tests assert the contract regardless
+// of mode/preset.
+
+describe("tool metadata — descriptions and schema hints", () => {
+  // Recognized verb prefixes. Comma-separated openers ("Read, write, search…")
+  // match because the first word is a verb. Tools whose descriptions open with
+  // a noun-category instead of a verb stay in VERB_OPENER_ALLOWLIST — keep that
+  // set narrow; adding a name here is a deliberate exception to the contract.
+  const VERB_PREFIX_RE =
+    /^(List|Get|Read|Put|Append|Patch|Delete|Replace|Move|Search|Run|Execute|Check|Force|Refresh|Create|Configure|Analyze|Insert|Open|Find|View|Query|CRUD)\b/;
+  const VERB_OPENER_ALLOWLIST = new Set<string>([
+    // vault_analysis opens with "Backlinks, connections, structure…" — it
+    // describes a category of read-only inspections, not a single action.
+    "vault_analysis",
+    // simple_search opens with "Full-text search across all vault files…" —
+    // the noun-modifier describes the search variety; rewriting to "Search…"
+    // would lose the disambiguation from complex_search / dataview_search.
+    "simple_search",
+  ]);
+
+  // Duck-type the captured inputSchema (a ZodObject) without importing zod.
+  // ZodObject exposes .shape: Record<string, ZodTypeAny>; each ZodTypeAny
+  // exposes .description: string | undefined (set via .describe()).
+  //
+  // Zod wraps optional/nullable/default by *replacing* the outer schema with a
+  // new wrapper whose .description is undefined unless .describe() was called
+  // on the wrapper itself. The convention in this codebase is mixed: some
+  // fields use `.optional().describe(...)` (description on outer), others use
+  // `someSharedSchema.optional()` (description on inner). Both are valid; the
+  // walker descends through _def.innerType (ZodOptional/ZodNullable/ZodDefault)
+  // and _def.type (ZodArray) to find the first non-empty description.
+  function getZodDescription(node: unknown): string | undefined {
+    if (!node || typeof node !== "object") return undefined;
+    const obj = node as {
+      description?: string;
+      _def?: { innerType?: unknown; type?: unknown };
+    };
+    if (typeof obj.description === "string" && obj.description.length > 0) {
+      return obj.description;
+    }
+    if (obj._def?.innerType) return getZodDescription(obj._def.innerType);
+    if (obj._def?.type) return getZodDescription(obj._def.type);
+    return undefined;
+  }
+
+  function inputFieldDescriptions(
+    schema: Record<string, unknown>,
+  ): Array<[string, string | undefined]> {
+    const inputSchema = (schema as { inputSchema?: unknown }).inputSchema;
+    if (
+      !inputSchema ||
+      typeof inputSchema !== "object" ||
+      !("shape" in inputSchema)
+    ) {
+      return [];
+    }
+    const shape = (inputSchema as { shape: Record<string, unknown> }).shape;
+    return Object.entries(shape).map(([fieldName, fieldType]) => [
+      fieldName,
+      getZodDescription(fieldType),
+    ]);
+  }
+
+  function enumerateAllTools(
+    toolMode: "granular" | "consolidated",
+  ): CapturedTool[] {
+    const { server, getRegistered, getTool } = makeMockServer();
+    const client = makeMockClient();
+    const cache = makeMockCache();
+    registerAllTools(
+      server as never,
+      client,
+      cache,
+      makeConfig({ toolMode, toolPreset: "full" }),
+    );
+    return getRegistered().map(getTool);
+  }
+
+  for (const mode of ["granular", "consolidated"] as const) {
+    describe(`${mode} mode (preset: full)`, () => {
+      it("every tool has a non-empty description ≥ 10 chars", () => {
+        const tools = enumerateAllTools(mode);
+        expect(tools.length).toBeGreaterThan(0);
+        for (const t of tools) {
+          expect(typeof t.description, `${t.name}: description type`).toBe(
+            "string",
+          );
+          expect(
+            t.description.trim().length,
+            `${t.name}: description length`,
+          ).toBeGreaterThanOrEqual(10);
+        }
+      });
+
+      it("every tool description starts with a recognized verb (or is allowlisted)", () => {
+        const tools = enumerateAllTools(mode);
+        for (const t of tools) {
+          if (VERB_OPENER_ALLOWLIST.has(t.name)) continue;
+          expect(t.description, `${t.name}: description verb prefix`).toMatch(
+            VERB_PREFIX_RE,
+          );
+        }
+      });
+
+      it("every Zod schema field has a non-empty .describe() text ≥ 3 chars", () => {
+        const tools = enumerateAllTools(mode);
+        for (const t of tools) {
+          for (const [fieldName, desc] of inputFieldDescriptions(t.schema)) {
+            expect(
+              typeof desc,
+              `${t.name}.${fieldName}: .describe() type`,
+            ).toBe("string");
+            expect(
+              (desc ?? "").trim().length,
+              `${t.name}.${fieldName}: .describe() length`,
+            ).toBeGreaterThanOrEqual(3);
+          }
+        }
+      });
+    });
+  }
+});
+
+// ===========================================================================
 // Section 2: granular.ts tool handlers
 // ===========================================================================
 

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -442,8 +442,12 @@ describe("tool metadata — descriptions and schema hints", () => {
   // match because the first word is a verb. Tools whose descriptions open with
   // a noun-category instead of a verb stay in VERB_OPENER_ALLOWLIST — keep that
   // set narrow; adding a name here is a deliberate exception to the contract.
+  // Verb set is liberal by design — adding a verb here is cheap, but failing
+  // a real PR for a legitimately verb-led description (e.g., a future "Rename"
+  // tool) is an annoying yak-shave. New verbs added on each Phase 4 reviewer
+  // pass; extend further if a future tool surfaces a missing one.
   const VERB_PREFIX_RE =
-    /^(List|Get|Read|Put|Append|Patch|Delete|Replace|Move|Search|Run|Execute|Check|Force|Refresh|Create|Configure|Analyze|Insert|Open|Find|View|Query|CRUD)\b/;
+    /^(List|Get|Read|Put|Append|Patch|Delete|Replace|Move|Search|Run|Execute|Check|Force|Refresh|Create|Configure|Analyze|Insert|Open|Find|View|Query|Update|Toggle|Enable|Disable|Rename|Copy|CRUD)\b/;
   const VERB_OPENER_ALLOWLIST = new Set<string>([
     // vault_analysis opens with "Backlinks, connections, structure…" — it
     // describes a category of read-only inspections, not a single action.
@@ -458,24 +462,44 @@ describe("tool metadata — descriptions and schema hints", () => {
   // ZodObject exposes .shape: Record<string, ZodTypeAny>; each ZodTypeAny
   // exposes .description: string | undefined (set via .describe()).
   //
-  // Zod wraps optional/nullable/default by *replacing* the outer schema with a
-  // new wrapper whose .description is undefined unless .describe() was called
-  // on the wrapper itself. The convention in this codebase is mixed: some
-  // fields use `.optional().describe(...)` (description on outer), others use
-  // `someSharedSchema.optional()` (description on inner). Both are valid; the
-  // walker descends through _def.innerType (ZodOptional/ZodNullable/ZodDefault)
-  // and _def.type (ZodArray) to find the first non-empty description.
+  // Zod wraps optional/nullable/default/effects by *replacing* the outer
+  // schema with a new wrapper whose .description is undefined unless
+  // .describe() was called on the wrapper itself. The convention in this
+  // codebase is mixed: some fields use `.optional().describe(...)`
+  // (description on outer), others use `someSharedSchema.optional()`
+  // (description on inner). Both are valid; the walker descends through
+  // _def.innerType (ZodOptional/ZodNullable/ZodDefault), _def.type
+  // (ZodArray), and _def.schema (ZodEffects from .refine()/.transform()) to
+  // find the first non-empty description.
   function getZodDescription(node: unknown): string | undefined {
     if (!node || typeof node !== "object") return undefined;
     const obj = node as {
       description?: string;
-      _def?: { innerType?: unknown; type?: unknown };
+      _def?: { innerType?: unknown; type?: unknown; schema?: unknown };
     };
     if (typeof obj.description === "string" && obj.description.length > 0) {
       return obj.description;
     }
     if (obj._def?.innerType) return getZodDescription(obj._def.innerType);
     if (obj._def?.type) return getZodDescription(obj._def.type);
+    if (obj._def?.schema) return getZodDescription(obj._def.schema);
+    return undefined;
+  }
+
+  // Unwrap the captured inputSchema until a ZodObject (with .shape) surfaces.
+  // Mirrors getZodDescription's traversal so a top-level .refine()/.transform()
+  // wrapping the object schema doesn't silently skip field assertions.
+  function unwrapToZodObject(
+    node: unknown,
+  ): { shape: Record<string, unknown> } | undefined {
+    if (!node || typeof node !== "object") return undefined;
+    if ("shape" in node) {
+      return node as { shape: Record<string, unknown> };
+    }
+    const def = (node as { _def?: { innerType?: unknown; schema?: unknown } })
+      ._def;
+    if (def?.innerType) return unwrapToZodObject(def.innerType);
+    if (def?.schema) return unwrapToZodObject(def.schema);
     return undefined;
   }
 
@@ -483,15 +507,9 @@ describe("tool metadata — descriptions and schema hints", () => {
     schema: Record<string, unknown>,
   ): Array<[string, string | undefined]> {
     const inputSchema = (schema as { inputSchema?: unknown }).inputSchema;
-    if (
-      !inputSchema ||
-      typeof inputSchema !== "object" ||
-      !("shape" in inputSchema)
-    ) {
-      return [];
-    }
-    const shape = (inputSchema as { shape: Record<string, unknown> }).shape;
-    return Object.entries(shape).map(([fieldName, fieldType]) => [
+    const unwrapped = unwrapToZodObject(inputSchema);
+    if (!unwrapped) return [];
+    return Object.entries(unwrapped.shape).map(([fieldName, fieldType]) => [
       fieldName,
       getZodDescription(fieldType),
     ]);

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -473,16 +473,20 @@ describe("tool metadata — descriptions and schema hints", () => {
   // find the first non-empty description.
   function getZodDescription(node: unknown): string | undefined {
     if (!node || typeof node !== "object") return undefined;
-    const obj = node as {
-      description?: string;
-      _def?: { innerType?: unknown; type?: unknown; schema?: unknown };
-    };
-    if (typeof obj.description === "string" && obj.description.length > 0) {
-      return obj.description;
+    if (
+      "description" in node &&
+      typeof node.description === "string" &&
+      node.description.length > 0
+    ) {
+      return node.description;
     }
-    if (obj._def?.innerType) return getZodDescription(obj._def.innerType);
-    if (obj._def?.type) return getZodDescription(obj._def.type);
-    if (obj._def?.schema) return getZodDescription(obj._def.schema);
+    if (!("_def" in node) || !node._def || typeof node._def !== "object") {
+      return undefined;
+    }
+    const def = node._def;
+    if ("innerType" in def) return getZodDescription(def.innerType);
+    if ("type" in def) return getZodDescription(def.type);
+    if ("schema" in def) return getZodDescription(def.schema);
     return undefined;
   }
 
@@ -491,25 +495,29 @@ describe("tool metadata — descriptions and schema hints", () => {
   // wrapping the object schema doesn't silently skip field assertions.
   function unwrapToZodObject(
     node: unknown,
-  ): { shape: Record<string, unknown> } | undefined {
+  ): Record<string, unknown> | undefined {
     if (!node || typeof node !== "object") return undefined;
-    if ("shape" in node) {
-      return node as { shape: Record<string, unknown> };
+    if ("shape" in node && node.shape && typeof node.shape === "object") {
+      // Provably safe: shape is narrowed to non-null object; ZodObject's shape
+      // is structurally Record<string, ZodTypeAny> at runtime — we treat its
+      // values as `unknown` and let getZodDescription narrow them.
+      return node.shape as Record<string, unknown>;
     }
-    const def = (node as { _def?: { innerType?: unknown; schema?: unknown } })
-      ._def;
-    if (def?.innerType) return unwrapToZodObject(def.innerType);
-    if (def?.schema) return unwrapToZodObject(def.schema);
+    if (!("_def" in node) || !node._def || typeof node._def !== "object") {
+      return undefined;
+    }
+    const def = node._def;
+    if ("innerType" in def) return unwrapToZodObject(def.innerType);
+    if ("schema" in def) return unwrapToZodObject(def.schema);
     return undefined;
   }
 
   function inputFieldDescriptions(
     schema: Record<string, unknown>,
   ): Array<[string, string | undefined]> {
-    const inputSchema = (schema as { inputSchema?: unknown }).inputSchema;
-    const unwrapped = unwrapToZodObject(inputSchema);
-    if (!unwrapped) return [];
-    return Object.entries(unwrapped.shape).map(([fieldName, fieldType]) => [
+    const shape = unwrapToZodObject(schema.inputSchema);
+    if (!shape) return [];
+    return Object.entries(shape).map(([fieldName, fieldType]) => [
       fieldName,
       getZodDescription(fieldType),
     ]);

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -454,6 +454,12 @@ describe("tool metadata — descriptions and schema hints", () => {
   // here so future tool additions can't drift past the budget unnoticed.
   const MAX_TOOL_DESCRIPTION_WORDS = 15;
   const MAX_PARAM_DESCRIPTION_WORDS = 10;
+
+  /**
+   * Counts whitespace-separated words in a description string. Empty / blank
+   * inputs return 0.
+   * @param s description string
+   */
   const countWords = (s: string): number =>
     s.trim().split(/\s+/).filter(Boolean).length;
   const VERB_OPENER_ALLOWLIST = new Set<string>([
@@ -466,19 +472,22 @@ describe("tool metadata — descriptions and schema hints", () => {
     "simple_search",
   ]);
 
-  // Duck-type the captured inputSchema (a ZodObject) without importing zod.
-  // ZodObject exposes .shape: Record<string, ZodTypeAny>; each ZodTypeAny
-  // exposes .description: string | undefined (set via .describe()).
-  //
-  // Zod wraps optional/nullable/default/effects by *replacing* the outer
-  // schema with a new wrapper whose .description is undefined unless
-  // .describe() was called on the wrapper itself. The convention in this
-  // codebase is mixed: some fields use `.optional().describe(...)`
-  // (description on outer), others use `someSharedSchema.optional()`
-  // (description on inner). Both are valid; the walker descends through
-  // _def.innerType (ZodOptional/ZodNullable/ZodDefault), _def.type
-  // (ZodArray), and _def.schema (ZodEffects from .refine()/.transform()) to
-  // find the first non-empty description.
+  /**
+   * Walks a Zod schema tree and returns the first non-empty `.description`
+   * found, descending through wrapper types.
+   *
+   * Zod replaces the outer schema with a new wrapper whose `.description` is
+   * undefined unless `.describe()` was called on the wrapper itself. This
+   * codebase mixes `.optional().describe(...)` (outer-described) and
+   * `someSharedSchema.optional()` (inner-described); the walker descends
+   * through `_def.innerType` (ZodOptional / ZodNullable / ZodDefault),
+   * `_def.type` (ZodArray), and `_def.schema` (ZodEffects from `.refine()` /
+   * `.transform()`) so both patterns surface a description.
+   *
+   * @param node Zod schema (typed as `unknown` so the helper stays
+   *             zod-import-free; narrowed via `in` operator + `typeof`).
+   * @returns the description text, or `undefined` if none found.
+   */
   function getZodDescription(node: unknown): string | undefined {
     if (!node || typeof node !== "object") return undefined;
     if (
@@ -498,9 +507,16 @@ describe("tool metadata — descriptions and schema hints", () => {
     return undefined;
   }
 
-  // Unwrap the captured inputSchema until a ZodObject (with .shape) surfaces.
-  // Mirrors getZodDescription's traversal so a top-level .refine()/.transform()
-  // wrapping the object schema doesn't silently skip field assertions.
+  /**
+   * Unwraps a captured inputSchema until a ZodObject surfaces (one that
+   * exposes `.shape`). Mirrors {@link getZodDescription}'s traversal so a
+   * top-level `.refine()` / `.transform()` wrapping the object schema doesn't
+   * silently skip field assertions for the tool.
+   *
+   * @param node candidate ZodObject or wrapper containing one.
+   * @returns the underlying `.shape` map, or `undefined` if no ZodObject is
+   *          reachable through the wrapper chain.
+   */
   function unwrapToZodObject(
     node: unknown,
   ): Record<string, unknown> | undefined {
@@ -520,10 +536,28 @@ describe("tool metadata — descriptions and schema hints", () => {
     return undefined;
   }
 
+  /**
+   * Extracts `[fieldName, descriptionText]` pairs for every field in a
+   * captured tool's Zod inputSchema. Returns `[]` if the tool legitimately
+   * has no inputSchema (e.g. `list_files_in_vault`); HARD-FAILS via
+   * `expect()` if an inputSchema is present but the walker cannot reach a
+   * ZodObject — that case would otherwise let the `.describe()` contract
+   * pass vacuously while skipping every field.
+   *
+   * @param toolName name of the tool (for assertion failure messages).
+   * @param schema captured tool's full registration config (`{ description,
+   *               inputSchema }`).
+   */
   function inputFieldDescriptions(
+    toolName: string,
     schema: Record<string, unknown>,
   ): Array<[string, string | undefined]> {
+    if (schema.inputSchema === undefined) return [];
     const shape = unwrapToZodObject(schema.inputSchema);
+    expect(
+      shape,
+      `${toolName}: inputSchema present but unwrapToZodObject did not reach a ZodObject — metadata checks would silently skip every field`,
+    ).toBeDefined();
     if (!shape) return [];
     return Object.entries(shape).map(([fieldName, fieldType]) => [
       fieldName,
@@ -531,6 +565,13 @@ describe("tool metadata — descriptions and schema hints", () => {
     ]);
   }
 
+  /**
+   * Registers every tool for a given mode at preset=`full` and returns the
+   * captured registrations. Per-mode preset filters are bypassed so the
+   * metadata assertions see the full tool surface.
+   *
+   * @param toolMode `"granular"` (39 tools) or `"consolidated"` (11 tools).
+   */
   function enumerateAllTools(
     toolMode: "granular" | "consolidated",
   ): CapturedTool[] {
@@ -579,7 +620,10 @@ describe("tool metadata — descriptions and schema hints", () => {
       it("every Zod schema field has a non-empty .describe() text ≥ 3 chars and ≤ 10 words", () => {
         const tools = enumerateAllTools(mode);
         for (const t of tools) {
-          for (const [fieldName, desc] of inputFieldDescriptions(t.schema)) {
+          for (const [fieldName, desc] of inputFieldDescriptions(
+            t.name,
+            t.schema,
+          )) {
             expect(
               typeof desc,
               `${t.name}.${fieldName}: .describe() type`,

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -448,6 +448,14 @@ describe("tool metadata — descriptions and schema hints", () => {
   // pass; extend further if a future tool surfaces a missing one.
   const VERB_PREFIX_RE =
     /^(List|Get|Read|Put|Append|Patch|Delete|Replace|Move|Search|Run|Execute|Check|Force|Refresh|Create|Configure|Analyze|Insert|Open|Find|View|Query|Update|Toggle|Enable|Disable|Rename|Copy|CRUD)\b/;
+
+  // Token budget contract from CLAUDE.md L81: "Tool descriptions: MAX 15
+  // words. Parameter descriptions: MAX 10 words. Tokens matter." Codified
+  // here so future tool additions can't drift past the budget unnoticed.
+  const MAX_TOOL_DESCRIPTION_WORDS = 15;
+  const MAX_PARAM_DESCRIPTION_WORDS = 10;
+  const countWords = (s: string): number =>
+    s.trim().split(/\s+/).filter(Boolean).length;
   const VERB_OPENER_ALLOWLIST = new Set<string>([
     // vault_analysis opens with "Backlinks, connections, structure…" — it
     // describes a category of read-only inspections, not a single action.
@@ -540,7 +548,7 @@ describe("tool metadata — descriptions and schema hints", () => {
 
   for (const mode of ["granular", "consolidated"] as const) {
     describe(`${mode} mode (preset: full)`, () => {
-      it("every tool has a non-empty description ≥ 10 chars", () => {
+      it("every tool has a non-empty description ≥ 10 chars and ≤ 15 words", () => {
         const tools = enumerateAllTools(mode);
         expect(tools.length).toBeGreaterThan(0);
         for (const t of tools) {
@@ -551,6 +559,10 @@ describe("tool metadata — descriptions and schema hints", () => {
             t.description.trim().length,
             `${t.name}: description length`,
           ).toBeGreaterThanOrEqual(10);
+          expect(
+            countWords(t.description),
+            `${t.name}: description word count (CLAUDE.md L81 token budget)`,
+          ).toBeLessThanOrEqual(MAX_TOOL_DESCRIPTION_WORDS);
         }
       });
 
@@ -564,7 +576,7 @@ describe("tool metadata — descriptions and schema hints", () => {
         }
       });
 
-      it("every Zod schema field has a non-empty .describe() text ≥ 3 chars", () => {
+      it("every Zod schema field has a non-empty .describe() text ≥ 3 chars and ≤ 10 words", () => {
         const tools = enumerateAllTools(mode);
         for (const t of tools) {
           for (const [fieldName, desc] of inputFieldDescriptions(t.schema)) {
@@ -576,6 +588,10 @@ describe("tool metadata — descriptions and schema hints", () => {
               (desc ?? "").trim().length,
               `${t.name}.${fieldName}: .describe() length`,
             ).toBeGreaterThanOrEqual(3);
+            expect(
+              countWords(desc ?? ""),
+              `${t.name}.${fieldName}: .describe() word count (CLAUDE.md L81 token budget)`,
+            ).toBeLessThanOrEqual(MAX_PARAM_DESCRIPTION_WORDS);
           }
         }
       });


### PR DESCRIPTION
## **User description**
## Summary

Closes #15. Adds Vitest tests in `src/__tests__/tools.test.ts` that assert the MCP tool metadata contract — every tool's `description` and every Zod field's `.describe()` text. These are the primary signals an LLM uses to pick the right tool and fill its parameters; the tests kill the ~25 surviving `StringLiteral` mutants Stryker found on `src/tools/granular.ts L43-L1079` during Phase 3 PR #12.

## What the tests assert

For each (mode ∈ {granular, consolidated}) at preset=`full`:

1. **Every tool has a non-empty description ≥ 10 chars.**
2. **Every description starts with a recognized verb prefix.** Allowed verbs:
   `List | Get | Read | Put | Append | Patch | Delete | Replace | Move | Search | Run | Execute | Check | Force | Refresh | Create | Configure | Analyze | Insert | Open | Find | View | Query | CRUD`
   Two noun-opener anomalies allowlisted with rationale: `vault_analysis` ("Backlinks, connections, structure…" — describes a category, not a single action) and `simple_search` ("Full-text search…" — the noun-modifier disambiguates from `complex_search`/`dataview_search`).
3. **Every Zod schema field has a non-empty `.describe()` text ≥ 3 chars.** The walker descends through `ZodOptional` / `ZodNullable` / `ZodDefault` / `ZodArray` wrappers via `_def.innerType` and `_def.type` to find the description. Necessary because the codebase mixes two patterns: `field: z.string().optional().describe(...)` (description on outer wrapper) and `field: someSharedSchema.optional()` (description on inner type, see `src/schemas.ts`).

## Test count

`208 → 214` (6 new — 3 assertions × 2 modes).

## Out of scope (Hard Rule 8)

This is test-quality work per the issue. No source code (`src/tools/*`, `src/schemas.ts`) is modified. The walker correctly traverses the inner types where shared schemas live, so no field is currently flagged as missing `.describe()`. If a future change registers a tool with a blank description or a schema field without `.describe()`, these tests will fail; the developer can either fix the source or — for legitimate noun-opener cases like the existing two — add to the allowlist with documented rationale.

## Local gate results

`npm run pre-pr -- --skip-qwen`:

| Gate | Time | Result |
|---|---:|:---:|
| Prettier | 1s | ✓ |
| ESLint | 1s | ✓ |
| tsc | 1s | ✓ |
| knip | 0s | ✓ |
| Tests + coverage | 8s | ✓ (214 pass / 0 fail) |
| Stryker | 40s | ✓ (≥ baseline 55) |
| SonarQube | 5s | ✓ |
| Gitleaks | 1s | ✓ |
| Madge | 0s | ✓ |
| Semgrep | 5s | ✓ |
| Qwen review | 0s | SKIP |
| **Total** | **62s** | **PASS** |

## Test plan

- [ ] CI green (`Pipeline gate`, `CodeRabbit`, `build (22)`, `build (24)`)
- [ ] CI Stryker run shows the new tests killing previously-surviving mutants (verify by comparing mutation report to baseline if available)
- [ ] Reviewer cycle clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added contract-style tests that enumerate registered tools across modes and validate each tool's top-level description is present, sufficiently detailed, and follows required verb-prefix style unless exempt.
  * Added deep schema checks that extract input parameter descriptions, assert every field has a non-empty, meaningful description within length constraints, and hard-fail if a schema cannot be reliably analyzed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add coverage for tool descriptions and field hints**

### What Changed
- Adds tests that check every tool has a usable description and that it starts with a clear action verb, with two documented exceptions kept for existing tool names
- Adds tests that check every input field still has a visible `.describe()` hint, including fields wrapped in optional, nullable, default, or array shapes
- Runs the checks in both tool modes so missing metadata is caught before release

### Impact
`✅ Fewer unusable tools in AI picker`
`✅ Clearer parameter hints for tool filling`
`✅ Earlier detection of missing metadata`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=qQIKPgjCcGs92O4LEt8Y6ZvdLBxZ5RoLflou_6f0LHE&org=adder-factory)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
