### PR TITLE
test(tools): cover switch exhaustiveness guards — closes #14

### DIFF
--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -3856,4 +3856,104 @@ describe("consolidated tools — registration and behavior", () => {
       expect(getText(result)).toContain("ERROR: unexpected");
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Switch exhaustiveness guards (Issue #14)
+  // -------------------------------------------------------------------------
+  //
+  // Stryker surfaced 8 surviving BlockStatement mutants: the bodies of
+  // `default:` branches of exhaustive switches could be blanked without any
+  // test noticing. These guards are the runtime counterpart of TypeScript's
+  // `const _exhaustive: never = x` compile-time check — if a future
+  // maintainer deletes the body, the switch falls through silently and the
+  // handler returns `undefined` to the MCP runtime. Each test drives an
+  // invalid discriminant through the switch (bypassing compile-time
+  // narrowing via the mock handler's `Record<string, unknown>` signature)
+  // and asserts the tool-prefixed error message actually fires.
+
+  describe("switch exhaustiveness guards", () => {
+    it("vault default branch returns [vault] Unknown action error", async () => {
+      const { getTool } = setup();
+      const result = await getTool("vault").handler({
+        action: "bogus",
+        path: "note.md",
+        useRegex: false,
+        caseSensitive: true,
+        replaceAll: true,
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("[vault] Unknown action: bogus");
+    });
+
+    it("active_file default branch returns [active_file] Unknown action error", async () => {
+      const { getTool } = setup();
+      const result = await getTool("active_file").handler({
+        action: "bogus",
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("[active_file] Unknown action: bogus");
+    });
+
+    it("commands default branch returns [commands] Unknown action error", async () => {
+      const { getTool } = setup();
+      const result = await getTool("commands").handler({
+        action: "bogus",
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("[commands] Unknown action: bogus");
+    });
+
+    it("search default branch returns [search] Unknown type error", async () => {
+      const { getTool } = setup();
+      const result = await getTool("search").handler({
+        type: "bogus",
+        contextLength: 100,
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("[search] Unknown type: bogus");
+    });
+
+    it("periodic_note default branch returns [periodic_note] Unknown action error", async () => {
+      const { getTool } = setup();
+      const result = await getTool("periodic_note").handler({
+        action: "bogus",
+        period: "daily",
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain(
+        "[periodic_note] Unknown action: bogus",
+      );
+    });
+
+    it("recent default branch returns [recent] Unknown type error", async () => {
+      const { getTool } = setup();
+      const result = await getTool("recent").handler({
+        type: "bogus",
+        limit: 10,
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("[recent] Unknown type: bogus");
+    });
+
+    it("vault_analysis default branch returns [vault_analysis] Unknown action error", async () => {
+      const { getTool } = setup({ enableCache: true });
+      const result = await getTool("vault_analysis").handler({
+        action: "bogus",
+        limit: 10,
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain(
+        "[vault_analysis] Unknown action: bogus",
+      );
+    });
+
+    it("configure default branch returns [configure] Unknown action error", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({
+        action: "bogus",
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("[configure] Unknown action: bogus");
+    });
+  });
 });

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -3872,6 +3872,12 @@ describe("consolidated tools — registration and behavior", () => {
   // and asserts the tool-prefixed error message actually fires.
 
   describe("switch exhaustiveness guards", () => {
+    // `toBe` rather than `toContain` on the error text: the whole point of
+    // these tests is to kill BlockStatement mutants on the guard body, and
+    // exact-match assertions also catch any future drift in the message
+    // format itself (e.g., missing `[tool]` prefix or dropped discriminant
+    // interpolation).
+
     it("vault default branch returns [vault] Unknown action error", async () => {
       const { getTool } = setup();
       const result = await getTool("vault").handler({
@@ -3882,7 +3888,7 @@ describe("consolidated tools — registration and behavior", () => {
         replaceAll: true,
       });
       expect(result.isError).toBe(true);
-      expect(getText(result)).toContain("[vault] Unknown action: bogus");
+      expect(getText(result)).toBe("[vault] Unknown action: bogus");
     });
 
     it("active_file default branch returns [active_file] Unknown action error", async () => {
@@ -3891,7 +3897,7 @@ describe("consolidated tools — registration and behavior", () => {
         action: "bogus",
       });
       expect(result.isError).toBe(true);
-      expect(getText(result)).toContain("[active_file] Unknown action: bogus");
+      expect(getText(result)).toBe("[active_file] Unknown action: bogus");
     });
 
     it("commands default branch returns [commands] Unknown action error", async () => {
@@ -3900,7 +3906,7 @@ describe("consolidated tools — registration and behavior", () => {
         action: "bogus",
       });
       expect(result.isError).toBe(true);
-      expect(getText(result)).toContain("[commands] Unknown action: bogus");
+      expect(getText(result)).toBe("[commands] Unknown action: bogus");
     });
 
     it("search default branch returns [search] Unknown type error", async () => {
@@ -3910,7 +3916,7 @@ describe("consolidated tools — registration and behavior", () => {
         contextLength: 100,
       });
       expect(result.isError).toBe(true);
-      expect(getText(result)).toContain("[search] Unknown type: bogus");
+      expect(getText(result)).toBe("[search] Unknown type: bogus");
     });
 
     it("periodic_note default branch returns [periodic_note] Unknown action error", async () => {
@@ -3920,9 +3926,7 @@ describe("consolidated tools — registration and behavior", () => {
         period: "daily",
       });
       expect(result.isError).toBe(true);
-      expect(getText(result)).toContain(
-        "[periodic_note] Unknown action: bogus",
-      );
+      expect(getText(result)).toBe("[periodic_note] Unknown action: bogus");
     });
 
     it("recent default branch returns [recent] Unknown type error", async () => {
@@ -3932,19 +3936,17 @@ describe("consolidated tools — registration and behavior", () => {
         limit: 10,
       });
       expect(result.isError).toBe(true);
-      expect(getText(result)).toContain("[recent] Unknown type: bogus");
+      expect(getText(result)).toBe("[recent] Unknown type: bogus");
     });
 
     it("vault_analysis default branch returns [vault_analysis] Unknown action error", async () => {
-      const { getTool } = setup({ enableCache: true });
+      const { getTool } = setup();
       const result = await getTool("vault_analysis").handler({
         action: "bogus",
         limit: 10,
       });
       expect(result.isError).toBe(true);
-      expect(getText(result)).toContain(
-        "[vault_analysis] Unknown action: bogus",
-      );
+      expect(getText(result)).toBe("[vault_analysis] Unknown action: bogus");
     });
 
     it("configure default branch returns [configure] Unknown action error", async () => {
@@ -3953,7 +3955,7 @@ describe("consolidated tools — registration and behavior", () => {
         action: "bogus",
       });
       expect(result.isError).toBe(true);
-      expect(getText(result)).toContain("[configure] Unknown action: bogus");
+      expect(getText(result)).toBe("[configure] Unknown action: bogus");
     });
   });
 });

--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -16,12 +16,16 @@ export default {
   // See pipeline-spec.md → Stryker section → "key glob patterns to
   // actual project file types".
   mutate: ["src/**/*.ts", "!src/**/*.test.ts"],
-  // Baseline score on v1.1.1 was 56.78 %. Starting the `break` threshold at
-  // 55 so the gate passes on current tests while still failing on regressions,
-  // then ratcheting up (60 → 65 → 70) as tests improve. See
-  // ~/projects/code-review-pipeline/baseline-findings.md for the bake-in run.
+  // Baseline score on v1.1.1 was 56.78 %. The `break` threshold ratchets up
+  // `(new_score − 1pp)` after each test-improvement PR so it always sits
+  // ~1pp below the current kill rate — tight enough to catch a regression,
+  // loose enough to tolerate incremental-cache noise. History:
+  //   56.78 → break 55       (PR #12 baseline)
+  //   60.76 → break 59.76    (PR closing #14, switch exhaustiveness guards)
+  // See ~/projects/code-review-pipeline/baseline-findings.md for the bake-in
+  // run and build-log.md for each ratchet entry.
   // TODO: raise `break` to 70 once a sustained run keeps the score above it.
-  thresholds: { high: 80, low: 70, break: 55 },
+  thresholds: { high: 80, low: 70, break: 59.76 },
   // ignoreStatic must stay `false` — static mutants catch wrong defaults
   // / bad constants / bad regex literals, which is exactly what type checks
   // and linters miss. Explicit value (not relying on Stryker's current


### PR DESCRIPTION
## **User description**
## Summary

- Adds 8 vitest cases — one per surviving BlockStatement mutant from Stryker's Phase-3 baseline run — covering the `default:` branches of every exhaustive switch in `src/tools/consolidated.ts` (L170, L396, L464, L630, L673, L737, L872) plus `src/tools/shared.ts:681`. Each test passes an invalid discriminant through the mock handler and asserts the exact tool-prefixed error (`[tool] Unknown action: bogus` / `Unknown type`). Blanking the guard body now fails the suite instead of falling through silently.
- Ratchets `stryker.conf.mjs` `thresholds.break` from `55` → `59.76` per `(new_score − 1pp)` policy. Local incremental Stryker run: mutation score **56.78 → 60.76** (+3.98pp).
- Closes #14.

## Test plan

- [x] `npx vitest run` — 654 passed (previously 646)
- [x] `npx tsc --noEmit` — clean
- [x] `npx prettier --check` — clean (edited files)
- [x] `npx stryker run` — 60.76 % (was 56.78 %), threshold 59.76 → PASS
- [x] `bash scripts/pre-pr.sh --skip-qwen` — all 10 gates green, 33s wall clock

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add coverage for tool handlers’ invalid input errors

### What Changed
- Added tests that call each exhaustive tool path with an invalid action or type and confirm the expected error message is returned instead of falling through
- Covered the vault, active_file, commands, search, periodic_note, recent, vault_analysis, and configure tool flows
- Raised the mutation-test break threshold to match the stronger test coverage

### Impact
`✅ Fewer silent tool failures`
`✅ Clearer invalid input errors`
`✅ Stronger protection against missed switch cases`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=gsQweBqogC0Sx2_969BthWljkyoyzqDQqYTzBWQjeJk&org=adder-factory)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for error handling validation in tool handlers, ensuring robust error responses for invalid inputs.

* **Chores**
  * Updated mutation testing configuration thresholds to align with current code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->