### PR TITLE
chore: propagate Issue #7 sonar QG verdict verification

### DIFF
--- a/.adder-pipeline/installed.json
+++ b/.adder-pipeline/installed.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
-  "installed_at": "2026-04-24T01:39:30Z",
-  "git_commit": "4da91fb1c3b09613373409c3c3b151cbe2f98788",
+  "installed_at": "2026-04-24T19:30:15Z",
+  "git_commit": "9aa4ec40cca4c348361208fa49c9ed952096d3a7",
   "components": {
     "scripts": true,
     "package_json": true,

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -119,9 +119,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Two-stage SonarQube gate (Issue #7). The scan-action only uploads
+      # analysis; the QG verdict is computed asynchronously by the server's
+      # CE task and must be polled via /api/qualitygates/project_status.
+      # Without the paired quality-gate-action, a failing QG is silently
+      # reported as "SonarQube pass" on every PR.
       - uses: SonarSource/sonarqube-scan-action@v5
         if: env.SONAR_TOKEN != ''
 
-      - uses: SonarSource/sonarqube-quality-gate-action@v1.1.0
+      - uses: SonarSource/sonarqube-quality-gate-action@v1.2.0
         if: env.SONAR_TOKEN != ''
-        timeout-minutes: 5
+        # Leave headroom above pollingTimeoutSec so the GHA wall-clock doesn't
+        # race the action's internal polling timeout (action warm-up adds time).
+        timeout-minutes: 7
+        with:
+          # pollingTimeoutSec input requires v1.2.0+ (added in that release).
+          pollingTimeoutSec: 300

--- a/scripts/lib/sonar-qg.sh
+++ b/scripts/lib/sonar-qg.sh
@@ -1,0 +1,173 @@
+# sonar-qg.sh — SonarQube quality-gate verdict polling.
+#
+# Sourced by scripts/pre-pr.sh after common.sh. NOT executed directly.
+# Depends on the banner/info/warn/fail/ok helpers from lib/common.sh.
+#
+# Rationale: the scanner (`npx sonarqube-scanner`) exits 0 whenever it
+# successfully uploads analysis data to the server. The gate verdict is
+# computed asynchronously server-side by a compute engine (CE) task and
+# is only readable via `/api/qualitygates/project_status`. Without a
+# server-side poll after the scanner exits, a failing QG is silently
+# reported as "SonarQube pass" on every PR (Issue #7).
+
+if [ -n "${_ADDER_SONAR_QG_SH_LOADED:-}" ]; then return 0; fi
+_ADDER_SONAR_QG_SH_LOADED=1
+
+# verify_sonar_qg [report-task.txt]
+# Polls the CE task to completion, then reads the quality-gate verdict.
+# Returns 0 when projectStatus.status = OK, non-zero otherwise.
+#
+# Requires:
+#   SONAR_TOKEN               auth token (user token; password field left empty)
+#   SONAR_HOST_URL            server URL (falls back from report-task.txt serverUrl)
+#
+# Env overrides (mainly for tests):
+#   SONAR_QG_TIMEOUT_SEC      max wait for CE task to complete (default 300)
+#   SONAR_QG_POLL_INTERVAL    sleep between CE task polls (default 5)
+verify_sonar_qg() {
+  local report_file="${1:-.scannerwork/report-task.txt}"
+  local timeout="${SONAR_QG_TIMEOUT_SEC:-300}"
+  local interval="${SONAR_QG_POLL_INTERVAL:-5}"
+  # Per-request caps so a hung curl can't blow past the outer deadline.
+  # --connect-timeout fails fast on DNS/TCP; --max-time caps total request
+  # wall time. Outer deadline still enforces the overall timeout.
+  local connect_to="${SONAR_QG_CONNECT_TIMEOUT:-10}"
+  local request_to="${SONAR_QG_REQUEST_TIMEOUT:-30}"
+
+  if [ ! -f "$report_file" ]; then
+    fail "Sonar report-task.txt not found at $report_file — scanner did not produce one"
+    return 1
+  fi
+  if [ -z "${SONAR_TOKEN:-}" ]; then
+    fail "SONAR_TOKEN must be set to query quality-gate verdict"
+    return 1
+  fi
+  require_cmd curl   "brew install curl (or ensure system curl is on PATH)"   || return 1
+  require_cmd python3 "install python3 (macOS ships a recent version)"        || return 1
+
+  # Strip the leading key with sub() rather than -F= — report-task.txt values
+  # can legitimately contain '=' (e.g. server URLs with query params).
+  local ce_task_id server_url
+  ce_task_id=$(awk '/^ceTaskId=/{sub(/^ceTaskId=/, ""); print; exit}'  "$report_file")
+  server_url=$(awk '/^serverUrl=/{sub(/^serverUrl=/, ""); print; exit}' "$report_file")
+
+  if [ -z "$ce_task_id" ]; then
+    fail "Could not parse ceTaskId from $report_file"
+    return 1
+  fi
+
+  local host="${server_url:-${SONAR_HOST_URL:-}}"
+  host="${host%/}"
+  if [ -z "$host" ]; then
+    fail "No serverUrl in $report_file and SONAR_HOST_URL unset"
+    return 1
+  fi
+
+  info "Polling Sonar CE task $ce_task_id at $host (timeout ${timeout}s, interval ${interval}s)..."
+
+  local deadline task_resp task_status analysis_id
+  deadline=$(( $(date +%s) + timeout ))
+  task_status=""
+  task_resp=""
+  while :; do
+    # Feed `-u "$SONAR_TOKEN:"` via curl's --config on stdin so the token
+    # never lands in argv / `ps aux` / /proc/<pid>/cmdline. Also avoids the
+    # gitleaks curl-auth-user rule hit.
+    if ! task_resp=$(printf -- '-u "%s:"\n' "$SONAR_TOKEN" | \
+        curl -fsS --connect-timeout "$connect_to" --max-time "$request_to" \
+        -K - "$host/api/ce/task?id=$ce_task_id"); then
+      fail "Failed to fetch CE task status from $host/api/ce/task?id=$ce_task_id"
+      return 1
+    fi
+    # `(d.get("k") or {})` handles both missing-key AND key=null (Gemini catch).
+    if ! task_status=$(printf '%s' "$task_resp" | python3 -c '
+import json, sys
+try: d = json.load(sys.stdin)
+except Exception as e:
+    print(f"JSON parse failed: {e}", file=sys.stderr); sys.exit(1)
+print((d.get("task") or {}).get("status", "") if isinstance(d, dict) else "")
+'); then
+      fail "Malformed JSON from $host/api/ce/task (see stderr)"
+      return 1
+    fi
+    case "$task_status" in
+      SUCCESS) break ;;
+      FAILED|CANCELED)
+        fail "Sonar CE task $ce_task_id ended with status $task_status"
+        return 1 ;;
+    esac
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      fail "Sonar CE task $ce_task_id did not reach SUCCESS within ${timeout}s (last status: ${task_status:-<none>})"
+      return 1
+    fi
+    sleep "$interval"
+  done
+
+  if ! analysis_id=$(printf '%s' "$task_resp" | python3 -c '
+import json, sys
+try: d = json.load(sys.stdin)
+except Exception as e:
+    print(f"JSON parse failed: {e}", file=sys.stderr); sys.exit(1)
+print((d.get("task") or {}).get("analysisId", "") if isinstance(d, dict) else "")
+'); then
+    fail "Malformed JSON from $host/api/ce/task (analysisId parse)"
+    return 1
+  fi
+  if [ -z "$analysis_id" ]; then
+    fail "CE task SUCCESS but response has no analysisId"
+    return 1
+  fi
+
+  local qg_resp qg_status
+  # Same -K stdin pattern for argv hygiene.
+  if ! qg_resp=$(printf -- '-u "%s:"\n' "$SONAR_TOKEN" | \
+      curl -fsS --connect-timeout "$connect_to" --max-time "$request_to" \
+      -K - "$host/api/qualitygates/project_status?analysisId=$analysis_id"); then
+    fail "Failed to fetch quality-gate status from $host/api/qualitygates/project_status"
+    return 1
+  fi
+  if ! qg_status=$(printf '%s' "$qg_resp" | python3 -c '
+import json, sys
+try: d = json.load(sys.stdin)
+except Exception as e:
+    print(f"JSON parse failed: {e}", file=sys.stderr); sys.exit(1)
+print((d.get("projectStatus") or {}).get("status", "") if isinstance(d, dict) else "")
+'); then
+    fail "Malformed JSON from $host/api/qualitygates/project_status"
+    return 1
+  fi
+
+  case "$qg_status" in
+    OK)
+      ok "SonarQube quality gate: OK"
+      return 0 ;;
+    WARN)
+      # Issue #7 contract is "fail on status != OK" — strict. WARN was
+      # deprecated in Sonar 7.6+ and modern servers don't emit it, but if
+      # a legacy server does, we fail rather than silently wave it through.
+      fail "SonarQube quality gate: WARN (deprecated status; failing under strict != OK contract)"
+      return 1 ;;
+    ERROR)
+      fail "SonarQube quality gate: ERROR"
+      printf '%s' "$qg_resp" | python3 -c '
+import json, sys
+try:
+    raw = json.load(sys.stdin)
+except Exception as e:
+    print(f"(diagnostic unavailable — malformed JSON: {e})", file=sys.stderr); sys.exit(0)
+d = (raw.get("projectStatus") or {}) if isinstance(raw, dict) else {}
+for c in (d.get("conditions") or []):
+    if isinstance(c, dict) and c.get("status") == "ERROR":
+        print("    • {mk}: actual={av} {op} threshold={th}".format(
+            mk=c.get("metricKey", "?"),
+            av=c.get("actualValue", "?"),
+            op=c.get("comparator", "?"),
+            th=c.get("errorThreshold", "?"),
+        ))
+' || true
+      return 1 ;;
+    *)
+      fail "SonarQube QG returned unexpected status: ${qg_status:-<empty>}"
+      return 1 ;;
+  esac
+}

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -11,6 +11,8 @@ set -o pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/common.sh
 . "$HERE/lib/common.sh"
