### PR TITLE
chore(stryker): set hard 80% floor on thresholds.break

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,35 @@ drift — surfaced before code goes public.
 Time budget: ~120 seconds. If the reviewer takes longer than that
 consistently, log the run-times and revisit the prompt or the model choice.
 
+## Mutation Testing — Hard 80% Floor (active)
+
+Stryker `thresholds.break` is set to **80** in `stryker.conf.mjs`. The
+pipeline (`npm run pre-pr`) blocks any push whose mutation score is
+below 80%. As of `chore/stryker-floor-80` the score is **64.66%**, so
+**every PR opened now will fail the Stryker gate** until the backfill
+work lifts the score over the floor.
+
+While the floor is unmet:
+
+- **No feature work.** Pipeline is frozen for new features. The only
+  PR types allowed to merge are (a) the floor-bootstrap PR itself
+  (admin-merged once, despite its own gate failure), and (b) backfill
+  PRs that add tests to kill surviving mutants.
+- **One file (or one logical group) per backfill PR** — no mega-PRs.
+  Each backfill PR must itself clear the 80% gate; aggregate score
+  ratchets up with each merge.
+- **Tests-only.** Hard Rule 8 still applies: backfill PRs add tests,
+  not production code, unless a minimal change is genuinely required
+  to make code testable (justify in PR body).
+- **Per-file carve-outs allowed but justified.** If a file truly can't
+  hit 80 (entry-point wiring like `index.ts`, content-heavy modules),
+  add a per-file Stryker threshold and explain why in the PR body.
+  More than 5 carve-outs ⇒ escalate for human policy review.
+
+Once the aggregate score is ≥80, the ratchet policy resumes:
+`thresholds.break = (current_score − 1pp)`, with a hard floor that
+never drops below 80.
+
 ## Testing
 
 - **Framework:** Vitest — native ESM + TypeScript, no config issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,18 +149,32 @@ consistently, log the run-times and revisit the prompt or the model choice.
 Stryker `thresholds.break` is set to **80** in `stryker.conf.mjs`. The
 pipeline (`npm run pre-pr`) blocks any push whose mutation score is
 below 80%. As of `chore/stryker-floor-80` the score is **64.66%**, so
-**every PR opened now will fail the Stryker gate** until the backfill
-work lifts the score over the floor.
+**every PR opened now will fail the Stryker gate** until the cumulative
+backfill series lifts the aggregate score over the floor.
 
-While the floor is unmet:
+### Why every backfill PR also needs admin-merge
+
+Stryker measures the whole `src/**/*.ts` surface, not just the file a
+PR touches. A single backfill PR that adds tests for one file might
+move the aggregate from 64.66 → 65.5 — still red against the 80 floor.
+**The Stryker gate therefore stays red across the entire backfill
+series**, not just the bootstrap PR. Every backfill PR in the series
+will need an admin-merge override, not just this one. That is the real
+cost of Option C: ~N admin-merges, where N is roughly the number of
+files needed to cross the aggregate floor. Plan accordingly.
+
+Once the aggregate crosses 80, normal gate enforcement resumes
+automatically — no further admin-merges needed.
+
+### Rules while the floor is unmet
 
 - **No feature work.** Pipeline is frozen for new features. The only
-  PR types allowed to merge are (a) the floor-bootstrap PR itself
-  (admin-merged once, despite its own gate failure), and (b) backfill
-  PRs that add tests to kill surviving mutants.
+  PR types allowed to merge are (a) the floor-bootstrap PR itself, and
+  (b) backfill PRs that add tests to kill surviving mutants. Both PR
+  types require admin-merge until the aggregate score crosses 80.
 - **One file (or one logical group) per backfill PR** — no mega-PRs.
-  Each backfill PR must itself clear the 80% gate; aggregate score
-  ratchets up with each merge.
+  This makes each merge's contribution to the aggregate score easy to
+  attribute and roll back if a regression surfaces.
 - **Tests-only.** Hard Rule 8 still applies: backfill PRs add tests,
   not production code, unless a minimal change is genuinely required
   to make code testable (justify in PR body).
