### PR TITLE
test(obsidian): backfill mutation coverage on putContent (21 mutants)

### DIFF
--- a/src/__tests__/obsidian.test.ts
+++ b/src/__tests__/obsidian.test.ts
@@ -981,6 +981,16 @@ describe("ObsidianClient — getFileContents", () => {
 // ObsidianClient — putContent
 // ---------------------------------------------------------------------------
 describe("ObsidianClient — putContent", () => {
+  // Restore vi.spyOn-installed mocks (notably the file-level
+  // process.stderr.write spy) between tests so .mock.calls history
+  // doesn't leak from a "warns" test into a subsequent "does NOT warn"
+  // assertion. The file-level beforeEach re-installs the spy, but
+  // vi.spyOn on the same property returns the same mock reference and
+  // does not auto-clear call history.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("writes content successfully", async () => {
     const { client, mockRequest } = createMockedClient();
     mockRequest.mockResolvedValue(ok204());
@@ -1075,6 +1085,156 @@ describe("ObsidianClient — putContent", () => {
       "/vault/note.md",
       expect.objectContaining({ body: "" }),
     );
+  });
+
+  // --- Stryker mutation backfill: header shape, status acceptance, verify branches ---
+
+  it("sends Content-Type: text/markdown on the PUT request", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue(ok204());
+
+    await client.putContent("note.md", "body");
+    const headers = getCallHeaders(mockRequest.mock.calls[0]);
+    expect(headers["Content-Type"]).toBe("text/markdown");
+  });
+
+  it("accepts 200 OK in addition to 204 No Content", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "",
+    });
+
+    await expect(client.putContent("note.md", "body")).resolves.toBeUndefined();
+  });
+
+  it("does NOT call verify-read when verifyWrites is disabled (default)", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue(ok204());
+
+    await client.putContent("note.md", "body");
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("verify-read sends Accept: text/markdown header", async () => {
+    const { client, mockRequest } = createMockedClient({ verifyWrites: true });
+    mockRequest.mockResolvedValueOnce(ok204());
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 200,
+      headers: {},
+      body: "matching",
+    });
+
+    await client.putContent("note.md", "matching");
+    const verifyHeaders = getCallHeaders(mockRequest.mock.calls[1]);
+    expect(verifyHeaders["Accept"]).toBe("text/markdown");
+    // The verify call must be a GET to the same path
+    expect(mockRequest.mock.calls[1]?.[0]).toBe("GET");
+    expect(mockRequest.mock.calls[1]?.[1]).toBe("/vault/note.md");
+  });
+
+  it("does NOT warn when verify-read content matches written content", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    const { client, mockRequest } = createMockedClient({ verifyWrites: true });
+    mockRequest.mockResolvedValueOnce(ok204());
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 200,
+      headers: {},
+      body: "exact match",
+    });
+
+    await client.putContent("note.md", "exact match");
+    const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((c) => c.includes("Write verification failed"))).toBe(
+      false,
+    );
+    expect(
+      calls.some((c) => c.includes("Write verification inconclusive")),
+    ).toBe(false);
+  });
+
+  it("considers content matched when only surrounding whitespace differs", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    const { client, mockRequest } = createMockedClient({ verifyWrites: true });
+    mockRequest.mockResolvedValueOnce(ok204());
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 200,
+      headers: {},
+      body: "  body  \n",
+    });
+
+    await client.putContent("note.md", "body");
+    const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((c) => c.includes("Write verification failed"))).toBe(
+      false,
+    );
+  });
+
+  it("warns 'inconclusive' when verify-read returns non-200 status", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    const { client, mockRequest } = createMockedClient({ verifyWrites: true });
+    mockRequest.mockResolvedValueOnce(ok204());
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 503,
+      headers: {},
+      body: "service unavailable",
+    });
+
+    await client.putContent("note.md", "body");
+    const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+    const inconclusive = calls.find((c) =>
+      c.includes("Write verification inconclusive"),
+    );
+    expect(inconclusive).toBeDefined();
+    expect(inconclusive).toContain("note.md");
+    expect(inconclusive).toContain("503");
+    // Must NOT also emit the mismatch warning when status was non-200
+    expect(calls.some((c) => c.includes("Write verification failed"))).toBe(
+      false,
+    );
+  });
+
+  it("warning text 'failed' includes 'content mismatch' explanation", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    const { client, mockRequest } = createMockedClient({ verifyWrites: true });
+    mockRequest.mockResolvedValueOnce(ok204());
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 200,
+      headers: {},
+      body: "different",
+    });
+
+    await client.putContent("note.md", "expected");
+    const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+    const failed = calls.find((c) => c.includes("Write verification failed"));
+    expect(failed).toContain("note.md");
+    expect(failed).toContain("content mismatch");
+  });
+
+  it("read-failure warning includes the underlying error message", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    const { client, mockRequest } = createMockedClient({ verifyWrites: true });
+    mockRequest.mockResolvedValueOnce(ok204());
+    mockRequest.mockRejectedValueOnce(new Error("ECONNRESET"));
+
+    await client.putContent("note.md", "body");
+    const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+    const readFailed = calls.find((c) =>
+      c.includes("Write verification could not read back"),
+    );
+    expect(readFailed).toContain("note.md");
+    expect(readFailed).toContain("ECONNRESET");
   });
 });
 