+# shellcheck source=lib/sonar-qg.sh
+. "$HERE/lib/sonar-qg.sh"
 
 SKIP_QWEN=0
 BASE_REF=""
@@ -83,27 +85,33 @@ GATE_RESULTS=()
 # Each gate_* function runs one step; returns 0 on pass, non-zero on fail.
 # Skipping is decided by the caller (below) based on project state / env.
 
+# gate_prettier — step 5. Format check via `prettier --check .`.
 gate_prettier() {
   banner "STEP 5 / Prettier"
   require_cmd npx "install Node.js" || return 1
   npx --no-install prettier --check .
 }
 
+# gate_eslint — step 6. Flat-config lint; any warning fails the gate.
 gate_eslint() {
   banner "STEP 6 / ESLint"
   npx --no-install eslint . --max-warnings=0
 }
 
+# gate_tsc — step 7. Strict type check (no emit).
 gate_tsc() {
   banner "STEP 7 / TypeScript (tsc --noEmit)"
   npx --no-install tsc --noEmit
 }
 
+# gate_knip — step 8. Dead-code / unused-exports scan.
 gate_knip() {
   banner "STEP 8 / knip (dead code, unused exports)"
   npx --no-install knip
 }
 
+# gate_tests — step 9. `npm test -- --coverage`; coverage threshold is
+# enforced by the runner config (Vitest/Jest), not by this gate.
 gate_tests() {
   banner "STEP 9 / Tests + coverage threshold"
   # Coverage threshold is enforced by the test runner config
@@ -123,6 +131,7 @@ gate_tests() {
   npm test --silent -- --coverage
 }
 
+# gate_stryker — step 10. Mutation testing; incremental so CI cache hits.
 gate_stryker() {
   banner "STEP 10 / Stryker (mutation testing)"
   # --incremental: only mutate files changed since the last run. CI runs full
@@ -130,6 +139,11 @@ gate_stryker() {
   npx --no-install stryker run --incremental
 }
 
+# gate_sonar — two-stage SonarQube gate (pipeline step 11).
+# Stage 1: run the npm scanner (sonarqube-scanner or @sonar/scan) to upload
+# analysis; stage 2: call verify_sonar_qg() to poll the server for the
+# compute-engine task and read the quality-gate verdict. The scanner alone
+# only reports upload success — Issue #7 added the verdict poll.
 gate_sonar() {
   banner "STEP 11 / SonarQube"
   if [ ! -f sonar-project.properties ]; then
@@ -149,15 +163,25 @@ gate_sonar() {
     printf '    Install: npm install -D sonarqube-scanner\n'
     return 1
   fi
-  npx --no-install "$scanner_cmd"
+  # Stage 1: upload analysis. The scanner exits 0 on successful upload —
+  # NOT on quality-gate pass.
+  if ! npx --no-install "$scanner_cmd"; then
+    return 1
+  fi
+  # Stage 2: wait for the server-side CE task and read the QG verdict.
+  # Before this was wired, every PR saw "SonarQube pass" the instant the
+  # scanner uploaded, even when the gate was failing server-side (Issue #7).
+  verify_sonar_qg
 }
 
+# gate_gitleaks — step 12. Secret scan over the full working tree.
 gate_gitleaks() {
   banner "STEP 12 / Gitleaks (secrets)"
   require_cmd gitleaks "brew install gitleaks" || return 1
   gitleaks detect --source . --verbose --redact --no-banner
 }
 
+# gate_madge — step 13. Circular-dependency detection on src/ (or repo root).
 gate_madge() {
   banner "STEP 13 / Madge (circular deps)"
   local src_dir="src"
@@ -165,6 +189,7 @@ gate_madge() {
   npx --no-install madge --circular --extensions ts,tsx,js,jsx "$src_dir"
 }
 
+# gate_semgrep — step 14. SAST via Semgrep's default + TS/JS rulesets.
 gate_semgrep() {
   banner "STEP 14 / Semgrep"
   require_cmd semgrep "brew install semgrep" || return 1
@@ -172,6 +197,7 @@ gate_semgrep() {
           --error --metrics=off --quiet .
 }
 
+# gate_qwen — step 15. Delegates to qwen-review.sh for the local AI review.
 gate_qwen() {
   banner "STEP 15 / Qwen local review"
   bash "$HERE/qwen-review.sh" --base "$BASE_REF"


### PR DESCRIPTION
## **User description**
## Summary

Propagates the fix from `adder-factory/adder-pipeline-tools#8` (merged as `2537725`). Closes Issue #7's adopter gap for this repo.

### Before

`gate_sonar()` exited 0 as soon as the scanner uploaded analysis. A failing server-side QG was silently reported as "SonarQube pass" on every PR since pipeline adoption (PR #12 onward).

### After

Two-stage Sonar gate: scanner upload, then `verify_sonar_qg()` polls `/api/ce/task` until SUCCESS and reads `/api/qualitygates/project_status`, failing on `status != OK` with a per-condition diagnostic (metric / actual / comparator / threshold).

## What's in this PR

- `scripts/lib/sonar-qg.sh` — **new** helper, copied from pipeline-tools `2537725`.
- `scripts/pre-pr.sh` — `gate_sonar()` calls `verify_sonar_qg` after the scanner; `gate_*` functions get one-line header comments.
- `.github/workflows/pipeline.yml` — explicit `pollingTimeoutSec: 300` on the paired `sonarqube-quality-gate-action` step.
- `.adder-pipeline/installed.json` — bumped `git_commit` to `2537725`.

## Local verification

`npm run pre-pr -- --skip-qwen` against the local Sonar server at `localhost:9000`:

```
→ Polling Sonar CE task b2b708f6-0f50-4132-a0ef-320e102f5824 at http://localhost:9000 (timeout 300s, interval 5s)...
✗ SonarQube quality gate: ERROR
    • new_coverage:   actual=81.4 LT threshold=85
    • new_violations: actual=1   GT threshold=0
```

**This is the intended outcome.** Those are the exact numbers Issue #7's evidence section cited — they were already present on the server before this PR, just never enforced at the gate level. This PR's only job is to surface them.

All non-Sonar gates stay green locally (Prettier, ESLint, tsc, knip, tests+coverage, Stryker, Gitleaks, Madge, Semgrep).

## Out of scope

- **Clearing the failing QG findings** (recomputing leak baseline, raising `new_coverage`, fixing `new_violations`) — tracked separately as Issue #20 cleanup PR. Per the kickoff-prompt scope, this propagation PR wires the mechanism only.

## CI

The CI `SonarQube` job here no-ops on `pass 4s` because `SONAR_TOKEN` is unset in Actions secrets (self-hosted Sonar reaches only the Mac Studio via tunnel). The `Pipeline gate` CI job covers the non-Sonar gates and should stay green.

## Test plan

- [x] Installed via `adder-pipeline-tools/install.sh .` from `main@2537725`
- [x] `npm run pre-pr -- --skip-qwen` — all gates green except the newly-loud Sonar
- [x] Output captures the expected failing-conditions diagnostic exactly as Issue #7 predicted
- [ ] CI `Pipeline gate` green
- [ ] CodeRabbit review triage (and CodeAnt if still installed — dropping per Phase-4 closeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced SonarQube quality-gate validation in CI with more reliable server-side polling and configurable timeouts to avoid false passes.
  * Improved pipeline timeout settings and polling behavior for sturdier asynchronous verification.
  * Added stronger validation and error handling around quality-gate checks for consistent failure reporting.
  * Updated installation metadata timestamp to reflect the latest state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Require SonarQube to pass before marking a PR green**

### What Changed
- SonarQube checks now wait for the server-side quality gate result instead of stopping after the scan upload
- PRs now fail when SonarQube reports a failing gate, with the failing checks shown in the output
- The Sonar job now uses an explicit wait time for the quality-gate check, so the gate behavior is consistent in CI

### Impact
`✅ Fewer false SonarQube passes`
`✅ Clearer SonarQube failure messages`
`✅ Fewer PRs marked green with failing analysis`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=lG-CYT9LBBj5GIV5b6V7J8uOiB4XViUefHyJgWkGVSw&org=adder-factory)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