@@ -168,10 +182,16 @@ While the floor is unmet:
   hit 80 (entry-point wiring like `index.ts`, content-heavy modules),
   add a per-file Stryker threshold and explain why in the PR body.
   More than 5 carve-outs ⇒ escalate for human policy review.
+- **Re-baseline after each merge.** Update the score-history comment
+  in `stryker.conf.mjs` and `~/projects/code-review-pipeline/build-log.md`
+  with the new aggregate so the next backfill PR knows where it starts.
+
+### After the floor is hit
 
 Once the aggregate score is ≥80, the ratchet policy resumes:
 `thresholds.break = (current_score − 1pp)`, with a hard floor that
-never drops below 80.
+never drops below 80. `low`/`high` re-separate from `break` at that
+point and the three-threshold band becomes meaningful again.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,14 +172,17 @@ automatically — no further admin-merges needed.
   PR types allowed to merge are (a) the floor-bootstrap PR itself, and
   (b) backfill PRs that add tests to kill surviving mutants. Both PR
   types require admin-merge until the aggregate score crosses 80.
-- **Temporary exception to the "Pull request workflow" merge rule.**
-  The standard rule below (Pull request workflow → step 6) requires
-  all CI checks green and `npm run pre-pr` passing before merge.
-  While the floor is unmet, bootstrap and backfill PRs are exempt
-  from that requirement **for the Stryker / Pipeline-gate failure
-  only** — every other gate must still be green, and every reviewer
-  thread must still be resolved. Once aggregate ≥ 80 the standard
-  rule resumes automatically for all PRs.
+- **Temporary exception to the standard pipeline gates.** Two
+  sections below — "Adder Code Review Pipeline → Before every push"
+  (`npm run pre-pr` must pass before push) and "Pull request workflow
+  → step 6" (all CI green + `npm run pre-pr` passing before merge) —
+  together would block any PR whose pre-pr fails on Stryker. While
+  the floor is unmet, bootstrap and backfill PRs are exempt from
+  both rules **for the Stryker / Pipeline-gate failure only**.
+  Every other pre-pr step (build, lint, audit, knip, madge, semgrep,
+  snyk, sonar) must still pass, every other CI check must still be
+  green, and every reviewer thread must still be resolved. Once
+  aggregate ≥ 80 the standard rules resume automatically for all PRs.
 - **One file (or one logical group) per backfill PR** — no mega-PRs.
   This makes each merge's contribution to the aggregate score easy to
   attribute and roll back if a regression surfaces.
@@ -191,8 +194,12 @@ automatically — no further admin-merges needed.
   add a per-file Stryker threshold and explain why in the PR body.
   More than 5 carve-outs ⇒ escalate for human policy review.
 - **Re-baseline after each merge.** Update the score-history comment
-  in `stryker.conf.mjs` and `~/projects/code-review-pipeline/build-log.md`
-  with the new aggregate so the next backfill PR knows where it starts.
+  in `stryker.conf.mjs` (the in-repo authoritative record). The
+  maintainer-local audit log at `~/projects/code-review-pipeline/build-log.md`
+  is updated by the same maintainer who runs the Adder pipeline locally;
+  contributors not running that pipeline can skip it — the in-repo
+  comment in `stryker.conf.mjs` is sufficient to know where the next
+  backfill PR starts from.
 
 ### After the floor is hit
 
@@ -349,6 +356,13 @@ All steps must pass (exit 0). Do **not** push until they do. If a gate is
 incorrectly failing, fix the gate's config rather than skipping it.
 `--skip-qwen` is allowed during fast iteration but the final run before
 opening a PR must include Qwen.
+
+**Exception while the Stryker mutation-testing floor is unmet:**
+bootstrap and backfill PRs may push despite a `npm run pre-pr` failure
+**caused only by the Stryker / Pipeline-gate red**. All other pre-pr
+steps must still pass. See "Mutation Testing — Hard 80% Floor (active)"
+above for the full carve-out rules. The exception ends automatically
+when aggregate score crosses 80.
 
 The gate invokes `npm test -- --coverage`. Your project's `test` script
 must be plain (e.g. `"test": "vitest run"`), without a hardcoded

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ consistently, log the run-times and revisit the prompt or the model choice.
 
 Stryker `thresholds.break` is set to **80** in `stryker.conf.mjs`. The
 pipeline (`npm run pre-pr`) blocks any push whose mutation score is
