### PR TITLE
test(obsidian): backfill mutation coverage on active file family (5 methods, 31 mutants)

### DIFF
--- a/src/__tests__/obsidian.test.ts
+++ b/src/__tests__/obsidian.test.ts
@@ -1818,7 +1818,11 @@ describe("ObsidianClient — patchContent", () => {
         statusCode: 200,
         headers: { "content-type": "application/json" },
         // headings is a string, not an array
-        body: JSON.stringify({ headings: "oops", blocks: [], frontmatterFields: [] }),
+        body: JSON.stringify({
+          headings: "oops",
+          blocks: [],
+          frontmatterFields: [],
+        }),
       });
 
     await expect(
@@ -2275,9 +2279,30 @@ describe("ObsidianClient — active file", () => {
     await expect(client.appendActiveFile("body")).resolves.toBeUndefined();
   });
 
-  it("patchActiveFile sends PATCH to /active/ and strips Create-Target-If-Missing", async () => {
+  it("patchActiveFile sends PATCH to /active/ and strips Create-Target-If-Missing even when buildPatchHeaders would set it", async () => {
     const { client, mockRequest } = createMockedClient();
     mockRequest.mockResolvedValue(ok204());
+
+    // Seed the header by patching buildPatchHeaders to include it. Without this
+    // seeding, the strip mutant survives because nothing produces the header in
+    // the first place (the active-file public API has Omit<PatchOptions, "createIfMissing">).
+    const originalBuild = (
+      client as unknown as Record<
+        string,
+        (options: unknown) => Record<string, string>
+      >
+    )["buildPatchHeaders"]?.bind(client);
+    if (!originalBuild) throw new Error("buildPatchHeaders not found");
+    (
+      client as unknown as Record<
+        string,
+        (options: unknown) => Record<string, string>
+      >
+    )["buildPatchHeaders"] = (options: unknown) => {
+      const h = originalBuild(options);
+      h["Create-Target-If-Missing"] = "true";
+      return h;
+    };
 
     await client.patchActiveFile("body", {
       operation: "append",
@@ -2287,7 +2312,8 @@ describe("ObsidianClient — active file", () => {
     expect(mockRequest.mock.calls[0]?.[0]).toBe("PATCH");
     expect(mockRequest.mock.calls[0]?.[1]).toBe("/active/");
     const headers = getCallHeaders(mockRequest.mock.calls[0]);
-    // Active file PATCH must never include Create-Target-If-Missing (REST API doesn't support it)
+    // Active file PATCH must never include Create-Target-If-Missing (REST API doesn't support it).
+    // Seeded above, then patchActiveFile's `delete headers[...]` should remove it.
     expect(headers["Create-Target-If-Missing"]).toBeUndefined();
   });
 
@@ -2322,7 +2348,7 @@ describe("ObsidianClient — active file", () => {
     expect(mockCache.invalidateAll).toHaveBeenCalled();
   });
 
-  it("patchActiveFile retry uses '(active file)' as the debug-log label", async () => {
+  it("patchActiveFile retry passes '(active file)' as the label arg to retryPatchWithMapLookup (visible in retry debug log)", async () => {
     setDebugEnabled(true);
     const stderrSpy = spyOnStderr();
     const { client, mockRequest } = createMockedClient();
@@ -2350,11 +2376,13 @@ describe("ObsidianClient — active file", () => {
       target: "tasks",
     });
 
+    // The label arg is rendered by retryPatchWithMapLookup's debug log
+    // (`PATCH retry: heading "..." → "..." in ${label}`), not the
+    // caller-side auto-corrected log (which has "(active file)" hardcoded).
+    // Asserting on the retry log proves the label parameter is actually plumbed.
     const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
-    const correctedLog = calls.find((c) =>
-      c.includes("PATCH heading auto-corrected"),
-    );
-    expect(correctedLog).toContain("(active file)");
+    const retryLog = calls.find((c) => c.includes("PATCH retry: heading"));
+    expect(retryLog).toContain("(active file)");
   });
 
   it("patchActiveFile retry passes /active/ as the patch path (not a vault path)", async () => {
@@ -2397,13 +2425,13 @@ describe("ObsidianClient — active file", () => {
       body: '{"message":"heading not found"}',
     });
 
-    await client
-      .patchActiveFile("body", {
+    await expect(
+      client.patchActiveFile("body", {
         operation: "append",
         targetType: "block",
         target: "block-id",
-      })
-      .catch(() => undefined);
+      }),
+    ).rejects.toThrow(ObsidianApiError);
 
     // Only 1 call — no retry because targetType is "block"
     expect(mockRequest).toHaveBeenCalledTimes(1);
@@ -2418,13 +2446,13 @@ describe("ObsidianClient — active file", () => {
       body: '{"message":"invalid frontmatter"}',
     });
 
-    await client
-      .patchActiveFile("body", {
+    await expect(
+      client.patchActiveFile("body", {
         operation: "append",
         targetType: "heading",
         target: "Some Heading",
-      })
-      .catch(() => undefined);
+      }),
+    ).rejects.toThrow(ObsidianApiError);
 
     // Only 1 call — no retry because the 400 body isn't a heading-not-found error
     expect(mockRequest).toHaveBeenCalledTimes(1);

--- a/src/__tests__/obsidian.test.ts
+++ b/src/__tests__/obsidian.test.ts
@@ -2193,6 +2193,262 @@ describe("ObsidianClient — active file", () => {
     await client.deleteActiveFile();
     expect(mockCache.invalidateAll).toHaveBeenCalled();
   });
+
+  // --- Stryker mutation backfill: request shape, status acceptance, retry logic ---
+
+  // Reset spies + debug flag between tests so log-text and call-count
+  // assertions don't accumulate state from earlier active-file tests.
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setDebugEnabled(false);
+  });
+
+  it("getActiveFile sends GET to /active/ with Accept header for markdown", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "# active",
+    });
+
+    await client.getActiveFile("markdown");
+    expect(mockRequest.mock.calls[0]?.[0]).toBe("GET");
+    expect(mockRequest.mock.calls[0]?.[1]).toBe("/active/");
+    const headers = getCallHeaders(mockRequest.mock.calls[0]);
+    expect(headers["Accept"]).toBe("text/markdown");
+  });
+
+  it("getActiveFile sends Accept header for json format", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content: "x", path: "n.md", tags: [], stat: {} }),
+    });
+
+    await client.getActiveFile("json");
+    const headers = getCallHeaders(mockRequest.mock.calls[0]);
+    expect(headers["Accept"]).toBe("application/vnd.olrapi.note+json");
+  });
+
+  it("putActiveFile sends PUT to /active/ with Content-Type: text/markdown", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue(ok204());
+
+    await client.putActiveFile("body");
+    expect(mockRequest.mock.calls[0]?.[0]).toBe("PUT");
+    expect(mockRequest.mock.calls[0]?.[1]).toBe("/active/");
+    const headers = getCallHeaders(mockRequest.mock.calls[0]);
+    expect(headers["Content-Type"]).toBe("text/markdown");
+  });
+
+  it("putActiveFile accepts 200 OK in addition to 204", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "",
+    });
+
+    await expect(client.putActiveFile("body")).resolves.toBeUndefined();
+  });
+
+  it("appendActiveFile sends POST to /active/ with Content-Type: text/markdown", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue(ok204());
+
+    await client.appendActiveFile("body");
+    expect(mockRequest.mock.calls[0]?.[0]).toBe("POST");
+    expect(mockRequest.mock.calls[0]?.[1]).toBe("/active/");
+    const headers = getCallHeaders(mockRequest.mock.calls[0]);
+    expect(headers["Content-Type"]).toBe("text/markdown");
+  });
+
+  it("appendActiveFile accepts 200 OK in addition to 204", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "",
+    });
+
+    await expect(client.appendActiveFile("body")).resolves.toBeUndefined();
+  });
+
+  it("patchActiveFile sends PATCH to /active/ and strips Create-Target-If-Missing", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue(ok204());
+
+    await client.patchActiveFile("body", {
+      operation: "append",
+      targetType: "heading",
+      target: "H",
+    });
+    expect(mockRequest.mock.calls[0]?.[0]).toBe("PATCH");
+    expect(mockRequest.mock.calls[0]?.[1]).toBe("/active/");
+    const headers = getCallHeaders(mockRequest.mock.calls[0]);
+    // Active file PATCH must never include Create-Target-If-Missing (REST API doesn't support it)
+    expect(headers["Create-Target-If-Missing"]).toBeUndefined();
+  });
+
+  it("patchActiveFile accepts 200 OK in addition to 204", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "",
+    });
+
+    await expect(
+      client.patchActiveFile("body", {
+        operation: "append",
+        targetType: "heading",
+        target: "H",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("patchActiveFile invalidates cache on success", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue(ok204());
+    const mockCache = { invalidate: vi.fn(), invalidateAll: vi.fn() };
+    client.setCache(mockCache);
+
+    await client.patchActiveFile("body", {
+      operation: "append",
+      targetType: "heading",
+      target: "H",
+    });
+    expect(mockCache.invalidateAll).toHaveBeenCalled();
+  });
+
+  it("patchActiveFile retry uses '(active file)' as the debug-log label", async () => {
+    setDebugEnabled(true);
+    const stderrSpy = spyOnStderr();
+    const { client, mockRequest } = createMockedClient();
+    const docMap = {
+      headings: ["Tasks"],
+      blocks: [],
+      frontmatterFields: [],
+    };
+    mockRequest
+      .mockResolvedValueOnce({
+        statusCode: 400,
+        headers: {},
+        body: '{"message":"heading not found"}',
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(docMap),
+      })
+      .mockResolvedValueOnce(ok204());
+
+    await client.patchActiveFile("body", {
+      operation: "append",
+      targetType: "heading",
+      target: "tasks",
+    });
+
+    const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+    const correctedLog = calls.find((c) =>
+      c.includes("PATCH heading auto-corrected"),
+    );
+    expect(correctedLog).toContain("(active file)");
+  });
+
+  it("patchActiveFile retry passes /active/ as the patch path (not a vault path)", async () => {
+    const { client, mockRequest } = createMockedClient();
+    const docMap = {
+      headings: ["Tasks"],
+      blocks: [],
+      frontmatterFields: [],
+    };
+    mockRequest
+      .mockResolvedValueOnce({
+        statusCode: 400,
+        headers: {},
+        body: '{"message":"heading not found"}',
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(docMap),
+      })
+      .mockResolvedValueOnce(ok204());
+
+    await client.patchActiveFile("body", {
+      operation: "append",
+      targetType: "heading",
+      target: "tasks",
+    });
+
+    expect(mockRequest).toHaveBeenCalledTimes(3);
+    // Third call (retry PATCH) must hit /active/, not a /vault/* path
+    expect(mockRequest.mock.calls[2]?.[0]).toBe("PATCH");
+    expect(mockRequest.mock.calls[2]?.[1]).toBe("/active/");
+  });
+
+  it("patchActiveFile does NOT retry when targetType is not 'heading'", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 400,
+      headers: {},
+      body: '{"message":"heading not found"}',
+    });
+
+    await client
+      .patchActiveFile("body", {
+        operation: "append",
+        targetType: "block",
+        target: "block-id",
+      })
+      .catch(() => undefined);
+
+    // Only 1 call — no retry because targetType is "block"
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("patchActiveFile does NOT retry when 400 body is not a heading-not-found error", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 400,
+      headers: {},
+      // 400 with a body that doesn't match the heading-not-found pattern
+      body: '{"message":"invalid frontmatter"}',
+    });
+
+    await client
+      .patchActiveFile("body", {
+        operation: "append",
+        targetType: "heading",
+        target: "Some Heading",
+      })
+      .catch(() => undefined);
+
+    // Only 1 call — no retry because the 400 body isn't a heading-not-found error
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("deleteActiveFile sends DELETE to /active/", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue(ok204());
+
+    await client.deleteActiveFile();
+    expect(mockRequest.mock.calls[0]?.[0]).toBe("DELETE");
+    expect(mockRequest.mock.calls[0]?.[1]).toBe("/active/");
+  });
+
+  it("deleteActiveFile accepts 200 OK in addition to 204 and 404", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "",
+    });
+
+    await expect(client.deleteActiveFile()).resolves.toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fifth Stage 2 backfill PR. Batches the entire active-file family (5 methods, 31 mutants) — they mirror the vault-file family in shape so they share patterns.

