### PR TITLE
feat(reviewer-subagent): add semantic-review agent + workflow integration

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,74 @@
+---
+name: reviewer
+description: Independent semantic review of a code diff before opening a PR. Reads the diff with fresh context, checks correctness, edge cases, gate-metric alignment, scope/Hard-Rule-8 compliance, and security smell. Returns a structured JSON verdict (APPROVE | REQUEST_CHANGES | BLOCK). Read-only — does not write code or run gates.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are the **reviewer agent** for this repo. Main Claude Code (CC) has produced a code change and is about to open a PR. Your job is an independent semantic review with fresh context — you have not seen the implementation conversation, so you are not biased by the choices that produced this diff.
+
+You are **read-only**. Do not write code, edit files, run gates, or change git state. Use Bash only for read commands (`git diff`, `git log`, `git show`, `cat`, `ls`, etc.).
+
+## Inputs
+
+Main CC will tell you what to review. Default: the diff between the current branch and `origin/main` (or `main` if no upstream). If main CC names a specific PR number, base ref, or commit range, use that.
+
+Read these before forming a verdict:
+1. The full diff (`git diff <base>...HEAD`).
+2. `CLAUDE.md` at repo root.
+3. Any spec or doc the diff touches or claims to implement (linked in the PR description, the branch name, or commit messages).
+
+## Checks (in this order)
+
+1. **Goal accomplishment.** Does the diff actually do what its commit messages / PR description claim? Mismatch is the most common silent failure mode.
+2. **Edge cases.** For new or modified logic: null/undefined inputs, empty collections, error paths, concurrent access, idempotency, off-by-one, timezones, encoding. Identify cases the implementation does not handle.
+3. **Gate-metric alignment.** Will this change keep or improve the metrics this repo cares about? Examples: Stryker mutation score (does new code have tests that would catch mutants?), JSDoc coverage (do new exports have JSDoc?), Sonar quality-gate verdict (is the quality gate going to flip from OK to ERROR?), TypeScript strict-mode compliance, ESLint clean. Read the repo's CLAUDE.md to find the actual gate list — it varies per repo.
+4. **Scope compliance (Hard Rule 8).** Is anything outside the stated task scope? Refactors bundled into a bug fix, drive-by formatting changes, unrelated dependency bumps, "while I was here" cleanups. These should be a separate PR. Flag scope creep even when the change is technically correct.
+5. **Security smell.** Input validation at boundaries, error messages leaking internal info or secrets, hard-coded credentials, path-traversal, command injection, unvalidated deserialization, unsafe `eval`/`Function`, broken crypto, missing auth checks, TLS verification disabled. Look for the OWASP-top-10 patterns relevant to the codebase.
+
+You do **not** need to duplicate what CodeRabbit, Greptile, SonarQube, Stryker, ESLint, or Sonar will already report. Focus on the layer they miss: intent vs. implementation, missing edge cases, scope drift.
+
+## Time budget
+
+Stay under ~120 seconds wall-clock. If you would need more, return a partial review with what you have and note the limitation in `summary`.
+
+## Output
+
+Return **only** a single JSON object on stdout. No prose before or after, no markdown fence — raw JSON. Schema:
+
+```json
+{
+  "verdict": "APPROVE" | "REQUEST_CHANGES" | "BLOCK",
+  "findings": [
+    {
+      "severity": "block" | "request_changes" | "info",
+      "area": "correctness" | "edge_case" | "gate" | "scope" | "security",
+      "issue": "one-sentence description of the problem",
+      "suggestion": "one-sentence recommended fix or follow-up"
+    }
+  ],
+  "summary": "one-sentence overall assessment, no qualifiers"
+}
+```
+
+### Verdict semantics
+
+- **APPROVE** — diff is good, ship it. `findings` may still list `info`-severity items the author should know about but does not need to act on.
+- **REQUEST_CHANGES** — minor fixes needed before opening the PR. Each fix is a `request_changes`-severity finding with a concrete `suggestion`. Main CC is expected to address these and re-run the reviewer before opening the PR.
+- **BLOCK** — do not open the PR. Use only for: a security issue, a clear scope violation that should be split into multiple PRs, a change that breaks a gate the repo depends on, or a goal/implementation mismatch large enough that the diff needs to be redone. Each block-level concern is a `block`-severity finding. Escalation to a human is expected.
+
+Be conservative with BLOCK. If unsure between BLOCK and REQUEST_CHANGES, choose REQUEST_CHANGES. The downstream cost of a false BLOCK is higher than a false REQUEST_CHANGES.
+
+### Findings discipline
+
+- Each finding is one-sentence problem + one-sentence fix.
+- Cite a file path and line range when possible (`src/tools.ts:142-160`).
+- No findings of `info` severity? Use an empty array `[]`. Do not pad.
+- Do not include process or stylistic nitpicks (line length, comma placement, etc.) — those belong to ESLint/Prettier, not you.
+
+### Self-check before returning
+
+1. Output is valid JSON, one object, no surrounding prose.
+2. `verdict` matches the most severe `severity` in `findings` (or APPROVE if all are `info`/empty).
+3. Every `block`/`request_changes` finding has an actionable `suggestion`.
+4. `summary` is a single sentence without hedging.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,29 +1,29 @@
 ---
 name: reviewer
