### PR TITLE
test(tools): backfill consolidated.ts remaining tools via Zod (32 mutants)

### DIFF
--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -2750,12 +2750,29 @@ describe("consolidated tools — registration and behavior", () => {
   }
 
   describe("vault — Zod schema validation (Stryker backfill)", () => {
+    // Action tuple is the source of truth. The payloads-record type below
+    // requires a payload for every action AND only those actions
+    // (bidirectional type safety, no `as` casts on `Object.keys()`).
+    //
     // Per-action minimal valid payloads. All non-action fields are
     // currently `.optional()` in the source schema, so `{action}` alone
     // parses today — but if Zod gains conditional required fields per
     // action (via `.refine` etc.), passing the realistic minimum keeps
     // these tests focused on the enum/default mutants they target.
-    const VAULT_PAYLOADS = {
+    const VAULT_ACTIONS = [
+      "list",
+      "list_dir",
+      "get",
+      "put",
+      "append",
+      "patch",
+      "delete",
+      "search_replace",
+      "move",
+    ] as const;
+    const VAULT_PAYLOADS: Readonly<
+      Record<(typeof VAULT_ACTIONS)[number], Readonly<Record<string, unknown>>>
+    > = {
       list: { action: "list" },
       list_dir: { action: "list_dir", path: "dir" },
       get: { action: "get", path: "note.md" },
@@ -2777,10 +2794,7 @@ describe("consolidated tools — registration and behavior", () => {
         replace: "y",
       },
       move: { action: "move", source: "a.md", destination: "b.md" },
-    } as const;
-    const VAULT_ACTIONS = Object.keys(VAULT_PAYLOADS) as ReadonlyArray<
-      keyof typeof VAULT_PAYLOADS
-    >;
+    };
 
     it.each(VAULT_ACTIONS)("accepts action: %s", (action) => {
       const schema = getInputSchema("vault");
@@ -2867,7 +2881,19 @@ describe("consolidated tools — registration and behavior", () => {
   });
 
   describe("active_file — Zod schema validation (Stryker backfill)", () => {
-    const ACTIVE_FILE_PAYLOADS = {
+    const ACTIVE_FILE_ACTIONS = [
+      "get",
+      "put",
+      "append",
+      "patch",
+      "delete",
+    ] as const;
+    const ACTIVE_FILE_PAYLOADS: Readonly<
+      Record<
+        (typeof ACTIVE_FILE_ACTIONS)[number],
+        Readonly<Record<string, unknown>>
+      >
+    > = {
       get: { action: "get" },
       put: { action: "put", content: "body" },
       append: { action: "append", content: "body" },
@@ -2879,10 +2905,7 @@ describe("consolidated tools — registration and behavior", () => {
         target: "H",
       },
       delete: { action: "delete" },
-    } as const;
-    const ACTIVE_FILE_ACTIONS = Object.keys(
-      ACTIVE_FILE_PAYLOADS,
-    ) as ReadonlyArray<keyof typeof ACTIVE_FILE_PAYLOADS>;
+    };
 
     it.each(ACTIVE_FILE_ACTIONS)("accepts action: %s", (action) => {
       const schema = getInputSchema("active_file");
@@ -2945,13 +2968,16 @@ describe("consolidated tools — registration and behavior", () => {
   // -------------------------------------------------------------------------
 
   describe("commands — Zod schema validation (Stryker backfill)", () => {
-    const COMMANDS_PAYLOADS = {
+    const COMMANDS_ACTIONS = ["list", "execute"] as const;
+    const COMMANDS_PAYLOADS: Readonly<
+      Record<
+        (typeof COMMANDS_ACTIONS)[number],
+        Readonly<Record<string, unknown>>
+      >
+    > = {
       list: { action: "list" },
       execute: { action: "execute", commandId: "workspace:next-tab" },
-    } as const;
-    const COMMANDS_ACTIONS = Object.keys(COMMANDS_PAYLOADS) as ReadonlyArray<
-      keyof typeof COMMANDS_PAYLOADS
-    >;
+    };
 
     it.each(COMMANDS_ACTIONS)("accepts action: %s", (action) => {
       const schema = getInputSchema("commands");
@@ -2976,14 +3002,14 @@ describe("consolidated tools — registration and behavior", () => {
   });
 
   describe("search — Zod schema validation (Stryker backfill)", () => {
-    const SEARCH_PAYLOADS = {
+    const SEARCH_TYPES = ["simple", "jsonlogic", "dataview"] as const;
+    const SEARCH_PAYLOADS: Readonly<
+      Record<(typeof SEARCH_TYPES)[number], Readonly<Record<string, unknown>>>
+    > = {
       simple: { type: "simple", query: "term" },
       jsonlogic: { type: "jsonlogic", jsonQuery: { glob: ["*.md"] } },
       dataview: { type: "dataview", query: 'TABLE FROM ""' },
-    } as const;
-    const SEARCH_TYPES = Object.keys(SEARCH_PAYLOADS) as ReadonlyArray<
-      keyof typeof SEARCH_PAYLOADS
-    >;
+    };
 
     it.each(SEARCH_TYPES)("accepts type: %s", (type) => {
       const schema = getInputSchema("search");
@@ -3004,7 +3030,19 @@ describe("consolidated tools — registration and behavior", () => {
   });
 
   describe("periodic_note — Zod schema validation (Stryker backfill)", () => {
-    const PERIODIC_PAYLOADS = {
+    const PERIODIC_ACTIONS = [
+      "get",
+      "put",
+      "append",
+      "patch",
+      "delete",
+    ] as const;
+    const PERIODIC_PAYLOADS: Readonly<
+      Record<
+        (typeof PERIODIC_ACTIONS)[number],
+        Readonly<Record<string, unknown>>
+      >
+    > = {
       get: { action: "get", period: "daily" },
       put: { action: "put", period: "daily", content: "body" },
       append: { action: "append", period: "daily", content: "body" },
@@ -3017,10 +3055,16 @@ describe("consolidated tools — registration and behavior", () => {
         target: "H",
       },
       delete: { action: "delete", period: "daily" },
-    } as const;
-    const PERIODIC_ACTIONS = Object.keys(PERIODIC_PAYLOADS) as ReadonlyArray<
-      keyof typeof PERIODIC_PAYLOADS
-    >;
+    };
+    // Periodic-note period enum (from periodSchema in src/schemas.ts).
+    // Tested here because handler-level tests bypass Zod validation.
+    const PERIODS = [
+      "daily",
+      "weekly",
+      "monthly",
+      "quarterly",
+      "yearly",
+    ] as const;
 
     it.each(PERIODIC_ACTIONS)("accepts action: %s", (action) => {
       const schema = getInputSchema("periodic_note");
@@ -3034,11 +3078,28 @@ describe("consolidated tools — registration and behavior", () => {
       ).toThrow();
     });
 
-    // Numeric constraints on month (1-12) and day (1-31). Stryker mutates
-    // .min(1).max(12) → .min(1).min(12) (both bounds same direction) etc.
-    // Tests must exercise BOTH bounds (lower and upper) to kill the mutants.
+    // periodSchema enum coverage — kills mutants on the shared periodSchema
+    // ArrayDeclaration / StringLiteral entries (in src/schemas.ts) when
+    // exercised through any tool that uses it.
+    it.each(PERIODS)("accepts period: %s", (period) => {
+      const schema = getInputSchema("periodic_note");
+      expect(() => schema.parse({ action: "get", period })).not.toThrow();
+    });
 
-    it.each([0, -1, 13, 100])("rejects invalid month: %i", (month) => {
+    it("rejects a period outside the enum", () => {
+      const schema = getInputSchema("periodic_note");
+      expect(() =>
+        schema.parse({ action: "get", period: "fortnightly" }),
+      ).toThrow();
+    });
+
+    // Numeric constraints on month (1-12) and day (1-31). Stryker mutates
+    // .min(1).max(12) → .min(1).min(12) (both bounds same direction) AND
+    // can remove the .int() constraint entirely. Tests exercise BOTH bounds
+    // AND the integer constraint (with non-integer values like 1.5/15.5)
+    // to kill all three mutant categories.
+
+    it.each([0, -1, 1.5, 13, 100])("rejects invalid month: %s", (month) => {
       const schema = getInputSchema("periodic_note");
       expect(() =>
         schema.parse({
@@ -3064,7 +3125,7 @@ describe("consolidated tools — registration and behavior", () => {
       ).not.toThrow();
     });
 
-    it.each([0, -1, 32, 100])("rejects invalid day: %i", (day) => {
+    it.each([0, -1, 15.5, 32, 100])("rejects invalid day: %s", (day) => {
       const schema = getInputSchema("periodic_note");
       expect(() =>
         schema.parse({
@@ -3111,13 +3172,13 @@ describe("consolidated tools — registration and behavior", () => {
   });
 
   describe("recent — Zod schema validation (Stryker backfill)", () => {
-    const RECENT_PAYLOADS = {
+    const RECENT_TYPES = ["changes", "periodic_notes"] as const;
+    const RECENT_PAYLOADS: Readonly<
+      Record<(typeof RECENT_TYPES)[number], Readonly<Record<string, unknown>>>
+    > = {
       changes: { type: "changes" },
       periodic_notes: { type: "periodic_notes", period: "daily" },
-    } as const;
-    const RECENT_TYPES = Object.keys(RECENT_PAYLOADS) as ReadonlyArray<
-      keyof typeof RECENT_PAYLOADS
-    >;
+    };
 
     it.each(RECENT_TYPES)("accepts type: %s", (type) => {
       const schema = getInputSchema("recent");
@@ -3136,22 +3197,31 @@ describe("consolidated tools — registration and behavior", () => {
       expect(parsed["limit"]).toBe(10);
     });
 
-    it("rejects limit < 1 (min(1) constraint)", () => {
+    // limit constraint — kills mutants on .int() and .min(1).
+    it.each([0, -1, 1.5])("rejects invalid limit: %s", (limit) => {
       const schema = getInputSchema("recent");
-      expect(() => schema.parse({ type: "changes", limit: 0 })).toThrow();
+      expect(() => schema.parse({ type: "changes", limit })).toThrow();
     });
   });
 
   describe("vault_analysis — Zod schema validation (Stryker backfill)", () => {
-    const VAULT_ANALYSIS_PAYLOADS = {
+    const VAULT_ANALYSIS_ACTIONS = [
+      "backlinks",
+      "connections",
+      "structure",
+      "refresh",
+    ] as const;
+    const VAULT_ANALYSIS_PAYLOADS: Readonly<
+      Record<
+        (typeof VAULT_ANALYSIS_ACTIONS)[number],
+        Readonly<Record<string, unknown>>
+      >
+    > = {
       backlinks: { action: "backlinks", path: "note.md" },
       connections: { action: "connections", path: "note.md" },
       structure: { action: "structure" },
       refresh: { action: "refresh" },
-    } as const;
-    const VAULT_ANALYSIS_ACTIONS = Object.keys(
-      VAULT_ANALYSIS_PAYLOADS,
-    ) as ReadonlyArray<keyof typeof VAULT_ANALYSIS_PAYLOADS>;
+    };
 
     it.each(VAULT_ANALYSIS_ACTIONS)("accepts action: %s", (action) => {
       const schema = getInputSchema("vault_analysis");
@@ -3170,9 +3240,10 @@ describe("consolidated tools — registration and behavior", () => {
       expect(parsed["limit"]).toBe(10);
     });
 
-    it("rejects limit < 1 (min(1) constraint)", () => {
+    // limit constraint — kills mutants on .int() and .min(1).
+    it.each([0, -1, 1.5])("rejects invalid limit: %s", (limit) => {
       const schema = getInputSchema("vault_analysis");
-      expect(() => schema.parse({ action: "structure", limit: 0 })).toThrow();
+      expect(() => schema.parse({ action: "structure", limit })).toThrow();
     });
   });
 

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -2936,6 +2936,247 @@ describe("consolidated tools — registration and behavior", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Stryker mutation backfill: Zod-schema validation for the rest of the
+  // consolidated tools (commands, search, periodic_note, batch_get, recent,
+  // vault_analysis). Reuses isParseable / isRecord / getInputSchema helpers
+  // defined above. Each describe block targets the tool's surviving mutants
+  // (action enums, numeric constraints, message literals) via direct schema
+  // round-trip, since handler-level tests bypass Zod entirely.
+  // -------------------------------------------------------------------------
+
+  describe("commands — Zod schema validation (Stryker backfill)", () => {
+    const COMMANDS_PAYLOADS = {
+      list: { action: "list" },
+      execute: { action: "execute", commandId: "workspace:next-tab" },
+    } as const;
+    const COMMANDS_ACTIONS = Object.keys(COMMANDS_PAYLOADS) as ReadonlyArray<
+      keyof typeof COMMANDS_PAYLOADS
+    >;
+
+    it.each(COMMANDS_ACTIONS)("accepts action: %s", (action) => {
+      const schema = getInputSchema("commands");
+      expect(() => schema.parse(COMMANDS_PAYLOADS[action])).not.toThrow();
+    });
+
+    it("rejects an action outside the enum", () => {
+      const schema = getInputSchema("commands");
+      expect(() => schema.parse({ action: "invalid_command" })).toThrow();
+    });
+
+    it("execute returns exactly 'Executed: <commandId>' on success", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.executeCommand).mockResolvedValue();
+      const result = await getTool("commands").handler({
+        action: "execute",
+        commandId: "workspace:next-tab",
+      });
+      expect(result.isError).toBeFalsy();
+      expect(getText(result)).toBe("Executed: workspace:next-tab");
+    });
+  });
+
+  describe("search — Zod schema validation (Stryker backfill)", () => {
+    const SEARCH_PAYLOADS = {
+      simple: { type: "simple", query: "term" },
+      jsonlogic: { type: "jsonlogic", jsonQuery: { glob: ["*.md"] } },
+      dataview: { type: "dataview", query: 'TABLE FROM ""' },
+    } as const;
+    const SEARCH_TYPES = Object.keys(SEARCH_PAYLOADS) as ReadonlyArray<
+      keyof typeof SEARCH_PAYLOADS
+    >;
+
+    it.each(SEARCH_TYPES)("accepts type: %s", (type) => {
+      const schema = getInputSchema("search");
+      expect(() => schema.parse(SEARCH_PAYLOADS[type])).not.toThrow();
+    });
+
+    it("rejects a type outside the enum", () => {
+      const schema = getInputSchema("search");
+      expect(() => schema.parse({ type: "fuzzy" })).toThrow();
+    });
+
+    it("contextLength defaults to 100 when omitted", () => {
+      const schema = getInputSchema("search");
+      const parsed = schema.parse(SEARCH_PAYLOADS["simple"]);
+      if (!isRecord(parsed)) throw new Error("expected object");
+      expect(parsed["contextLength"]).toBe(100);
+    });
+  });
+
+  describe("periodic_note — Zod schema validation (Stryker backfill)", () => {
+    const PERIODIC_PAYLOADS = {
+      get: { action: "get", period: "daily" },
+      put: { action: "put", period: "daily", content: "body" },
+      append: { action: "append", period: "daily", content: "body" },
+      patch: {
+        action: "patch",
+        period: "daily",
+        content: "body",
+        operation: "append",
+        targetType: "heading",
+        target: "H",
+      },
+      delete: { action: "delete", period: "daily" },
+    } as const;
+    const PERIODIC_ACTIONS = Object.keys(PERIODIC_PAYLOADS) as ReadonlyArray<
+      keyof typeof PERIODIC_PAYLOADS
+    >;
+
+    it.each(PERIODIC_ACTIONS)("accepts action: %s", (action) => {
+      const schema = getInputSchema("periodic_note");
+      expect(() => schema.parse(PERIODIC_PAYLOADS[action])).not.toThrow();
+    });
+
+    it("rejects an action outside the enum", () => {
+      const schema = getInputSchema("periodic_note");
+      expect(() =>
+        schema.parse({ action: "invalid_periodic_action", period: "daily" }),
+      ).toThrow();
+    });
+
+    // Numeric constraints on month (1-12) and day (1-31). Stryker mutates
+    // .min(1).max(12) → .min(1).min(12) (both bounds same direction) etc.
+    // Tests must exercise BOTH bounds (lower and upper) to kill the mutants.
+
+    it.each([0, -1, 13, 100])("rejects invalid month: %i", (month) => {
+      const schema = getInputSchema("periodic_note");
+      expect(() =>
+        schema.parse({
+          action: "get",
+          period: "daily",
+          year: 2026,
+          month,
+          day: 1,
+        }),
+      ).toThrow();
+    });
+
+    it.each([1, 6, 12])("accepts valid month: %i", (month) => {
+      const schema = getInputSchema("periodic_note");
+      expect(() =>
+        schema.parse({
+          action: "get",
+          period: "daily",
+          year: 2026,
+          month,
+          day: 1,
+        }),
+      ).not.toThrow();
+    });
+
+    it.each([0, -1, 32, 100])("rejects invalid day: %i", (day) => {
+      const schema = getInputSchema("periodic_note");
+      expect(() =>
+        schema.parse({
+          action: "get",
+          period: "daily",
+          year: 2026,
+          month: 1,
+          day,
+        }),
+      ).toThrow();
+    });
+
+    it.each([1, 15, 31])("accepts valid day: %i", (day) => {
+      const schema = getInputSchema("periodic_note");
+      expect(() =>
+        schema.parse({
+          action: "get",
+          period: "daily",
+          year: 2026,
+          month: 1,
+          day,
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe("batch_get — Zod schema validation (Stryker backfill)", () => {
+    it("rejects an empty paths array (min(1) constraint)", () => {
+      const schema = getInputSchema("batch_get");
+      expect(() => schema.parse({ paths: [] })).toThrow();
+    });
+
+    it("accepts a single-element paths array", () => {
+      const schema = getInputSchema("batch_get");
+      expect(() => schema.parse({ paths: ["a.md"] })).not.toThrow();
+    });
+
+    it("accepts a multi-element paths array", () => {
+      const schema = getInputSchema("batch_get");
+      expect(() =>
+        schema.parse({ paths: ["a.md", "b.md", "c.md"] }),
+      ).not.toThrow();
+    });
+  });
+
+  describe("recent — Zod schema validation (Stryker backfill)", () => {
+    const RECENT_PAYLOADS = {
+      changes: { type: "changes" },
+      periodic_notes: { type: "periodic_notes", period: "daily" },
+    } as const;
+    const RECENT_TYPES = Object.keys(RECENT_PAYLOADS) as ReadonlyArray<
+      keyof typeof RECENT_PAYLOADS
+    >;
+
+    it.each(RECENT_TYPES)("accepts type: %s", (type) => {
+      const schema = getInputSchema("recent");
+      expect(() => schema.parse(RECENT_PAYLOADS[type])).not.toThrow();
+    });
+
+    it("rejects a type outside the enum", () => {
+      const schema = getInputSchema("recent");
+      expect(() => schema.parse({ type: "fuzzy" })).toThrow();
+    });
+
+    it("limit defaults to 10 when omitted", () => {
+      const schema = getInputSchema("recent");
+      const parsed = schema.parse(RECENT_PAYLOADS["changes"]);
+      if (!isRecord(parsed)) throw new Error("expected object");
+      expect(parsed["limit"]).toBe(10);
+    });
+
+    it("rejects limit < 1 (min(1) constraint)", () => {
+      const schema = getInputSchema("recent");
+      expect(() => schema.parse({ type: "changes", limit: 0 })).toThrow();
+    });
+  });
+
+  describe("vault_analysis — Zod schema validation (Stryker backfill)", () => {
+    const VAULT_ANALYSIS_PAYLOADS = {
+      backlinks: { action: "backlinks", path: "note.md" },
+      connections: { action: "connections", path: "note.md" },
+      structure: { action: "structure" },
+      refresh: { action: "refresh" },
+    } as const;
+    const VAULT_ANALYSIS_ACTIONS = Object.keys(
+      VAULT_ANALYSIS_PAYLOADS,
+    ) as ReadonlyArray<keyof typeof VAULT_ANALYSIS_PAYLOADS>;
+
+    it.each(VAULT_ANALYSIS_ACTIONS)("accepts action: %s", (action) => {
+      const schema = getInputSchema("vault_analysis");
+      expect(() => schema.parse(VAULT_ANALYSIS_PAYLOADS[action])).not.toThrow();
+    });
+
+    it("rejects an action outside the enum", () => {
+      const schema = getInputSchema("vault_analysis");
+      expect(() => schema.parse({ action: "invalid_analysis" })).toThrow();
+    });
+
+    it("limit defaults to 10 when omitted", () => {
+      const schema = getInputSchema("vault_analysis");
+      const parsed = schema.parse(VAULT_ANALYSIS_PAYLOADS["structure"]);
+      if (!isRecord(parsed)) throw new Error("expected object");
+      expect(parsed["limit"]).toBe(10);
+    });
+
+    it("rejects limit < 1 (min(1) constraint)", () => {
+      const schema = getInputSchema("vault_analysis");
+      expect(() => schema.parse({ action: "structure", limit: 0 })).toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // commands tool
   // -------------------------------------------------------------------------
   describe("commands — list", () => {


### PR DESCRIPTION
## Summary

Eighth Stage 2 backfill PR. Continues PR #56's Zod-schema-validation pattern across the rest of `src/tools/consolidated.ts`: commands, search, periodic_note, batch_get, recent, vault_analysis. **32 surviving mutants targeted**.

- **Aggregate:** 72.94% → ~73.5% (+0.6pp expected). Distance to 80: 7.06 → ~6.5pp.
- **Diff:** tests-only, +241 lines (44 new tests), reuses isParseable/isRecord/getInputSchema helpers from PR #56.

## Coverage added (44 tests across 6 describe blocks)

| Tool | Tests | What's killed |
|---|---:|---|
| commands | 3 | enum (list/execute), invalid-action rejection, "Executed: <id>" exact message |
| search | 5 | enum (simple/jsonlogic/dataview), invalid rejection, contextLength=100 default |
| periodic_note | 16 | enum (5 actions), invalid rejection, **month + day numeric constraints (it.each over both bounds)** |
| batch_get | 3 | paths.min(1) — empty rejected, single+multi accepted |
| recent | 4 | enum (changes/periodic_notes), invalid, limit=10 default, limit<1 rejected |
| vault_analysis | 4 | enum (4 actions), invalid, limit=10 default, limit<1 rejected |

## Numeric-constraint testing

Stryker mutates `.min(1).max(12)` to `.min(1).min(12)` (or `.max(1)`). The mutant survives if the test only checks one bound. Tests use `it.each([0, -1, 13, 100])` for invalid month + `it.each([1, 6, 12])` for valid month — each value tests a different bound. Same pattern for day (1-31).

## Stage 2 cumulative

| PR | Δ aggregate | Cumulative |
|---|---:|---:|
| #49-56 | various | 72.94% |
| **this** | **~+0.6** | **~73.5%** |

## Test plan

- [ ] CI completes — only Pipeline-gate (Stryker) fails
- [ ] Reviewers triaged
- [ ] Admin-merge under Stage 2 pre-authorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)
