### PR TITLE
fix(security): patch SonarSource action and harden workflow permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -137,7 +137,9 @@ jobs:
       # Without the paired quality-gate-action, a failing QG is silently
       # reported as "SonarQube pass" on every PR.
       # v6+ required: GHSA-5xq9-5g24-4g6f (argument injection in v4–v5).
-      - uses: SonarSource/sonarqube-scan-action@v6
+      # Pinned to immutable SHA (= v6.0.0) so a re-tag of v6 can't drift.
+      # nosemgrep: generic.secrets.security.detected-sonarqube-docs-api-key.detected-sonarqube-docs-api-key
+      - uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         if: env.SONAR_TOKEN != ''
 
       - uses: SonarSource/sonarqube-quality-gate-action@v1.2.0

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,6 +10,11 @@ concurrency:
   group: pipeline-${{ github.ref }}
   cancel-in-progress: true
 
+# Restrict GITHUB_TOKEN to the minimum needed. Both jobs only need to read
+# repo contents (checkout); SonarQube uses its own SONAR_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   gate:
     name: Pipeline gate
@@ -131,7 +136,8 @@ jobs:
       # CE task and must be polled via /api/qualitygates/project_status.
       # Without the paired quality-gate-action, a failing QG is silently
       # reported as "SonarQube pass" on every PR.
-      - uses: SonarSource/sonarqube-scan-action@v5
+      # v6+ required: GHSA-5xq9-5g24-4g6f (argument injection in v4–v5).
+      - uses: SonarSource/sonarqube-scan-action@v6
         if: env.SONAR_TOKEN != ''
 
       - uses: SonarSource/sonarqube-quality-gate-action@v1.2.0


### PR DESCRIPTION
## Summary

Closes the open security alerts on `main`:

- **Dependabot #1** (high) — `SonarSource/sonarqube-scan-action` argument injection (GHSA-5xq9-5g24-4g6f, fixed in v6.0.0). Pin bumped `v5` → `v6`.
- **Code scanning #1, #2** (medium) — workflow missing explicit `permissions:` for `GITHUB_TOKEN`. Added top-level `permissions: contents: read`. The Sonar steps authenticate with `SONAR_TOKEN`, so no broader scopes are needed.
- **Code scanning #3** (high, `js/disabling-certificate-validation`, `src/obsidian.ts:424`) — **not fixed in code; will be dismissed as won't-fix**. The branch is intentional and documented in `docs/cc-instructions-final.md` and `CLAUDE.md`: the Obsidian Local REST API ships with a self-signed cert, so `rejectUnauthorized: false` is the documented default. It is gated behind opt-in (`OBSIDIAN_CERT_PATH=...` for proper CA verification, or `OBSIDIAN_VERIFY_SSL=true` for strict TLS) — see `src/obsidian.ts:411-425`. The dismissal will be recorded with this rationale on the alert itself.

## Test plan

- [x] `npm run pre-pr` (full, including Qwen): all 12 gates green
- [ ] Pipeline workflow runs cleanly on this PR
- [ ] CodeRabbit + CodeAnt comments addressed before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)