### PR TITLE
docs(claude-md): add rigor sections (debugging, verification, multi-stage, subagents)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,11 +188,12 @@ upload not verdict — Issue #7).
 
 ## Verification Before Completion
 
-Before reporting a task complete, verify ALL of the following:
+Before reporting a task complete, verify ALL the following:
 
 1. The relevant gate or check actually ran (not skipped)
 2. Exit code was checked, not just process completion
-3. The metric the task targeted actually moved (not just "tests pass")
+3. The specific outcome or metric the task targeted actually changed (not
+   just "tests pass")
 4. Downstream consumers not broken (run dependent tests if changes touch
    shared code)
 5. The reported state matches the actual state (no hallucinated "all green")
@@ -210,7 +211,7 @@ next. Format per stage:
 1. Action — what the stage does
 2. Expected outcome — what success looks like, measurable
 3. Verification command/check — how to confirm the outcome
-4. Stop condition — what triggers escalation vs. proceeding
+4. Escalation trigger — what triggers stopping for human help vs. proceeding
 
 Do NOT batch verification at end of all stages. A failed early stage that
 propagates is harder to diagnose than one caught immediately.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,7 @@ coordination has overhead. Use them when work fits ALL three:
    with different inputs
 
 Examples:
+
 - ✅ JSDoc backfill across 60 files
 - ✅ Bulk test additions across independent modules
 - ✅ Multi-repo template propagation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,80 @@ npm run sonar                              # Zero issues of any severity in Sona
 
 Iterate with CodeRabbitAI + Greptile on PR until ALL comments resolved — including nitpicks.
 
+## Systematic Debugging
+
+When a test fails, gate regresses, or unexpected behavior surfaces, follow
+this 4-phase process. Do NOT skip to fix.
+
+**Phase 1 — Reproduce.** Confirm the failure is reproducible. If
+intermittent, capture frequency. No fix without reliable repro.
+
+**Phase 2 — Narrow scope.** Bisect to smallest input/file/commit that
+triggers the failure. Don't theorize on full system.
+
+**Phase 3 — Hypothesize with evidence.** State the hypothesis explicitly.
+List evidence supporting it. Distinguish "this would explain it" from "I
+have proof."
+
+**Phase 4 — Verify fix targets cause, not symptom.** After applying a fix,
+confirm: (a) original repro now passes, (b) the fix matches the hypothesis,
+not a workaround that masks it.
+
+Skipping phases produces silent-pass bugs (e.g., Sonar gate verifying
+upload not verdict — Issue #7).
+
+## Verification Before Completion
+
+Before reporting a task complete, verify ALL of the following:
+
+1. The relevant gate or check actually ran (not skipped)
+2. Exit code was checked, not just process completion
+3. The metric the task targeted actually moved (not just "tests pass")
+4. Downstream consumers not broken (run dependent tests if changes touch
+   shared code)
+5. The reported state matches the actual state (no hallucinated "all green")
+
+Reporting "done" without these checks creates the silent-pass class of
+bug. Sonar Issue #7 (every PR silently passing since #12) is the reference
+example.
+
+## Multi-Stage Task Verification
+
+When a task is broken into stages (e.g., "Stage 1 → Stage 2 → Stage 3"),
+each stage gets an explicit verification step before proceeding to the
+next. Format per stage:
+
+1. Action — what the stage does
+2. Expected outcome — what success looks like, measurable
+3. Verification command/check — how to confirm the outcome
+4. Stop condition — what triggers escalation vs. proceeding
+
+Do NOT batch verification at end of all stages. A failed early stage that
+propagates is harder to diagnose than one caught immediately.
+
+## When to Use Subagents
+
+Subagents are not free — each burns its own context window, and
+coordination has overhead. Use them when work fits ALL three:
+
+1. **Parallel-safe** — independent files, no shared state, results don't
+   depend on each other
+2. **Naturally splits 3+ ways** — fewer than 3 splits = overhead exceeds
+   benefit
+3. **Mechanical or templated** — each subtask follows the same pattern
+   with different inputs
+
+Examples:
+- ✅ JSDoc backfill across 60 files
+- ✅ Bulk test additions across independent modules
+- ✅ Multi-repo template propagation
+- ❌ Single-file refactor
+- ❌ Sequential multi-stage task
+- ❌ Small PR (<50 LOC, <3 files)
+
+Default to single-agent for everything else. The cost of a subagent that
+isn't pulling its weight is real.
+
 <!-- ADDER-PIPELINE:v1 -->
 
 ## Adder Code Review Pipeline


### PR DESCRIPTION
## Summary

Adds four standalone sections to `CLAUDE.md` under the existing "Verification Checklist (Before Every PR)" section:

- **Systematic Debugging** — 4-phase reproduce/narrow-scope/hypothesize/verify process so failures are diagnosed before fixed. Closes the silent-pass class of bug exemplified by Sonar Issue #7 (gate verifying scanner upload, not verdict).
- **Verification Before Completion** — explicit 5-item checklist for what "done" requires (gate ran, exit code checked, target metric moved, downstream not broken, reported state matches actual).
- **Multi-Stage Task Verification** — per-stage action/expected-outcome/verification-check/stop-condition format so propagating failures are caught at the boundary they originate, not at the end.
- **When to Use Subagents** — three-criterion gate: parallel-safe + naturally splits 3+ ways + mechanical/templated. Default to single-agent otherwise.

Hand-picked rigor patterns adapted to the existing pipeline — no framework introduced, no other code changes.

## What this is NOT

- No workflow changes — the verification checklist below is unchanged
- No new gates added — these sections shape how Claude approaches work, not what runs in CI
- No reviewer subagent yet — that lands in a follow-up Stage 2 PR

## Test plan

- [ ] CodeRabbit / CodeAnt review clean (or addressed)
- [ ] CI checks pass (no workflow files changed; existing checks should pass unchanged)
- [ ] No links broken in CLAUDE.md
- [ ] Documentation flows naturally with surrounding sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)