-below 80%. As of `chore/stryker-floor-80` the score is **64.66%**, so
+below 80%. As of the bootstrap PR (#49) the score is **64.66%**, so
 **every PR opened now will fail the Stryker gate** until the cumulative
 backfill series lifts the aggregate score over the floor.
 
@@ -172,6 +172,14 @@ automatically — no further admin-merges needed.
   PR types allowed to merge are (a) the floor-bootstrap PR itself, and
   (b) backfill PRs that add tests to kill surviving mutants. Both PR
   types require admin-merge until the aggregate score crosses 80.
+- **Temporary exception to the "Pull request workflow" merge rule.**
+  The standard rule below (Pull request workflow → step 6) requires
+  all CI checks green and `npm run pre-pr` passing before merge.
+  While the floor is unmet, bootstrap and backfill PRs are exempt
+  from that requirement **for the Stryker / Pipeline-gate failure
+  only** — every other gate must still be green, and every reviewer
+  thread must still be resolved. Once aggregate ≥ 80 the standard
+  rule resumes automatically for all PRs.
 - **One file (or one logical group) per backfill PR** — no mega-PRs.
   This makes each merge's contribution to the aggregate score easy to
   attribute and roll back if a regression surfaces.
@@ -189,7 +197,7 @@ automatically — no further admin-merges needed.
 ### After the floor is hit
 
 Once the aggregate score is ≥80, the ratchet policy resumes:
-`thresholds.break = (current_score − 1pp)`, with a hard floor that
+`thresholds.break = (current_score - 1pp)`, with a hard floor that
 never drops below 80. `low`/`high` re-separate from `break` at that
 point and the three-threshold band becomes meaningful again.
 
@@ -370,6 +378,13 @@ Coverage thresholds belong in `vitest.config.ts` / `jest.config.js`.
    - All CodeRabbit threads resolved
    - All CodeAnt threads resolved
    - `npm run pre-pr` passes locally on the branch head
+
+   **Exception while the Stryker mutation-testing floor is unmet:**
+   bootstrap and backfill PRs are exempt from the "all CI checks
+   green" and "`npm run pre-pr` passes" requirements **for the
+   Stryker / Pipeline-gate failure only**. See "Mutation Testing —
+   Hard 80% Floor (active)" above for the full carve-out rules. The
+   exception ends automatically when aggregate score crosses 80.
 
    **There is no human code review.** The pipeline spec is explicit: "No
    human code review — pipeline must be thorough enough that human only

--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -23,10 +23,13 @@ export default {
   //   56.78 → break 55       (PR #12 baseline)
   //   60.76 → break 59.76    (PR closing #14, switch exhaustiveness guards)
   //   64.66 → break 63.66    (PR closing #13, errorResult message content)
-  // See ~/projects/code-review-pipeline/baseline-findings.md for the bake-in
-  // run and build-log.md for each ratchet entry.
-  // TODO: raise `break` to 70 once a sustained run keeps the score above it.
-  thresholds: { high: 80, low: 70, break: 63.66 },
+  //   64.66 → break 80       (chore/stryker-floor-80, hard floor — the
+  //                           gate now blocks until backfill PRs lift the
+  //                           score to ≥80. This PR will fail its own gate;
+  //                           that is the bootstrap moment. After the floor
+  //                           is hit, ratchet resumes at (score − 1pp) but
+  //                           never drops below 80.)
+  thresholds: { high: 80, low: 70, break: 80 },
   // ignoreStatic must stay `false` — static mutants catch wrong defaults
   // / bad constants / bad regex literals, which is exactly what type checks
   // and linters miss. Explicit value (not relying on Stryker's current

--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -29,7 +29,13 @@ export default {
   //                           that is the bootstrap moment. After the floor
   //                           is hit, ratchet resumes at (score − 1pp) but
   //                           never drops below 80.)
-  thresholds: { high: 80, low: 70, break: 80 },
+  // See ~/projects/code-review-pipeline/baseline-findings.md for the bake-in
+  // run and build-log.md for the ratchet history (including this floor entry).
+  // `low` is collapsed to 80 alongside `break` and `high` — the 70-79 band
+  // would never be reported because `break` fires first. Three thresholds
+  // are kept (rather than a single value) for forward-compatibility with
+  // the post-floor ratchet, where `break` will sit below `high`/`low` again.
+  thresholds: { high: 80, low: 80, break: 80 },
   // ignoreStatic must stay `false` — static mutants catch wrong defaults
   // / bad constants / bad regex literals, which is exactly what type checks
   // and linters miss. Explicit value (not relying on Stryker's current

--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -27,7 +27,7 @@ export default {
   //                           gate now blocks until backfill PRs lift the
   //                           score to ≥80. This PR will fail its own gate;
   //                           that is the bootstrap moment. After the floor
-  //                           is hit, ratchet resumes at (score − 1pp) but
+  //                           is hit, ratchet resumes at (score - 1pp) but
   //                           never drops below 80.)
   // See ~/projects/code-review-pipeline/baseline-findings.md for the bake-in
   // run and build-log.md for the ratchet history (including this floor entry).


### PR DESCRIPTION
## Summary

- Locks Stryker `thresholds.break` at **80** in `stryker.conf.mjs` — ends the file-by-file ratchet (last value: `63.66`) and replaces it with a hard floor.
- Adds CLAUDE.md section "Mutation Testing — Hard 80% Floor (active)" documenting the freeze: feature work paused, only test-only backfill PRs (clearing 80 each) merge until aggregate score ≥ 80.
- **This PR is the bootstrap moment.** Current aggregate score is **64.66%** so the new gate will fail on this PR's own `npm run pre-pr` run. That is intentional — a gate-tightening change cannot pass its own new gate. Plan: admin-merge once, then Stage 2 (backfill PRs) lifts the score over the floor.

## Why a hard floor instead of continuing the ratchet

The ratchet (55 → 59.76 → 63.66) worked for kicking off mutation-testing discipline, but it has a ceiling: each backfill PR raises `break` by ~1pp, which would take dozens of PRs to reach a meaningful target. Locking at 80 inverts the incentive — every PR until score ≥ 80 must be a tests-only backfill that itself clears the gate. After the floor is hit, the ratchet resumes at `(score − 1pp)` but never drops below 80.

## Pre-PR reviewer subagent

Verdict: **APPROVE** with 3 info-only findings (none blocking).

- Internal consistency between `stryker.conf.mjs` and the new CLAUDE.md section holds.
- The self-defeating gate is explicitly acknowledged as the bootstrap contradiction in the policy text.
- Scope is clean — only the floor value and its documentation change.

Info findings (deferred, can be folded into a follow-up doc PR):

1. The "Adder Pipeline / Before every push" section ("All steps must pass") doesn't carve out the bootstrap PR explicitly — minor doc polish for clarity.
2. Per-file Stryker carve-out syntax not given as an example — useful for the upcoming backfill PRs.
3. Deleted comment lines in `stryker.conf.mjs` removed the pointer to `~/projects/code-review-pipeline/build-log.md` — audit-trail breadcrumb worth restoring.

## Expected gate status when the PR opens

- Build, lint, audit, knip, madge, semgrep, snyk, sonar, JSDoc — should all pass (no production code touched, only config + doc).
- Stryker — **expected to fail** with the new `break: 80` against the current `64.66%` score. This is the bootstrap.
- CodeRabbit + CodeAnt — will review normally; expected to comment on the policy text and may flag the deleted audit-trail pointer (info finding #3).

## Test plan

- [ ] CI runs to completion — confirm Stryker is the only failing step
- [ ] CodeRabbit + CodeAnt threads triaged (policy text only, no code semantics to argue)
- [ ] Admin-merge with override (Option C) — branch protection allows admin push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
