### PR TITLE
chore(stryker): carve out src/index.ts from mutate (1 of 5 budget)

### DIFF
--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -62,7 +62,7 @@ export default {
   //                           unclear, possibly coverageAnalysis: perTest
   //                           not attributing module-load Map init to
   //                           test cases. Investigate in a follow-up.)
-  //   70.30 → break 80       (PR #N, chore/stryker-carveout-index, +3.92
+  //   70.30 → break 80       (PR #51, chore/stryker-carveout-index, +3.92
   //                           pp from removing src/index.ts from mutate
   //                           glob — entry-point wiring, justified above
   //                           in the per-file carve-outs comment.)

--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -15,7 +15,33 @@ export default {
   // Stryker emits a zero-match warning for every unused glob otherwise.
   // See pipeline-spec.md → Stryker section → "key glob patterns to
   // actual project file types".
-  mutate: ["src/**/*.ts", "!src/**/*.test.ts"],
+  //
+  // Per-file carve-outs — see CLAUDE.md "Mutation Testing — Hard 80%
+  // Floor (active)" → "Per-file carve-outs allowed but justified".
+  // Budget: 5. Active count below; >5 ⇒ escalate for human policy review.
+  // Each line below is `// Carve-out N/5: <path>` so future authors can
+  // grep `Carve-out` to count what's already in flight.
+  //
+  // Carve-out 1/5: src/index.ts — entry-point wiring. Boots the MCP
+  //   server + StdioServerTransport, reads package.json for version,
+  //   runs the CLI flag dispatcher (--show-config / --setup /
+  //   --validate / --version), and starts the cache-build background
+  //   task. None of this can be exercised without spinning up the full
+  //   stdio transport in a child process; doing so in unit tests would
+  //   duplicate the smoke-test suite.
+  //
+  //   The file does contain two pure helpers (validatePort,
+  //   validateEnum) that are technically extract-and-test candidates,
+  //   but each is ~10 LOC and called only from the --setup CLI flow.
+  //   Extracting them to a setup-utils module would add a file +
+  //   import for ~10-15 reclaimed mutants out of 270 (~5 %). Decision:
+  //   subsumed in the carve-out by choice — extract later only if the
+  //   helpers grow non-trivial.
+  //
+  //   Removed 270 NoCoverage mutants (the file was at 0.00 %) from the
+  //   aggregate denominator, lifting the score from 66.38 % → 70.30 %
+  //   at carve-out time.
+  mutate: ["src/**/*.ts", "!src/**/*.test.ts", "!src/index.ts"],
   // Baseline score on v1.1.1 was 56.78 %. The `break` threshold ratchets up
   // `(new_score − 1pp)` after each test-improvement PR so it always sits
   // ~1pp below the current kill rate — tight enough to catch a regression,
@@ -23,12 +49,23 @@ export default {
   //   56.78 → break 55       (PR #12 baseline)
   //   60.76 → break 59.76    (PR closing #14, switch exhaustiveness guards)
   //   64.66 → break 63.66    (PR closing #13, errorResult message content)
-  //   64.66 → break 80       (chore/stryker-floor-80, hard floor — the
-  //                           gate now blocks until backfill PRs lift the
-  //                           score to ≥80. This PR will fail its own gate;
-  //                           that is the bootstrap moment. After the floor
-  //                           is hit, ratchet resumes at (score - 1pp) but
-  //                           never drops below 80.)
+  //   64.66 → break 80       (PR #49, chore/stryker-floor-80, hard floor —
+  //                           the gate now blocks until backfill PRs lift
+  //                           the score to ≥80. This PR will fail its own
+  //                           gate; that is the bootstrap moment. After
+  //                           the floor is hit, ratchet resumes at
+  //                           (score - 1pp) but never drops below 80.)
+  //   65.45 → break 80       (post-PR #49 cold baseline)
+  //   66.38 → break 80       (PR #50, +0.93 pp from skill.ts coverage —
+  //                           45 of 108 surviving mutants killed; the 63
+  //                           Map-line mutants survived for reasons
+  //                           unclear, possibly coverageAnalysis: perTest
+  //                           not attributing module-load Map init to
+  //                           test cases. Investigate in a follow-up.)
+  //   70.30 → break 80       (PR #N, chore/stryker-carveout-index, +3.92
+  //                           pp from removing src/index.ts from mutate
+  //                           glob — entry-point wiring, justified above
+  //                           in the per-file carve-outs comment.)
   // See ~/projects/code-review-pipeline/baseline-findings.md for the bake-in
   // run and build-log.md for the ratchet history (including this floor entry).
   // `low` is collapsed to 80 alongside `break` and `high` — the 70-79 band


### PR DESCRIPTION
## Summary

Second Stage 2 backfill PR. First per-file Stryker carve-out under the 5-carve-out budget.

- **Carve-out:** `src/index.ts` (entry-point wiring at 0.00% score, 270 NoCoverage mutants)
- **Mechanism:** add `!src/index.ts` to the Stryker `mutate` glob — file's 270 mutants are removed from the aggregate denominator
- **Budget after this PR:** 1/5 active. Future PRs adding a 2nd should grep `Carve-out` in `stryker.conf.mjs` to verify count.

## Score impact

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Aggregate | 66.38% | **70.30%** | **+3.92pp** |
| Total mutants | 4845 | 4575 | −270 |
| Killed | 3216 | 3216 | unchanged |
| Distance to 80 | 13.62pp | 9.70pp | −3.92pp |

The killed count is unchanged — only the denominator drops. Mathematically guaranteed gain, no test execution dependency.

## Why src/index.ts can't be unit-tested

Boots `McpServer` + `StdioServerTransport`, reads `package.json` for version, runs the CLI flag dispatcher (`--show-config` / `--setup` / `--validate` / `--version`), starts cache-build in background. Exercising any of this in unit tests would require spinning up a child-process MCP transport — work that is already covered by the smoke-test suite (`test:smoke`).

The file does contain two pure helpers (`validatePort`, `validateEnum`) that the reviewer subagent flagged as extract-and-test candidates. Each is ~10 LOC, called only from the `--setup` flow, and would reclaim ~10-15 of 270 mutants (~5%) at the cost of a new utility module + import. Decision: subsumed in the carve-out by choice — extract only if the helpers grow non-trivial. Documented inline in `stryker.conf.mjs`.

## Pre-PR reviewer

Verdict: **APPROVE** with 3 info findings (all folded):
- Pure helpers extract candidate → documented decision in carve-out comment
- Budget visibility → numbered `Carve-out N/5: <path>` grep-able pattern
- PR #N placeholder in score-history → will be updated post-PR-open

## Cumulative Stage 2 progress

- PR #49 (bootstrap): floor set at 80, aggregate 64.66 → 65.45 (cold re-measure)
- PR #50 (skill.ts tests): 65.45 → 66.38 (+0.93pp)
- PR #51 (this carve-out): 66.38 → 70.30 (+3.92pp)
- **Total: 64.66 → 70.30 (+5.64pp). Distance to 80 floor: 9.70pp.**

## Test plan

- [ ] CI runs to completion — confirm only Pipeline-gate (Stryker) fails
- [ ] CodeRabbit + Greptile + Gemini threads triaged
- [ ] Admin-merge under Stage 2 pre-authorization (config-only diff carve-out, reviewer APPROVE, all gates green except Stryker, score moves up)
- [ ] Update score-history "PR #N" placeholder to actual PR number after open

🤖 Generated with [Claude Code](https://claude.com/claude-code)
