### PR TITLE
test(tools): backfill consolidated vault + active_file via Zod schema validation (27 mutants)

### DIFF
--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -9,7 +9,6 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { z } from "zod";
 
 // ---------------------------------------------------------------------------
 // Module mocks — must be hoisted before imports
@@ -2722,55 +2721,101 @@ describe("consolidated tools — registration and behavior", () => {
   // round-trip args through the Zod schema directly and assert each
   // valid action parses + invalid actions reject + defaults take effect.
   // -------------------------------------------------------------------------
-  describe("vault — Zod schema validation (Stryker backfill)", () => {
-    function getVaultSchema(): z.ZodObject<z.ZodRawShape> {
-      const { getTool } = setup();
-      const tool = getTool("vault");
-      const schema = tool.schema["inputSchema"];
-      if (!(schema instanceof z.ZodObject)) {
-        throw new Error("vault inputSchema is not a ZodObject");
-      }
-      return schema as z.ZodObject<z.ZodRawShape>;
+  // Type guard for any object with a `.parse(unknown) => unknown` method.
+  // Avoids depending on z.ZodObject specifically — a future refinement
+  // (`.refine()`, `.transform()`, `.brand()`) would still satisfy this
+  // contract because Zod's wrappers preserve `.parse`. This also avoids
+  // the `as` type assertion that CLAUDE.md prohibits.
+  interface ParseableSchema {
+    parse: (value: unknown) => unknown;
+  }
+  function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === "object";
+  }
+  function isParseable(value: unknown): value is ParseableSchema {
+    return (
+      isRecord(value) &&
+      "parse" in value &&
+      typeof value["parse"] === "function"
+    );
+  }
+  function getInputSchema(toolName: string): ParseableSchema {
+    const { getTool } = setup();
+    const tool = getTool(toolName);
+    const schema = tool.schema["inputSchema"];
+    if (!isParseable(schema)) {
+      throw new Error(`${toolName} inputSchema is not parseable`);
     }
+    return schema; // narrowed by isParseable type guard
+  }
 
-    const VAULT_ACTIONS = [
-      "list",
-      "list_dir",
-      "get",
-      "put",
-      "append",
-      "patch",
-      "delete",
-      "search_replace",
-      "move",
-    ] as const;
+  describe("vault — Zod schema validation (Stryker backfill)", () => {
+    // Per-action minimal valid payloads. All non-action fields are
+    // currently `.optional()` in the source schema, so `{action}` alone
+    // parses today — but if Zod gains conditional required fields per
+    // action (via `.refine` etc.), passing the realistic minimum keeps
+    // these tests focused on the enum/default mutants they target.
+    const VAULT_PAYLOADS = {
+      list: { action: "list" },
+      list_dir: { action: "list_dir", path: "dir" },
+      get: { action: "get", path: "note.md" },
+      put: { action: "put", path: "note.md", content: "body" },
+      append: { action: "append", path: "note.md", content: "body" },
+      patch: {
+        action: "patch",
+        path: "note.md",
+        content: "body",
+        operation: "append",
+        targetType: "heading",
+        target: "H",
+      },
+      delete: { action: "delete", path: "note.md" },
+      search_replace: {
+        action: "search_replace",
+        path: "note.md",
+        search: "x",
+        replace: "y",
+      },
+      move: { action: "move", source: "a.md", destination: "b.md" },
+    } as const;
+    const VAULT_ACTIONS = Object.keys(VAULT_PAYLOADS) as ReadonlyArray<
+      keyof typeof VAULT_PAYLOADS
+    >;
 
     it.each(VAULT_ACTIONS)("accepts action: %s", (action) => {
-      const schema = getVaultSchema();
-      expect(() => schema.parse({ action })).not.toThrow();
+      const schema = getInputSchema("vault");
+      expect(() => schema.parse(VAULT_PAYLOADS[action])).not.toThrow();
     });
 
     it("rejects an action outside the enum", () => {
-      const schema = getVaultSchema();
+      const schema = getInputSchema("vault");
       expect(() => schema.parse({ action: "not_a_real_action" })).toThrow();
     });
 
+    // Helper that returns the parsed-defaults as a Record<string, unknown>
+    // narrowed via the isRecord type guard — avoids `as` casts entirely.
+    function parseSearchReplaceDefaults(): Record<string, unknown> {
+      const schema = getInputSchema("vault");
+      const parsed = schema.parse(VAULT_PAYLOADS["search_replace"]);
+      if (!isRecord(parsed)) {
+        throw new Error("vault schema parse did not return an object");
+      }
+      return parsed;
+    }
+
     it("useRegex defaults to false when omitted", () => {
-      const schema = getVaultSchema();
-      const parsed = schema.parse({ action: "search_replace" });
-      expect((parsed as { useRegex: boolean }).useRegex).toBe(false);
+      const parsed = parseSearchReplaceDefaults();
+      expect(parsed["useRegex"]).toBe(false);
     });
 
     it("caseSensitive defaults to true when omitted", () => {
-      const schema = getVaultSchema();
-      const parsed = schema.parse({ action: "search_replace" });
-      expect((parsed as { caseSensitive: boolean }).caseSensitive).toBe(true);
+      const parsed = parseSearchReplaceDefaults();
+      expect(parsed["caseSensitive"]).toBe(true);
     });
 
     it("replaceAll defaults to true when omitted", () => {
-      const schema = getVaultSchema();
-      const parsed = schema.parse({ action: "search_replace" });
-      expect((parsed as { replaceAll: boolean }).replaceAll).toBe(true);
+      const parsed = parseSearchReplaceDefaults();
+      expect(parsed["replaceAll"]).toBe(true);
     });
   });
 
@@ -2822,31 +2867,30 @@ describe("consolidated tools — registration and behavior", () => {
   });
 
   describe("active_file — Zod schema validation (Stryker backfill)", () => {
-    function getActiveFileSchema(): z.ZodObject<z.ZodRawShape> {
-      const { getTool } = setup();
-      const tool = getTool("active_file");
-      const schema = tool.schema["inputSchema"];
-      if (!(schema instanceof z.ZodObject)) {
-        throw new Error("active_file inputSchema is not a ZodObject");
-      }
-      return schema as z.ZodObject<z.ZodRawShape>;
-    }
-
-    const ACTIVE_FILE_ACTIONS = [
-      "get",
-      "put",
-      "append",
-      "patch",
-      "delete",
-    ] as const;
+    const ACTIVE_FILE_PAYLOADS = {
+      get: { action: "get" },
+      put: { action: "put", content: "body" },
+      append: { action: "append", content: "body" },
+      patch: {
+        action: "patch",
+        content: "body",
+        operation: "append",
+        targetType: "heading",
+        target: "H",
+      },
+      delete: { action: "delete" },
+    } as const;
+    const ACTIVE_FILE_ACTIONS = Object.keys(
+      ACTIVE_FILE_PAYLOADS,
+    ) as ReadonlyArray<keyof typeof ACTIVE_FILE_PAYLOADS>;
 
     it.each(ACTIVE_FILE_ACTIONS)("accepts action: %s", (action) => {
-      const schema = getActiveFileSchema();
-      expect(() => schema.parse({ action })).not.toThrow();
+      const schema = getInputSchema("active_file");
+      expect(() => schema.parse(ACTIVE_FILE_PAYLOADS[action])).not.toThrow();
     });
 
     it("rejects an action outside the enum", () => {
-      const schema = getActiveFileSchema();
+      const schema = getInputSchema("active_file");
       expect(() =>
         schema.parse({ action: "not_a_real_active_file_action" }),
       ).toThrow();

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -2800,10 +2800,14 @@ describe("consolidated tools — registration and behavior", () => {
       expect(getText(result)).toContain("old/note.md");
     });
 
-    it("uses args.path (NOT source) as the error path on a failing non-move action", async () => {
+    it("uses args.path (NOT source) as the error path on a failing non-move action (404 echoes path)", async () => {
       const { client, getTool } = setup();
+      // Same approach as the move test — 404 surfaces context.path in the
+      // error message, which lets the assertion confirm the picker chose
+      // `path` over `source` (instead of relying on a vacuous absence-check
+      // against a generic Error that doesn't echo the path at all).
       vi.mocked(client.deleteFile).mockRejectedValue(
-        new Error("backend exploded"),
+        new ObsidianApiError("file not found", 404),
       );
       const result = await getTool("vault").handler({
         action: "delete",
@@ -2811,12 +2815,8 @@ describe("consolidated tools — registration and behavior", () => {
         source: "should/be/ignored.md",
       });
       expect(result.isError).toBe(true);
-      // The error path picker should pick `path` (not `source`) for non-move.
-      // buildErrorMessage may not always echo the path verbatim, but it
-      // SHOULD echo `doomed.md` and SHOULD NOT echo `should/be/ignored.md`.
       const text = getText(result);
-      // Either the path is echoed in the error, or we at least confirm the
-      // ignored source string isn't leaked into the error message.
+      expect(text).toContain("doomed.md");
       expect(text).not.toContain("should/be/ignored.md");
     });
   });
@@ -2858,7 +2858,7 @@ describe("consolidated tools — registration and behavior", () => {
     // textResult/errorResult string. StringLiteral mutations on those
     // messages survive unless the test asserts the exact text.
 
-    it("put returns 'Active file updated' on success", async () => {
+    it("put returns exactly 'Active file updated' on success", async () => {
       const { client, getTool } = setup();
       vi.mocked(client.putActiveFile).mockResolvedValue();
       const result = await getTool("active_file").handler({
@@ -2866,10 +2866,10 @@ describe("consolidated tools — registration and behavior", () => {
         content: "body",
       });
       expect(result.isError).toBeFalsy();
-      expect(getText(result)).toContain("Active file updated");
+      expect(getText(result)).toBe("Active file updated");
     });
 
-    it("append returns 'Appended to active file' on success", async () => {
+    it("append returns exactly 'Appended to active file' on success", async () => {
       const { client, getTool } = setup();
       vi.mocked(client.appendActiveFile).mockResolvedValue();
       const result = await getTool("active_file").handler({
@@ -2877,17 +2877,17 @@ describe("consolidated tools — registration and behavior", () => {
         content: "body",
       });
       expect(result.isError).toBeFalsy();
-      expect(getText(result)).toContain("Appended to active file");
+      expect(getText(result)).toBe("Appended to active file");
     });
 
-    it("delete returns 'Active file deleted' on success", async () => {
+    it("delete returns exactly 'Active file deleted' on success", async () => {
       const { client, getTool } = setup();
       vi.mocked(client.deleteActiveFile).mockResolvedValue();
       const result = await getTool("active_file").handler({
         action: "delete",
       });
       expect(result.isError).toBeFalsy();
-      expect(getText(result)).toContain("Active file deleted");
+      expect(getText(result)).toBe("Active file deleted");
     });
   });
 

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
 
 // ---------------------------------------------------------------------------
 // Module mocks — must be hoisted before imports
@@ -2706,6 +2707,187 @@ describe("consolidated tools — registration and behavior", () => {
       const { getTool } = setup({ toolPreset: "read-only" });
       const result = await getTool("active_file").handler({ action: "delete" });
       expect(result.isError).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Stryker mutation backfill: Zod-schema validation for vault + active_file
+  //
+  // The action enum literals (e.g. ["list", "list_dir", "get", ...]) and
+  // boolean defaults (useRegex/caseSensitive/replaceAll) sit on the Zod
+  // schema attached to each registered tool. Handler-level tests bypass
+  // Zod entirely (`getTool(name).handler({...})`), so a mutation that
+  // shrinks the enum or flips a boolean default leaves handler tests
+  // passing while real MCP traffic would silently misbehave. These tests
+  // round-trip args through the Zod schema directly and assert each
+  // valid action parses + invalid actions reject + defaults take effect.
+  // -------------------------------------------------------------------------
+  describe("vault — Zod schema validation (Stryker backfill)", () => {
+    function getVaultSchema(): z.ZodObject<z.ZodRawShape> {
+      const { getTool } = setup();
+      const tool = getTool("vault");
+      const schema = tool.schema["inputSchema"];
+      if (!(schema instanceof z.ZodObject)) {
+        throw new Error("vault inputSchema is not a ZodObject");
+      }
+      return schema as z.ZodObject<z.ZodRawShape>;
+    }
+
+    const VAULT_ACTIONS = [
+      "list",
+      "list_dir",
+      "get",
+      "put",
+      "append",
+      "patch",
+      "delete",
+      "search_replace",
+      "move",
+    ] as const;
+
+    it.each(VAULT_ACTIONS)("accepts action: %s", (action) => {
+      const schema = getVaultSchema();
+      expect(() => schema.parse({ action })).not.toThrow();
+    });
+
+    it("rejects an action outside the enum", () => {
+      const schema = getVaultSchema();
+      expect(() => schema.parse({ action: "not_a_real_action" })).toThrow();
+    });
+
+    it("useRegex defaults to false when omitted", () => {
+      const schema = getVaultSchema();
+      const parsed = schema.parse({ action: "search_replace" });
+      expect((parsed as { useRegex: boolean }).useRegex).toBe(false);
+    });
+
+    it("caseSensitive defaults to true when omitted", () => {
+      const schema = getVaultSchema();
+      const parsed = schema.parse({ action: "search_replace" });
+      expect((parsed as { caseSensitive: boolean }).caseSensitive).toBe(true);
+    });
+
+    it("replaceAll defaults to true when omitted", () => {
+      const schema = getVaultSchema();
+      const parsed = schema.parse({ action: "search_replace" });
+      expect((parsed as { replaceAll: boolean }).replaceAll).toBe(true);
+    });
+  });
+
+  describe("vault — error path computation for move action (Stryker backfill)", () => {
+    // The error path picker is `action === "move" ? args.source ?? path : path`.
+    // For a move, the error message should reference the SOURCE path (because
+    // the operation reads from source); for any non-move action, it should
+    // reference the path arg.
+    //
+    // The move action calls handleMoveFile (in tools/shared.ts), which
+    // internally calls client.getFileContents on the source — mocking that
+    // to reject is the cleanest way to force the move into the catch block.
+    it("uses args.source as the error path on a failing move (404 echoes path)", async () => {
+      const { client, getTool } = setup();
+      // 404 is the error type whose buildErrorMessage echoes context.path —
+      // simulating a missing source file forces path to surface in the
+      // message, which lets the test verify the picker chose source over path.
+      vi.mocked(client.getFileContents).mockRejectedValue(
+        new ObsidianApiError("file not found", 404),
+      );
+      const result = await getTool("vault").handler({
+        action: "move",
+        source: "old/note.md",
+        destination: "new/note.md",
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("old/note.md");
+    });
+
+    it("uses args.path (NOT source) as the error path on a failing non-move action", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.deleteFile).mockRejectedValue(
+        new Error("backend exploded"),
+      );
+      const result = await getTool("vault").handler({
+        action: "delete",
+        path: "doomed.md",
+        source: "should/be/ignored.md",
+      });
+      expect(result.isError).toBe(true);
+      // The error path picker should pick `path` (not `source`) for non-move.
+      // buildErrorMessage may not always echo the path verbatim, but it
+      // SHOULD echo `doomed.md` and SHOULD NOT echo `should/be/ignored.md`.
+      const text = getText(result);
+      // Either the path is echoed in the error, or we at least confirm the
+      // ignored source string isn't leaked into the error message.
+      expect(text).not.toContain("should/be/ignored.md");
+    });
+  });
+
+  describe("active_file — Zod schema validation (Stryker backfill)", () => {
+    function getActiveFileSchema(): z.ZodObject<z.ZodRawShape> {
+      const { getTool } = setup();
+      const tool = getTool("active_file");
+      const schema = tool.schema["inputSchema"];
+      if (!(schema instanceof z.ZodObject)) {
+        throw new Error("active_file inputSchema is not a ZodObject");
+      }
+      return schema as z.ZodObject<z.ZodRawShape>;
+    }
+
+    const ACTIVE_FILE_ACTIONS = [
+      "get",
+      "put",
+      "append",
+      "patch",
+      "delete",
+    ] as const;
+
+    it.each(ACTIVE_FILE_ACTIONS)("accepts action: %s", (action) => {
+      const schema = getActiveFileSchema();
+      expect(() => schema.parse({ action })).not.toThrow();
+    });
+
+    it("rejects an action outside the enum", () => {
+      const schema = getActiveFileSchema();
+      expect(() =>
+        schema.parse({ action: "not_a_real_active_file_action" }),
+      ).toThrow();
+    });
+  });
+
+  describe("active_file — error message strings (Stryker backfill)", () => {
+    // Each branch of the active_file action switch returns a distinct
+    // textResult/errorResult string. StringLiteral mutations on those
+    // messages survive unless the test asserts the exact text.
+
+    it("put returns 'Active file updated' on success", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.putActiveFile).mockResolvedValue();
+      const result = await getTool("active_file").handler({
+        action: "put",
+        content: "body",
+      });
+      expect(result.isError).toBeFalsy();
+      expect(getText(result)).toContain("Active file updated");
+    });
+
+    it("append returns 'Appended to active file' on success", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.appendActiveFile).mockResolvedValue();
+      const result = await getTool("active_file").handler({
+        action: "append",
+        content: "body",
+      });
+      expect(result.isError).toBeFalsy();
+      expect(getText(result)).toContain("Appended to active file");
+    });
+
+    it("delete returns 'Active file deleted' on success", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.deleteActiveFile).mockResolvedValue();
+      const result = await getTool("active_file").handler({
+        action: "delete",
+      });
+      expect(result.isError).toBeFalsy();
+      expect(getText(result)).toContain("Active file deleted");
     });
   });
 


### PR DESCRIPTION
## Summary

Seventh Stage 2 backfill PR. Targets `vault` (18 mutants) + `active_file` (9 mutants) tools in `src/tools/consolidated.ts` — 27 of the file's 88 surviving mutants.

- **Aggregate:** 72.35% → ~72.8% (+0.5pp expected). Distance to 80: 7.65 → ~7.2pp.
- **Diff:** tests-only, +182 lines (24 new tests).

## New approach: Zod schema validation

Handler-level tests bypass the Zod input schema (`getTool(name).handler({...})`). That means StringLiteral mutations on the action enum arrays survive — handler tests pass even when the source's enum is mutated to `[]`. Fix: round-trip args through the captured Zod schema directly:

```ts
const schema = tool.schema["inputSchema"] as z.ZodObject<...>;
expect(() => schema.parse({ action: "list" })).not.toThrow();
```

This pattern kills the action-enum mutants on L493-503 (vault) and L559 (active_file) that handler-level tests can't reach.

## What's targeted

| Mutant area | Test |
|---|---|
| L493-503 vault enum (10 mutants) | `it.each(VAULT_ACTIONS)` over 9 actions + invalid-action rejection |
| L525-527 vault boolean defaults | useRegex=false, caseSensitive=true, replaceAll=true |
| L540 vault error-path picker | move uses `source`, non-move uses `path` (404 to surface path in error) |
| L559 active_file enum (6 mutants) | `it.each(ACTIVE_FILE_ACTIONS)` over 5 actions + invalid-action |
| L591/598/628 active_file messages | "Active file updated", "Appended to active file", "Active file deleted" |

## Stage 2 cumulative

| PR | Δ | Cumulative |
|---|---:|---:|
| #49 | bootstrap | 65.45% |
| #50 | +0.93 | 66.38% |
| #51 | +3.92 | 70.30% |
| #52 | +0.43 | 70.73% |
| #53 | +0.18 | 70.91% |
| #54 | +0.63 | 71.54% |
| #55 | +0.81 | 72.35% |
| **this** | **~+0.5** | **~72.8%** |

## Test plan

- [ ] CI completes — only Pipeline-gate (Stryker) fails
- [ ] Reviewers triaged
- [ ] Admin-merge under Stage 2 pre-authorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)
