### PR TITLE
test(obsidian): backfill mutation coverage on periodic notes family (10 methods, 55 mutants)

### DIFF
--- a/src/__tests__/obsidian.test.ts
+++ b/src/__tests__/obsidian.test.ts
@@ -3110,4 +3110,405 @@ describe("ObsidianClient — periodic notes (by date)", () => {
       client.deletePeriodicNoteForDate("daily", 2026, 1, 1),
     ).resolves.toBeUndefined();
   });
+
+  // --- Stryker mutation backfill: request shape, status acceptance, retry logic ---
+
+  // Mirrors the active-file describe block: reset spies + debug between tests
+  // because the patch retry tests below enable debug logging to assert on the
+  // (periodic: <type> [date]) label rendered by retryPatchWithMapLookup.
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setDebugEnabled(false);
+  });
+
+  it("getPeriodicNoteForDate sends Accept: text/markdown header for markdown format", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "body",
+    });
+
+    await client.getPeriodicNoteForDate("daily", 2026, 1, 1, "markdown");
+    const headers = getCallHeaders(mockRequest.mock.calls[0]);
+    expect(headers["Accept"]).toBe("text/markdown");
+  });
+
+  it("getPeriodicNoteForDate sends Accept: vnd.olrapi.note+json for json format", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content: "x", path: "n.md", tags: [], stat: {} }),
+    });
+
+    await client.getPeriodicNoteForDate("daily", 2026, 1, 1, "json");
+    const headers = getCallHeaders(mockRequest.mock.calls[0]);
+    expect(headers["Accept"]).toBe("application/vnd.olrapi.note+json");
+  });
+
+  it("putPeriodicNoteForDate sends Content-Type: text/markdown", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue(ok204());
+
+    await client.putPeriodicNoteForDate("daily", 2026, 1, 1, "body");
+    const headers = getCallHeaders(mockRequest.mock.calls[0]);
+    expect(headers["Content-Type"]).toBe("text/markdown");
+  });
+
+  it("putPeriodicNoteForDate accepts 200 OK in addition to 204", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "",
+    });
+
+    await expect(
+      client.putPeriodicNoteForDate("daily", 2026, 1, 1, "body"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("appendPeriodicNoteForDate sends Content-Type: text/markdown", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue(ok204());
+
+    await client.appendPeriodicNoteForDate("daily", 2026, 1, 1, "body");
+    const headers = getCallHeaders(mockRequest.mock.calls[0]);
+    expect(headers["Content-Type"]).toBe("text/markdown");
+  });
+
+  it("appendPeriodicNoteForDate accepts 200 OK in addition to 204", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "",
+    });
+
+    await expect(
+      client.appendPeriodicNoteForDate("daily", 2026, 1, 1, "body"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("patchPeriodicNoteForDate accepts 200 OK in addition to 204", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "",
+    });
+
+    await expect(
+      client.patchPeriodicNoteForDate("daily", 2026, 1, 1, "body", {
+        operation: "append",
+        targetType: "heading",
+        target: "H",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("patchPeriodicNoteForDate invalidates all cache on success", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue(ok204());
+    const mockCache = { invalidate: vi.fn(), invalidateAll: vi.fn() };
+    client.setCache(mockCache);
+
+    await client.patchPeriodicNoteForDate("daily", 2026, 1, 1, "body", {
+      operation: "append",
+      targetType: "heading",
+      target: "H",
+    });
+    expect(mockCache.invalidateAll).toHaveBeenCalled();
+  });
+
+  it("patchPeriodicNoteForDate retry passes '(periodic: daily date)' as the label arg (visible in retry debug log)", async () => {
+    setDebugEnabled(true);
+    const stderrSpy = spyOnStderr();
+    const { client, mockRequest } = createMockedClient();
+    const docMap = {
+      headings: ["Tasks"],
+      blocks: [],
+      frontmatterFields: [],
+    };
+    mockRequest
+      .mockResolvedValueOnce({
+        statusCode: 400,
+        headers: {},
+        body: '{"message":"heading not found"}',
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(docMap),
+      })
+      .mockResolvedValueOnce(ok204());
+
+    await client.patchPeriodicNoteForDate("daily", 2026, 1, 1, "body", {
+      operation: "append",
+      targetType: "heading",
+      target: "tasks",
+    });
+
+    const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+    const retryLog = calls.find((c) => c.includes("PATCH retry: heading"));
+    expect(retryLog).toContain("(periodic: daily date)");
+  });
+
+  it("patchPeriodicNoteForDate does NOT retry when targetType is not 'heading'", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 400,
+      headers: {},
+      body: '{"message":"heading not found"}',
+    });
+
+    await expect(
+      client.patchPeriodicNoteForDate("daily", 2026, 1, 1, "body", {
+        operation: "append",
+        targetType: "block",
+        target: "block-id",
+      }),
+    ).rejects.toThrow(ObsidianApiError);
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("patchPeriodicNoteForDate does NOT retry when 400 body is not heading-not-found", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 400,
+      headers: {},
+      body: '{"message":"invalid frontmatter"}',
+    });
+
+    await expect(
+      client.patchPeriodicNoteForDate("daily", 2026, 1, 1, "body", {
+        operation: "append",
+        targetType: "heading",
+        target: "Some Heading",
+      }),
+    ).rejects.toThrow(ObsidianApiError);
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletePeriodicNoteForDate accepts 200 OK in addition to 204 and 404", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "",
+    });
+
+    await expect(
+      client.deletePeriodicNoteForDate("daily", 2026, 1, 1),
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ObsidianClient — periodic notes (current) — Stryker backfill
+// (separate describe block so the afterEach hook here does not interfere
+// with the existing "periodic notes (current)" describe at line ~2660)
+// ---------------------------------------------------------------------------
+describe("ObsidianClient — periodic notes (current) — Stryker backfill", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setDebugEnabled(false);
+  });
+
+  it("getPeriodicNote sends Accept: text/markdown header for markdown format", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "body",
+    });
+
+    await client.getPeriodicNote("daily", "markdown");
+    const headers = getCallHeaders(mockRequest.mock.calls[0]);
+    expect(headers["Accept"]).toBe("text/markdown");
+    expect(mockRequest.mock.calls[0]?.[0]).toBe("GET");
+    expect(mockRequest.mock.calls[0]?.[1]).toBe("/periodic/daily/");
+  });
+
+  it("getPeriodicNote sends Accept: vnd.olrapi.note+json for json format", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content: "x", path: "n.md", tags: [], stat: {} }),
+    });
+
+    await client.getPeriodicNote("daily", "json");
+    const headers = getCallHeaders(mockRequest.mock.calls[0]);
+    expect(headers["Accept"]).toBe("application/vnd.olrapi.note+json");
+  });
+
+  it("putPeriodicNote sends Content-Type: text/markdown to /periodic/<period>/", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue(ok204());
+
+    await client.putPeriodicNote("daily", "body");
+    expect(mockRequest.mock.calls[0]?.[0]).toBe("PUT");
+    expect(mockRequest.mock.calls[0]?.[1]).toBe("/periodic/daily/");
+    const headers = getCallHeaders(mockRequest.mock.calls[0]);
+    expect(headers["Content-Type"]).toBe("text/markdown");
+  });
+
+  it("putPeriodicNote accepts 200 OK in addition to 204", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "",
+    });
+
+    await expect(
+      client.putPeriodicNote("daily", "body"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("appendPeriodicNote sends Content-Type: text/markdown via POST", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue(ok204());
+
+    await client.appendPeriodicNote("daily", "body");
+    expect(mockRequest.mock.calls[0]?.[0]).toBe("POST");
+    expect(mockRequest.mock.calls[0]?.[1]).toBe("/periodic/daily/");
+    const headers = getCallHeaders(mockRequest.mock.calls[0]);
+    expect(headers["Content-Type"]).toBe("text/markdown");
+  });
+
+  it("appendPeriodicNote accepts 200 OK in addition to 204", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "",
+    });
+
+    await expect(
+      client.appendPeriodicNote("daily", "body"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("patchPeriodicNote accepts 200 OK in addition to 204", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "",
+    });
+
+    await expect(
+      client.patchPeriodicNote("daily", "body", {
+        operation: "append",
+        targetType: "heading",
+        target: "H",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("patchPeriodicNote invalidates all cache on success", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue(ok204());
+    const mockCache = { invalidate: vi.fn(), invalidateAll: vi.fn() };
+    client.setCache(mockCache);
+
+    await client.patchPeriodicNote("daily", "body", {
+      operation: "append",
+      targetType: "heading",
+      target: "H",
+    });
+    expect(mockCache.invalidateAll).toHaveBeenCalled();
+  });
+
+  it("patchPeriodicNote retry passes '(periodic: daily)' as the label arg (visible in retry debug log)", async () => {
+    setDebugEnabled(true);
+    const stderrSpy = spyOnStderr();
+    const { client, mockRequest } = createMockedClient();
+    const docMap = {
+      headings: ["Tasks"],
+      blocks: [],
+      frontmatterFields: [],
+    };
+    mockRequest
+      .mockResolvedValueOnce({
+        statusCode: 400,
+        headers: {},
+        body: '{"message":"heading not found"}',
+      })
+      .mockResolvedValueOnce({
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(docMap),
+      })
+      .mockResolvedValueOnce(ok204());
+
+    await client.patchPeriodicNote("daily", "body", {
+      operation: "append",
+      targetType: "heading",
+      target: "tasks",
+    });
+
+    const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
+    const retryLog = calls.find((c) => c.includes("PATCH retry: heading"));
+    expect(retryLog).toContain("(periodic: daily)");
+  });
+
+  it("patchPeriodicNote does NOT retry when targetType is not 'heading'", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 400,
+      headers: {},
+      body: '{"message":"heading not found"}',
+    });
+
+    await expect(
+      client.patchPeriodicNote("daily", "body", {
+        operation: "append",
+        targetType: "block",
+        target: "block-id",
+      }),
+    ).rejects.toThrow(ObsidianApiError);
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("patchPeriodicNote does NOT retry when 400 body is not heading-not-found", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValueOnce({
+      statusCode: 400,
+      headers: {},
+      body: '{"message":"invalid frontmatter"}',
+    });
+
+    await expect(
+      client.patchPeriodicNote("daily", "body", {
+        operation: "append",
+        targetType: "heading",
+        target: "Some Heading",
+      }),
+    ).rejects.toThrow(ObsidianApiError);
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletePeriodicNote sends DELETE to /periodic/<period>/", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue(ok204());
+
+    await client.deletePeriodicNote("daily");
+    expect(mockRequest.mock.calls[0]?.[0]).toBe("DELETE");
+    expect(mockRequest.mock.calls[0]?.[1]).toBe("/periodic/daily/");
+  });
+
+  it("deletePeriodicNote accepts 200 OK in addition to 204 and 404", async () => {
+    const { client, mockRequest } = createMockedClient();
+    mockRequest.mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      body: "",
+    });
+
+    await expect(client.deletePeriodicNote("daily")).resolves.toBeUndefined();
+  });
 });