- **Aggregate:** 70.91% → ~71.4% (+0.4-0.5pp expected). Distance to 80: 9.09 → ~8.6pp.
- **Diff:** tests-only, +256 lines (15 new tests + describe-scoped `afterEach`).

## Methods covered + new tests

| Method | Mutants | New tests |
|---|---:|---|
| `getActiveFile` | 5 | path/method/Accept (markdown), Accept (json) |
| `putActiveFile` | 4 | request shape, 200-vs-204 status |
| `appendActiveFile` | 4 | request shape, 200-vs-204 status |
| `patchActiveFile` | 16 | shape + Create-Target-If-Missing strip, 200-vs-204, cache invalidate, retry "(active file)" label, retry path, no-retry on non-heading targetType, no-retry on non-heading-not-found 400 body |
| `deleteActiveFile` | 2 | request shape, 200 OK acceptance |

## Patterns reused

Same patterns established in PR #52 (putContent) and #53 (patchContent):
- `spyOnStderr()` helper
- describe-scoped `afterEach(() => { vi.restoreAllMocks(); setDebugEnabled(false); })`
- `setDebugEnabled(true)` in tests asserting on debug-level log output
- Per-call assertions on `mockRequest.mock.calls[N]` (HTTP verb + path + headers)

## Pre-PR reviewer

Verdict: **APPROVE** with 1 info finding (add `isHeadingNotFoundError` false-branch test in active-file context — folded as the 15th test).

## Stage 2 cumulative

| PR | Δ aggregate | Cumulative |
|---|---:|---:|
| #49 | bootstrap | 65.45% |
| #50 | +0.93 | 66.38% |
| #51 | +3.92 | 70.30% |
| #52 | +0.43 | 70.73% |
| #53 | +0.18 | 70.91% |
| **this** | **+0.4-0.5** | **~71.4%** |

Distance to 80: ~8.6pp.

## Test plan

- [ ] CI completes — only Pipeline-gate (Stryker) fails
- [ ] Reviewers triaged
- [ ] Admin-merge under Stage 2 pre-authorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)