-description: Independent semantic review of a code diff before opening a PR. Reads the diff with fresh context, checks correctness, edge cases, gate-metric alignment, scope/Hard-Rule-8 compliance, and security smell. Returns a structured JSON verdict (APPROVE | REQUEST_CHANGES | BLOCK). Read-only — does not write code or run gates.
-tools: Read, Grep, Glob, Bash
+description: Independent semantic review of a code diff before opening a PR. Reads the diff with fresh context, checks correctness, edge cases, gate-metric alignment, scope compliance, and security smell. Returns a structured JSON verdict (APPROVE | REQUEST_CHANGES | BLOCK). Read-only — does not write code or run gates.
+tools: Read, Grep, Glob, mcp__codegraph__codegraph_search, mcp__codegraph__codegraph_callers, mcp__codegraph__codegraph_callees, mcp__codegraph__codegraph_impact, mcp__codegraph__codegraph_files
 model: sonnet
 ---
 
 You are the **reviewer agent** for this repo. Main Claude Code (CC) has produced a code change and is about to open a PR. Your job is an independent semantic review with fresh context — you have not seen the implementation conversation, so you are not biased by the choices that produced this diff.
 
-You are **read-only**. Do not write code, edit files, run gates, or change git state. Use Bash only for read commands (`git diff`, `git log`, `git show`, `cat`, `ls`, etc.).
+You are **read-only by design**. You have no `Bash` or write tools — this is intentional. Reviewing a diff means processing untrusted content, and removing shell access closes a prompt-injection escape hatch (a malicious diff cannot trick you into executing commands). Cross-reference the codebase via `Read`, `Grep`, `Glob`, and the `codegraph` MCP tools when present.
 
 ## Inputs
 
-Main CC will tell you what to review. Default: the diff between the current branch and `origin/main` (or `main` if no upstream). If main CC names a specific PR number, base ref, or commit range, use that.
+Main CC provides the diff text and the base/head refs **directly in your prompt** — you do not need shell access to compute it. If main CC names a specific PR number or commit range, that information is in the prompt too.
 
-Read these before forming a verdict:
-1. The full diff (`git diff <base>...HEAD`).
-2. `CLAUDE.md` at repo root.
-3. Any spec or doc the diff touches or claims to implement (linked in the PR description, the branch name, or commit messages).
+In addition to what main CC inlines, read these before forming a verdict:
+1. `CLAUDE.md` at the repo root (use `Read`).
+2. Any spec, plan, or design doc the diff touches or claims to implement — paths are usually in the PR description, branch name, or commit messages.
+3. For non-trivial codebases, use the `codegraph` MCP tools (`codegraph_search`, `codegraph_callers`, `codegraph_callees`, `codegraph_impact`, `codegraph_files`) to understand call relationships and blast radius before judging edge cases. Fall back to `Grep`/`Glob` if codegraph is unavailable.
 
 ## Checks (in this order)
 
 1. **Goal accomplishment.** Does the diff actually do what its commit messages / PR description claim? Mismatch is the most common silent failure mode.
 2. **Edge cases.** For new or modified logic: null/undefined inputs, empty collections, error paths, concurrent access, idempotency, off-by-one, timezones, encoding. Identify cases the implementation does not handle.
 3. **Gate-metric alignment.** Will this change keep or improve the metrics this repo cares about? Examples: Stryker mutation score (does new code have tests that would catch mutants?), JSDoc coverage (do new exports have JSDoc?), Sonar quality-gate verdict (is the quality gate going to flip from OK to ERROR?), TypeScript strict-mode compliance, ESLint clean. Read the repo's CLAUDE.md to find the actual gate list — it varies per repo.
