### PR TITLE
chore: propagate adder-pipeline-tools 1060bd2 (JSDoc coverage gate)

### DIFF
--- a/.adder-pipeline/installed.json
+++ b/.adder-pipeline/installed.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
-  "installed_at": "2026-04-24T19:30:15Z",
-  "git_commit": "9aa4ec40cca4c348361208fa49c9ed952096d3a7",
+  "installed_at": "2026-04-24T21:58:16Z",
+  "git_commit": "1060bd2464e9e7394eb53c589b348589f7481e9a",
   "components": {
     "scripts": true,
     "package_json": true,

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -51,6 +51,13 @@ jobs:
       - name: Knip
         run: npx knip
 
+      # JSDoc coverage (opt-in). Skips cleanly on repos that haven't adopted
+      # the gate yet — their next install.sh run copies the script and the
+      # step becomes a hard check.
+      - name: JSDoc coverage
+        if: ${{ hashFiles('scripts/jsdoc-coverage.ts') != '' }}
+        run: npx tsx scripts/jsdoc-coverage.ts --threshold 85
+
       - name: Tests + coverage
         run: npm test -- --coverage
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ knip.json
 # Tool-generated (managed by external tools, not ours to format)
 .claude/
 .codegraph/
+scripts/jsdoc-coverage.ts

--- a/knip.json
+++ b/knip.json
@@ -8,6 +8,7 @@
   "ignore": [
     ".adder-pipeline/**",
     ".github/**",
+    "scripts/**",
     "stryker.conf.mjs"
   ],
   "ignoreBinaries": [
@@ -19,7 +20,10 @@
   ],
   "ignoreDependencies": [
     "esbuild",
-    "postject"
+    "glob",
+    "postject",
+    "ts-morph",
+    "tsx"
   ],
   "ignoreExportsUsedInFile": {
     "interface": true,

--- a/scripts/jsdoc-coverage.ts
+++ b/scripts/jsdoc-coverage.ts
@@ -76,12 +76,18 @@ interface FileStats {
 
 /**
  * Decide whether a declaration is "exported" for coverage purposes.
- * Covers `export` modifiers and re-exports via `export { ... }` / `export default`.
+ *
+ * Handles the forms we score: `export` modifiers on declarations (function /
+ * class / interface / type / enum / variable statement). Re-exports
+ * (`export { ... } from './x'`, `export * from './x'`) are deliberately
+ * excluded — the re-exported symbol is scored in its own source file.
+ * `export default expr;` assignments are also excluded: when the default
+ * target is a named declaration (`export default function foo() {}`) it is
+ * already caught via the exportable path; bare-identifier forms
+ * (`export default foo;`) point at a declaration scored in its own right.
  */
 function isExported(node: Node): boolean {
   if (Node.isExportable(node) && node.isExported()) return true;
-  if (Node.isExportAssignment(node)) return true;
-  if (Node.isExportDeclaration(node)) return true;
   return false;
 }
 
@@ -105,7 +111,6 @@ function collectTopLevel(sourceFile: import("ts-morph").SourceFile): Node[] {
       results.push(stmt);
     else if (Node.isVariableStatement(stmt) && stmt.isExported())
       results.push(stmt);
-    else if (Node.isExportAssignment(stmt)) results.push(stmt);
   }
   return results;
 }
@@ -129,6 +134,13 @@ function collectClassMembers(cls: import("ts-morph").ClassDeclaration): Node[] {
     ) {
       continue;
     }
+    // Overloaded methods: ts-morph returns one MethodDeclaration per
+    // signature plus one for the implementation. Scoring each separately
+    // over-weights a single API method by its overload count, so we keep
+    // only the implementation (signature-only overloads return true from
+    // isOverload()). hasMethodOrOverloadJSDoc below still consults the
+    // sibling signatures for JSDoc.
+    if (Node.isMethodDeclaration(m) && m.isOverload()) continue;
     const mods = m.getModifiers().map((mod) => mod.getKind());
     if (mods.includes(SyntaxKind.PrivateKeyword)) continue;
     if (mods.includes(SyntaxKind.ProtectedKeyword)) continue;

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -110,6 +110,17 @@ gate_knip() {
   npx --no-install knip
 }
 
+# gate_jsdoc_coverage — step 8b. Documentation coverage on exported
+# declarations. Opt-in: only runs when scripts/jsdoc-coverage.ts is present
+# in the target repo (installed by install.sh). Threshold defaults to 85 %
+# and can be overridden per repo by setting JSDOC_COVERAGE_THRESHOLD. See
+# script-specs/jsdoc-coverage.md for the metric definition.
+gate_jsdoc_coverage() {
+  banner "STEP 8b / JSDoc coverage (ts-morph)"
+  local threshold="${JSDOC_COVERAGE_THRESHOLD:-85}"
+  npx --no-install tsx scripts/jsdoc-coverage.ts --threshold "$threshold"
+}
+
 # gate_tests — step 9. `npm test -- --coverage`; coverage threshold is
 # enforced by the runner config (Vitest/Jest), not by this gate.
 gate_tests() {
@@ -210,6 +221,16 @@ time_gate "Prettier"         gate_prettier  || true
 time_gate "ESLint"           gate_eslint    || true
 time_gate "tsc"              gate_tsc       || true
 time_gate "knip"             gate_knip      || true
+
+# JSDoc coverage: opt-in. Runs when scripts/jsdoc-coverage.ts is present
+# (installed by install.sh). Absent in legacy projects that pre-date the
+# gate — they get a SKIP, not a failure, and pick the gate up on re-install.
+if [ -f scripts/jsdoc-coverage.ts ]; then
+  time_gate "JSDoc coverage" gate_jsdoc_coverage || true
+else
+  skip_gate "JSDoc coverage" "scripts/jsdoc-coverage.ts absent — re-run install.sh to adopt"
+fi
+
 time_gate "Tests + coverage" gate_tests     || true
 
 # Stryker: opt-in per project. Skip cleanly when no config present.


### PR DESCRIPTION
## **User description**
## Summary

Picks up the **step-8b JSDoc coverage gate** and the review fixes shipped with `adder-pipeline-tools#10` (commit `1060bd2`).

- `scripts/pre-pr.sh` — adds `gate_jsdoc_coverage`, runs between knip (8) and tests+coverage (9); opt-in via `scripts/jsdoc-coverage.ts` presence.
- `scripts/jsdoc-coverage.ts` — refined metric over what Stage 1 landed here (PR #24):
  - `ExportAssignment` dropped from scoring (prevents false failures on `export default foo;` where the assignment node isn't JSDoc-capable).
  - `isExported` comment corrected — re-exports aren't scored; target symbols are counted in their own files.
  - Overload signatures collapse to one logical member via `isOverload()`, so overloaded methods aren't over-weighted in the denominator.
- `.github/workflows/pipeline.yml` — JSDoc coverage step added inside the existing `Pipeline gate` job, guarded by `hashFiles()`.
- `.prettierignore` — installer added `scripts/jsdoc-coverage.ts` so the template file stays byte-identical across repos with varying prettier configs.
- `knip.json` — installer added `ts-morph` / `glob` / `tsx` to `ignoreDependencies` for fresh-install compatibility. Redundant on this repo (`scripts/**/*.{js,ts,mjs}` is already in `entry`) but knip only issues hints, not errors, for redundant entries.

### Validation

- `bash scripts/pre-pr.sh --skip-qwen` — all 11 deterministic gates + JSDoc coverage green (38 s)
- `tsx scripts/jsdoc-coverage.ts --per-file` → **100.00 % (110/110)** under the refined metric
- Sonar server-side QG verified OK locally

## Test plan

- [x] Full pre-PR gate green locally
- [x] JSDoc coverage 100 % with overload-aware + PropertyDeclaration-aware metric
- [ ] CI required checks green (Pipeline gate, CodeRabbit, build 22, build 24)
- [ ] Server-side Sonar QG verdict OK on PR scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSDoc coverage verification to CI pipeline and pre-PR checks with an 85% threshold, automatically skipped if not configured.

* **Chores**
  * Updated pipeline configuration and dependency analysis settings.
  * Added formatting exclusions for internal tooling scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add an optional JSDoc coverage check to the local gate and CI

### What Changed
- A new JSDoc coverage step now runs between knip and tests, and it also appears in the Pipeline gate job.
- Repos without the new script skip this check instead of failing, so older projects can adopt it on the next install.
- The coverage score no longer counts re-exports or `export default` assignments, which avoids false failures.
- Overloaded class methods are counted once instead of once per signature, so one API method is not over-weighted.

### Impact
`✅ Clearer documentation checks`
`✅ Fewer false JSDoc coverage failures`
`✅ Smoother adoption for older repos`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=CesVhxpneXXQlIHoJKPU4V460LkKq2gCiXWTNXhOcfI&org=adder-factory)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
