### PR TITLE
fix(quality): remove dead code flagged by CodeQL

### DIFF
--- a/scripts/stress-test-advanced.ts
+++ b/scripts/stress-test-advanced.ts
@@ -13,11 +13,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { loadConfig } from "../src/config.js";
 import { ObsidianClient } from "../src/obsidian.js";
 import { VaultCache } from "../src/cache.js";
-import {
-  ObsidianApiError,
-  ObsidianConnectionError,
-  ObsidianAuthError,
-} from "../src/errors.js";
+import { ObsidianApiError } from "../src/errors.js";
 
 // --- Constants ---
 
@@ -1025,7 +1021,6 @@ async function main(): Promise<void> {
   ];
 
   const results: ScenarioResult[] = [];
-  const allStats = new Stats();
 
   for (const scenario of scenarios) {
     write(`\n--- ${scenario.budget} budget ---`);
@@ -1072,11 +1067,6 @@ async function main(): Promise<void> {
   const totalPassed = results.reduce((sum, r) => sum + r.stats.totalPassed, 0);
   const scenariosPassed = results.filter((r) => r.passed).length;
   const scenariosFailed = results.filter((r) => !r.passed).length;
-  const toolsCovered = new Set<string>();
-  for (const r of results) {
-    // Count covered ops from each scenario's stats report
-    // (We can't easily access private toolCoverage, but we can count from summary)
-  }
 
   // Latency percentiles across all scenarios
   const allLatencies: number[] = [];

--- a/scripts/stress-test-patch.ts
+++ b/scripts/stress-test-patch.ts
@@ -9,7 +9,6 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { setTimeout as sleep } from "node:timers/promises";
 
 import { loadConfig } from "../src/config.js";
 import { ObsidianClient } from "../src/obsidian.js";

--- a/scripts/stress-test.ts
+++ b/scripts/stress-test.ts
@@ -7,7 +7,6 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { setTimeout as sleep } from "node:timers/promises";
 
 import { loadConfig } from "../src/config.js";
 import { ObsidianClient } from "../src/obsidian.js";

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -2134,7 +2134,7 @@ describe("consolidated tools — registration and behavior", () => {
   describe("vault — list_dir action", () => {
     it("calls client.listFilesInDir with path", async () => {
       const { client, getTool } = setup();
-      const result = await getTool("vault").handler({
+      await getTool("vault").handler({
         action: "list_dir",
         path: "mydir",
         useRegex: false,


### PR DESCRIPTION
## Summary

Closes the 8 open CodeQL "Code Quality" alerts on `main`:

- **7× `js/useless-assignment-to-local` / `js/unused-local`** — unused vars, imports, and `result` binding in a test that only asserts on a spy.
- **1× `js/unused-loop-iteration-variable`** — `for (const r of results)` whose body was only TODO comments. Removed the loop entirely (along with its unused `toolsCovered` Set).

ESLint in this repo excludes `scripts/` and `src/__tests__/` (see `eslint.config.js`), which is why these were not caught locally. Tightening that scope is a separate, larger change.

## Files changed

- `src/__tests__/tools.test.ts` — drop unused `result` binding
- `scripts/stress-test-advanced.ts` — drop unused imports, unused `allStats`, dead `for…of` loop
- `scripts/stress-test.ts` — drop unused `sleep` import
- `scripts/stress-test-patch.ts` — drop unused `sleep` import

## Test plan

- [x] `npm run pre-pr --skip-qwen`: all 11 gates green (Qwen flagged the dead-code removal as "may indicate a logical error" — same false-positive pattern as PR #28; deferred per prior decision)
- [ ] Pipeline workflow runs cleanly on this PR
- [ ] CodeRabbit thread(s) addressed before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)