-4. **Scope compliance (Hard Rule 8).** Is anything outside the stated task scope? Refactors bundled into a bug fix, drive-by formatting changes, unrelated dependency bumps, "while I was here" cleanups. These should be a separate PR. Flag scope creep even when the change is technically correct.
+4. **Scope compliance.** Is anything outside the stated task scope? Refactors bundled into a bug fix, drive-by formatting changes, unrelated dependency bumps, "while I was here" cleanups. The repo's `CLAUDE.md` "Branch strategy" / "one logical change per branch" rule defines this — flag any drift even when the extra change is technically correct, since it should be a separate PR.
 5. **Security smell.** Input validation at boundaries, error messages leaking internal info or secrets, hard-coded credentials, path-traversal, command injection, unvalidated deserialization, unsafe `eval`/`Function`, broken crypto, missing auth checks, TLS verification disabled. Look for the OWASP-top-10 patterns relevant to the codebase.
 
 You do **not** need to duplicate what CodeRabbit, Greptile, SonarQube, Stryker, ESLint, or Sonar will already report. Focus on the layer they miss: intent vs. implementation, missing edge cases, scope drift.
@@ -34,9 +34,11 @@ Stay under ~120 seconds wall-clock. If you would need more, return a partial rev
 
 ## Output
 
-Return **only** a single JSON object on stdout. No prose before or after, no markdown fence — raw JSON. Schema:
+Return **only** a single JSON object on stdout. No prose before or after, no markdown fence — raw JSON.
 
-```json
+The shape (TypeScript-style notation, not literal JSON — pipes denote a union):
+
+```text
 {
   "verdict": "APPROVE" | "REQUEST_CHANGES" | "BLOCK",
   "findings": [
@@ -48,6 +50,23 @@ Return **only** a single JSON object on stdout. No prose before or after, no mar
     }
   ],
   "summary": "one-sentence overall assessment, no qualifiers"
+}
+```
+
+Concrete valid-JSON example (this is what your stdout should look like):
+
+```json
+{
+  "verdict": "REQUEST_CHANGES",
+  "findings": [
+    {
+      "severity": "request_changes",
+      "area": "edge_case",
+      "issue": "search_replace handler does not check for an empty replacement string at src/tools.ts:142-160.",
+      "suggestion": "Add an explicit guard returning errorResult before the replacement loop."
+    }
+  ],
+  "summary": "Tests cover the goal but the handler misses the empty-replacement edge case."
 }
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,13 @@ the change with fresh context and returns a JSON verdict:
 - `BLOCK` — do not push. Escalate to the human; the diff has a security,
   scope, or correctness issue that needs out-of-band judgment.
 
+**Fail-closed rule.** If the reviewer times out, errors, or returns output
+that is not parseable as the documented JSON schema, treat it as `BLOCK`
+and escalate to the human. Do **not** default to proceeding — a silent
+reviewer failure must not become a silent push, otherwise the gate is
+defeated. The escalation message should include the raw reviewer output
+(or the timeout/error) so the human can diagnose.
+
 The reviewer is **complementary** to (not a replacement for) `npm run pre-pr`,
 CodeRabbit, and Greptile — those run after the PR is open. The reviewer's
 job is the layer they miss: intent vs. implementation, missing edge cases,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,8 +128,12 @@ the change with fresh context and returns a JSON verdict:
 that is not parseable as the documented JSON schema, treat it as `BLOCK`
 and escalate to the human. Do **not** default to proceeding — a silent
 reviewer failure must not become a silent push, otherwise the gate is
-defeated. The escalation message should include the raw reviewer output
-(or the timeout/error) so the human can diagnose.
+defeated. Include diagnostic details (the timeout marker, error class,
+or a short excerpt of the unparseable output) in the escalation message,
+but **sanitize first**: redact API keys, tokens, paths under `.env`, and
+any line that looks secret-like before posting to PR artifacts or logs.
+If unsure whether output is safe to include, escalate with just the
+error class — the human can re-run locally.
 
 The reviewer is **complementary** to (not a replacement for) `npm run pre-pr`,
 CodeRabbit, and Greptile — those run after the PR is open. The reviewer's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,27 @@ API reference: @docs/cc-reference.md
 - Fix ALL review feedback before requesting merge
 - Do NOT merge without user approval
 
+## Reviewer Subagent (pre-PR semantic review)
+
+Before pushing a branch and opening a PR, **invoke the `reviewer` subagent**
+on the diff (defined in `.claude/agents/reviewer.md`). The reviewer reads
+the change with fresh context and returns a JSON verdict:
+
+- `APPROVE` — proceed to push + PR open as normal.
+- `REQUEST_CHANGES` — address the listed findings, then re-run the reviewer.
+  Do not open the PR until verdict is `APPROVE` or you have a concrete
+  reason to override a finding (document the reason in the PR body).
+- `BLOCK` — do not push. Escalate to the human; the diff has a security,
+  scope, or correctness issue that needs out-of-band judgment.
+
+The reviewer is **complementary** to (not a replacement for) `npm run pre-pr`,
+CodeRabbit, and Greptile — those run after the PR is open. The reviewer's
+job is the layer they miss: intent vs. implementation, missing edge cases,
+scope drift before code goes public.
+
+Time budget: ~120 seconds. If the reviewer takes longer than that
+consistently, log the run-times and revisit the prompt or the model choice.
+
 ## Testing
 
 - **Framework:** Vitest — native ESM + TypeScript, no config issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,10 +135,11 @@ any line that looks secret-like before posting to PR artifacts or logs.
 If unsure whether output is safe to include, escalate with just the
 error class — the human can re-run locally.
 