--- a/src/__tests__/obsidian.test.ts
+++ b/src/__tests__/obsidian.test.ts
@@ -761,6 +761,13 @@ function createMockedClient(overrides: Partial<Config> = {}): {
   return { client, mockRequest };
 }
 
+/** Installs a no-op spy on process.stderr.write and returns it for assertions. */
+function spyOnStderr(): ReturnType<
+  typeof vi.spyOn<typeof process.stderr, "write">
+> {
+  return vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+}
+
 function okJson(data: unknown): RequestResult {
   return {
     statusCode: 200,
@@ -1029,9 +1036,7 @@ describe("ObsidianClient — putContent", () => {
   });
 
   it("warns on write verification mismatch", async () => {
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true);
+    const stderrSpy = spyOnStderr();
     const { client, mockRequest } = createMockedClient({ verifyWrites: true });
     mockRequest.mockResolvedValueOnce(ok204());
     mockRequest.mockResolvedValueOnce({
@@ -1048,9 +1053,7 @@ describe("ObsidianClient — putContent", () => {
   });
 
   it("warns on write verification read failure", async () => {
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true);
+    const stderrSpy = spyOnStderr();
     const { client, mockRequest } = createMockedClient({ verifyWrites: true });
     mockRequest.mockResolvedValueOnce(ok204());
     mockRequest.mockRejectedValueOnce(new Error("read failed"));
@@ -1135,9 +1138,7 @@ describe("ObsidianClient — putContent", () => {
   });
 
   it("does NOT warn when verify-read content matches written content", async () => {
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true);
+    const stderrSpy = spyOnStderr();
     const { client, mockRequest } = createMockedClient({ verifyWrites: true });
     mockRequest.mockResolvedValueOnce(ok204());
     mockRequest.mockResolvedValueOnce({
@@ -1157,9 +1158,7 @@ describe("ObsidianClient — putContent", () => {
   });
 
   it("considers content matched when only surrounding whitespace differs", async () => {
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true);
+    const stderrSpy = spyOnStderr();
     const { client, mockRequest } = createMockedClient({ verifyWrites: true });
     mockRequest.mockResolvedValueOnce(ok204());
     mockRequest.mockResolvedValueOnce({
@@ -1176,9 +1175,7 @@ describe("ObsidianClient — putContent", () => {
   });
 
   it("warns 'inconclusive' when verify-read returns non-200 status", async () => {
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true);
+    const stderrSpy = spyOnStderr();
     const { client, mockRequest } = createMockedClient({ verifyWrites: true });
     mockRequest.mockResolvedValueOnce(ok204());
     mockRequest.mockResolvedValueOnce({
@@ -1202,9 +1199,7 @@ describe("ObsidianClient — putContent", () => {
   });
 
   it("warning text 'failed' includes 'content mismatch' explanation", async () => {
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true);
+    const stderrSpy = spyOnStderr();
     const { client, mockRequest } = createMockedClient({ verifyWrites: true });
     mockRequest.mockResolvedValueOnce(ok204());
     mockRequest.mockResolvedValueOnce({
@@ -1221,9 +1216,7 @@ describe("ObsidianClient — putContent", () => {
   });
 
   it("read-failure warning includes the underlying error message", async () => {
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true);
+    const stderrSpy = spyOnStderr();
     const { client, mockRequest } = createMockedClient({ verifyWrites: true });
     mockRequest.mockResolvedValueOnce(ok204());
     mockRequest.mockRejectedValueOnce(new Error("ECONNRESET"));


### PR DESCRIPTION
## Summary

Third Stage 2 backfill PR. Targets `src/obsidian.ts#putContent` — 21 surviving mutants in lines 977-1025.

- **Aggregate:** 70.30% → ~70.7% (+0.4pp expected). Distance to 80: 9.70 → ~9.3pp.
- **Diff:** tests-only (`src/__tests__/obsidian.test.ts`); 9 new test cases + describe-scoped `afterEach(() => vi.restoreAllMocks())`.

## Why putContent first (not patchContent)

`patchContent` has 23 survivors (slightly more) but ~110 lines of heading/block/frontmatter dispatch logic. `putContent` is a tight 47-line method whose 21 mutants are concentrated in clear branches (Content-Type header, 200-vs-204 acceptance, `if (verifyWrites)`, verify-match logic, warning text). Higher kill-rate per LOC of new test code.

## What the 9 tests target

| Mutant location | New test |
|---|---|
| L985 — `Content-Type: "text/markdown"` literal | sends Content-Type header |
| L988 — `statusCode !== 204 && !== 200` | accepts 200 OK in addition to 204 |
| L997 — `if (this.verifyWrites)` | does NOT verify-read when disabled |
| L999-1000 — verify GET shape | verify-read sends Accept header |
| L1003-1004 — match logic | does NOT warn on match |
| L1004 — `body.trim() !== content.trim()` | matched even if whitespace differs |
| L1010 — `else if (statusCode !== 200)` | warns 'inconclusive' on non-200 |
| L1007 — "failed" warning text | warning includes 'content mismatch' |
| L1019 — read-failure warning text | warning includes underlying error msg |

## Test isolation fix folded

Reviewer subagent flagged that the file-level `beforeEach` re-installs the stderr spy via `vi.spyOn`, but `vi.spyOn` returns the *same* mock reference and does not auto-clear `.mock.calls` between tests — leaking writes from one test into another's negative assertions. First-pass workaround was per-test `stderrSpy.mockClear()`; the cleaner pattern (per the reviewer) is a describe-scoped `afterEach(() => vi.restoreAllMocks())`. Applied.

## Stage 2 cumulative progress

| PR | Target | Δ | Cumulative |
|---|---|---:|---:|
| #49 | floor bootstrap | — | 65.45% |
| #50 | skill.ts coverage | +0.93 | 66.38% |
| #51 | index.ts carve-out (1/5) | +3.92 | 70.30% |
| **#52 (this)** | **obsidian.ts/putContent** | **+0.4** | **~70.7%** |

Distance to 80: ~9.3pp. ~12-15 more PRs at this rate.

## Backfill queue (rough order)

- patchContent (23)
- ActiveFile family (31, 5 methods)
- PeriodicNotesCurrent + ByDate (55, repetitive CRUD)
- CaseInsensitiveFallback (23)
- Search (16)
- shared.ts (135), cache.ts (239), config.ts (150)

## Pre-PR reviewer subagent

Verdict: APPROVE (after folding the `afterEach` fix).

## Test plan

- [ ] CI completes — only Pipeline-gate (Stryker) fails
- [ ] Reviewers triaged
- [ ] Admin-merge under Stage 2 pre-authorization (test-only diff, reviewer APPROVE, all gates green except Stryker, score moves up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