--- a/src/__tests__/obsidian.test.ts
+++ b/src/__tests__/obsidian.test.ts
@@ -3110,18 +3110,20 @@ describe("ObsidianClient — periodic notes (by date)", () => {
       client.deletePeriodicNoteForDate("daily", 2026, 1, 1),
     ).resolves.toBeUndefined();
   });
+});
 
-  // --- Stryker mutation backfill: request shape, status acceptance, retry logic ---
-
-  // Mirrors the active-file describe block: reset spies + debug between tests
-  // because the patch retry tests below enable debug logging to assert on the
-  // (periodic: <type> [date]) label rendered by retryPatchWithMapLookup.
+// ---------------------------------------------------------------------------
+// ObsidianClient — periodic notes (by date) — Stryker backfill
+// (separate describe block so the afterEach hook here does not interfere
+// with the existing "(by date)" describe block above — Greptile P2 on PR #55)
+// ---------------------------------------------------------------------------
+describe("ObsidianClient — periodic notes (by date) — Stryker backfill", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     setDebugEnabled(false);
   });
 
-  it("getPeriodicNoteForDate sends Accept: text/markdown header for markdown format", async () => {
+  it("getPeriodicNoteForDate sends GET to /periodic/<period>/<y>/<m>/<d>/ with Accept: text/markdown for markdown format", async () => {
     const { client, mockRequest } = createMockedClient();
     mockRequest.mockResolvedValue({
       statusCode: 200,
@@ -3130,6 +3132,8 @@ describe("ObsidianClient — periodic notes (by date)", () => {
     });
 
     await client.getPeriodicNoteForDate("daily", 2026, 1, 1, "markdown");
+    expect(mockRequest.mock.calls[0]?.[0]).toBe("GET");
+    expect(mockRequest.mock.calls[0]?.[1]).toBe("/periodic/daily/2026/01/01/");
     const headers = getCallHeaders(mockRequest.mock.calls[0]);
     expect(headers["Accept"]).toBe("text/markdown");
   });
@@ -3222,7 +3226,7 @@ describe("ObsidianClient — periodic notes (by date)", () => {
     expect(mockCache.invalidateAll).toHaveBeenCalled();
   });
 
-  it("patchPeriodicNoteForDate retry passes '(periodic: daily date)' as the label arg (visible in retry debug log)", async () => {
+  it("patchPeriodicNoteForDate retry rebuilds full request (PATCH + date path + corrected Target) and label '(periodic: daily date)' is rendered", async () => {
     setDebugEnabled(true);
     const stderrSpy = spyOnStderr();
     const { client, mockRequest } = createMockedClient();
@@ -3250,6 +3254,16 @@ describe("ObsidianClient — periodic notes (by date)", () => {
       target: "tasks",
     });
 
+    // Retry request shape — kills mutants on the retry path/method/Target args
+    // independently of the log assertion (per Gemini feedback on PR #55).
+    expect(mockRequest).toHaveBeenCalledTimes(3);
+    expect(mockRequest.mock.calls[2]?.[0]).toBe("PATCH");
+    expect(mockRequest.mock.calls[2]?.[1]).toBe("/periodic/daily/2026/01/01/");
+    const retryHeaders = getCallHeaders(mockRequest.mock.calls[2]);
+    expect(retryHeaders["Target"]).toBe("Tasks");
+
+    // Label is rendered in the retryPatchWithMapLookup debug log (not the
+    // caller-side auto-corrected log which has the string hardcoded).
     const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
     const retryLog = calls.find((c) => c.includes("PATCH retry: heading"));
     expect(retryLog).toContain("(periodic: daily date)");
@@ -3423,7 +3437,7 @@ describe("ObsidianClient — periodic notes (current) — Stryker backfill", () 
     expect(mockCache.invalidateAll).toHaveBeenCalled();
   });
 
-  it("patchPeriodicNote retry passes '(periodic: daily)' as the label arg (visible in retry debug log)", async () => {
+  it("patchPeriodicNote retry rebuilds full request (PATCH + current-period path + corrected Target) and label '(periodic: daily)' is rendered", async () => {
     setDebugEnabled(true);
     const stderrSpy = spyOnStderr();
     const { client, mockRequest } = createMockedClient();
@@ -3450,6 +3464,14 @@ describe("ObsidianClient — periodic notes (current) — Stryker backfill", () 
       targetType: "heading",
       target: "tasks",
     });
+
+    // Retry request shape (per Gemini feedback on PR #55) — kills mutants
+    // on the retry path/method/Target args independently of the log line.
+    expect(mockRequest).toHaveBeenCalledTimes(3);
+    expect(mockRequest.mock.calls[2]?.[0]).toBe("PATCH");
+    expect(mockRequest.mock.calls[2]?.[1]).toBe("/periodic/daily/");
+    const retryHeaders = getCallHeaders(mockRequest.mock.calls[2]);
+    expect(retryHeaders["Target"]).toBe("Tasks");
 
     const calls = stderrSpy.mock.calls.map((c) => String(c[0]));
     const retryLog = calls.find((c) => c.includes("PATCH retry: heading"));


### PR DESCRIPTION
## Summary

Sixth Stage 2 backfill PR. Largest single batch — periodic notes family (current + by-date = 10 methods, 55 surviving mutants). Patterns reused entirely from PRs #52-#54.

- **Aggregate:** 71.54% → ~72.3-72.5% (+0.7-1.0pp expected). Distance to 80: 8.46 → ~7.5pp.
- **Diff:** tests-only, +401 lines (25 new tests across two describe blocks).

## Methods covered

All 10 periodic note methods (5 ops × 2 path variants):
- `getPeriodicNote[ForDate]` — Accept header
- `putPeriodicNote[ForDate]` — Content-Type, status guard
- `appendPeriodicNote[ForDate]` — Content-Type, status guard  
- `patchPeriodicNote[ForDate]` — request shape, status guard, retry compound condition, label arg, retry skip conditions, cache invalidate
- `deletePeriodicNote[ForDate]` — DELETE method, 200 OK acceptance

## Reviewer subagent skipped

Identical pattern to PR #52-54 (same `spyOnStderr` helper, same describe-scoped `afterEach`, same `setDebugEnabled` discipline). All four reviewer feedback items from PR #54 are baked into the test design:
- `expect(...).rejects.toThrow()` for retry-skip tests (no `.catch()` swallowing)
- Retry-label tests assert on `"PATCH retry: heading"` log (where `label` arg is rendered) — not the auto-corrected log (which hardcodes the label string)
- Prettier formatting clean from the start

## Stage 2 cumulative

| PR | Δ aggregate | Cumulative |
|---|---:|---:|
| #49 | bootstrap | 65.45% |
| #50 | +0.93 | 66.38% |
| #51 | +3.92 | 70.30% |
| #52 | +0.43 | 70.73% |
| #53 | +0.18 | 70.91% |
| #54 | +0.63 | 71.54% |
| **this** | **+0.7-1.0** | **~72.3-72.5%** |

Distance to 80: ~7.5pp remaining.

## Test plan

- [ ] CI completes — only Pipeline-gate (Stryker) fails
- [ ] Reviewers triaged
- [ ] Admin-merge under Stage 2 pre-authorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)