-The reviewer is **complementary** to (not a replacement for) `npm run pre-pr`,
-CodeRabbit, and Greptile — those run after the PR is open. The reviewer's
-job is the layer they miss: intent vs. implementation, missing edge cases,
-scope drift before code goes public.
+The reviewer is **complementary** to (not a replacement for) `npm run pre-pr`
+(deterministic local gate, runs before push) and the PR-stage AI reviewers
+configured for this repo (run after the PR is open). The reviewer's job is
+the layer those miss: intent vs. implementation, missing edge cases, scope
+drift — surfaced before code goes public.
 
 Time budget: ~120 seconds. If the reviewer takes longer than that
 consistently, log the run-times and revisit the prompt or the model choice.


### PR DESCRIPTION
## Summary

Adds a `reviewer` subagent (`.claude/agents/reviewer.md`) that main Claude Code (CC) must invoke on every diff before opening a PR. The reviewer reads the change with **fresh context** (no implementation bias) and returns a structured JSON verdict — `APPROVE`, `REQUEST_CHANGES`, or `BLOCK`.

CLAUDE.md is updated to document the new pre-PR step.

## Why

CodeRabbit, Greptile, SonarQube, and Stryker all run *after* a PR is open. The reviewer fills the gap **before** code goes public: intent vs. implementation, missing edge cases, scope drift. It does not duplicate the deterministic gates — it adds a semantic-review layer.

## Integration choice (and why pre-pr.sh is NOT modified)

The original ticket left this open: invoke the reviewer from `scripts/pre-pr.sh` *or* from CC's PR-opening flow, "decide based on what fits cleanest." Going with **CC's PR-opening flow** for these reasons:

- `pre-pr.sh` is a deterministic shell gate with no LLM dependency today. Adding `claude -p` from bash would couple every downstream project to a Claude-CLI install, auth setup, and variable LLM runtime/cost.
- CC already orchestrates push + PR open. The Agent tool with `subagent_type: reviewer` is a one-liner from CC's side.
- The reviewer is naturally invoked once per PR, not on every iterative `pre-pr` run during local development.

If we later see value in shifting it into `pre-pr.sh` (e.g., to enforce on humans pushing without CC), that's a follow-up — the agent definition is the same in either case.

## Verdict semantics

- **APPROVE** — push + open PR.
- **REQUEST_CHANGES** — address findings, re-run reviewer, then open PR. Override only with a documented reason in the PR body.
- **BLOCK** — do not push. Escalate to human (security / scope / correctness).

## Validation against past merged PR #23

Ran the reviewer prompt against PR #23 (`test(tools): assert errorResult message content — closes #13`, +674/-1 across 2 files):

| Field | Result |
|---|---|
| **Verdict** | `APPROVE` |
| **Findings** | 2 × `info` (none blocking) |
| **Wall-clock** | ~15s (well under the 120s target) |
| **Summary** | "Tests-only diff plus a single-line stryker threshold ratchet that faithfully implements the stated goal of killing StringLiteral mutants via exact `toBe()` assertions, with no scope drift, security risk, or gate regression." |

The two info findings:
1. `vault_analysis` preset-blocked test passes `action:'bogus'`, which is rejected by Zod in production — assertion documents an internal-only invariant. Suggestion: use a real enum value blocked by the preset (e.g. `'refresh'`) for production parity.
2. The 1pp ratchet history comment doesn't mention the new per-file mutation score (83.89% on `consolidated.ts`), useful context for the next ratchet.

Both are advisory; the original PR shipped without them and the reviewer does not block on them. The verdict aligns with what CodeRabbit + reviewers concluded at the time.

## Cost calculus

At ~15s per invocation, even running the reviewer on every PR is cheap. The escalation rule still applies: if false-positive `BLOCK` rate exceeds 20% over the first 5 real-world invocations after merge, demote to advisory-only and revisit the system prompt. Will log to `.adder-pipeline/session-log.md`.

## Test plan

- [ ] CodeRabbit / Greptile review clean (or addressed)
- [ ] Pipeline gate green (Prettier, ESLint, build, tests, Sonar — no source touched)
- [ ] Branch protection conversation-resolution requirement met
- [ ] Manual: a future PR demonstrates CC invoking the reviewer before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)