### PR TITLE
test(tools): backfill handleMoveFile in shared.ts (22 mutants)

### DIFF
--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1100,13 +1100,14 @@ describe("granular tools — registration and basic behavior", () => {
       const { client, getTool } = setup();
       // First call returns a NoteJson object (typeof !== "string"),
       // which should trigger the L598 type-guard error path.
-      vi.mocked(client.getFileContents).mockResolvedValueOnce({
+      const noteJsonFixture = {
         content: "x",
         frontmatter: {},
         path: "old.md",
         tags: [],
         stat: { ctime: 0, mtime: 0, size: 0 },
-      } as NoteJson);
+      } satisfies NoteJson;
+      vi.mocked(client.getFileContents).mockResolvedValueOnce(noteJsonFixture);
       const result = await getTool("move_file").handler({
         source: "old.md",
         destination: "new.md",

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1047,8 +1047,8 @@ describe("granular tools — registration and basic behavior", () => {
       });
       expect(result.isError).toBe(true);
       // Exact message text — kills the L583 StringLiteral mutant.
-      expect(getText(result)).toContain(
-        "[move_file] Only .md files can be moved.",
+      expect(getText(result)).toBe(
+        "[move_file] Only .md files can be moved. Non-markdown files may lose data in the text round-trip.",
       );
     });
 
@@ -1060,7 +1060,7 @@ describe("granular tools — registration and basic behavior", () => {
       });
       expect(result.isError).toBe(true);
       // Exact message text — kills the L587 StringLiteral mutant.
-      expect(getText(result)).toContain(
+      expect(getText(result)).toBe(
         "[move_file] Destination must be a .md file.",
       );
     });
@@ -1113,7 +1113,7 @@ describe("granular tools — registration and basic behavior", () => {
       });
       expect(result.isError).toBe(true);
       // Exact message text — kills the L600 StringLiteral mutant.
-      expect(getText(result)).toContain(
+      expect(getText(result)).toBe(
         "[move_file] Expected markdown content from source file",
       );
     });

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1030,6 +1030,130 @@ describe("granular tools — registration and basic behavior", () => {
       });
       expect(result.isError).toBe(true);
     });
+
+    // --- Stryker mutation backfill: handleMoveFile (22 mutants) ---
+    //
+    // The existing 4 tests above cover the happy path + same-path no-op +
+    // conflict + missing-source error. These add the precise assertions
+    // needed to kill the surviving mutants in the .md filter, the
+    // markdown-content type guard, the conflict-check error filter, and
+    // the delete-file error path.
+
+    it("rejects non-.md source path with explicit message", async () => {
+      const { getTool } = setup();
+      const result = await getTool("move_file").handler({
+        source: "image.png",
+        destination: "renamed.png",
+      });
+      expect(result.isError).toBe(true);
+      // Exact message text — kills the L583 StringLiteral mutant.
+      expect(getText(result)).toContain(
+        "[move_file] Only .md files can be moved.",
+      );
+    });
+
+    it("rejects non-.md destination path with explicit message", async () => {
+      const { getTool } = setup();
+      const result = await getTool("move_file").handler({
+        source: "doc.md",
+        destination: "doc.txt",
+      });
+      expect(result.isError).toBe(true);
+      // Exact message text — kills the L587 StringLiteral mutant.
+      expect(getText(result)).toContain(
+        "[move_file] Destination must be a .md file.",
+      );
+    });
+
+    it("treats .md case-insensitively (.MD source accepted)", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents)
+        .mockResolvedValueOnce("# Content")
+        .mockRejectedValueOnce(new ObsidianApiError("Not found", 404));
+      const result = await getTool("move_file").handler({
+        source: "OLD.MD", // uppercase ext — must still pass the .md filter
+        destination: "new.md",
+      });
+      expect(result.isError).toBeFalsy();
+      expect(getText(result)).toContain("Moved");
+    });
+
+    it("calls getFileContents with format='markdown' and rawBypass=true (kills L595/596 args)", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents)
+        .mockResolvedValueOnce("# Content")
+        .mockRejectedValueOnce(new ObsidianApiError("Not found", 404));
+      await getTool("move_file").handler({
+        source: "old.md",
+        destination: "new.md",
+      });
+      // First call to getFileContents is the source-read.
+      const firstCall = vi.mocked(client.getFileContents).mock.calls[0];
+      expect(firstCall?.[0]).toBe("old.md");
+      // L595 StringLiteral on "markdown"
+      expect(firstCall?.[1]).toBe("markdown");
+      // L596 BooleanLiteral on true (rawBypass for move-file source read).
+      expect(firstCall?.[2]).toBe(true);
+    });
+
+    it("rejects when source returns NoteJson instead of markdown string", async () => {
+      const { client, getTool } = setup();
+      // First call returns a NoteJson object (typeof !== "string"),
+      // which should trigger the L598 type-guard error path.
+      vi.mocked(client.getFileContents).mockResolvedValueOnce({
+        content: "x",
+        frontmatter: {},
+        path: "old.md",
+        tags: [],
+        stat: { ctime: 0, mtime: 0, size: 0 },
+      } as NoteJson);
+      const result = await getTool("move_file").handler({
+        source: "old.md",
+        destination: "new.md",
+      });
+      expect(result.isError).toBe(true);
+      // Exact message text — kills the L600 StringLiteral mutant.
+      expect(getText(result)).toContain(
+        "[move_file] Expected markdown content from source file",
+      );
+    });
+
+    it("rethrows non-404 errors from the destination conflict-check (does NOT swallow)", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents)
+        .mockResolvedValueOnce("# Content") // source read succeeds
+        .mockRejectedValueOnce(new ObsidianApiError("Server error", 500)); // dest check throws non-404
+      const result = await getTool("move_file").handler({
+        source: "old.md",
+        destination: "new.md",
+      });
+      expect(result.isError).toBe(true);
+      // The 500 must propagate (not be swallowed as if-it-were-a-404 not-found).
+      // Confirms the L609 LogicalOperator + ConditionalExpression mutants are killed.
+      expect(client.putContent).not.toHaveBeenCalled();
+      expect(client.deleteFile).not.toHaveBeenCalled();
+    });
+
+    it("returns explicit error when deleteFile fails after putContent succeeded", async () => {
+      const { client, getTool } = setup();
+      vi.mocked(client.getFileContents)
+        .mockResolvedValueOnce("# Content") // source read
+        .mockRejectedValueOnce(new ObsidianApiError("Not found", 404)); // dest doesn't exist
+      vi.mocked(client.putContent).mockResolvedValueOnce(undefined);
+      vi.mocked(client.deleteFile).mockRejectedValueOnce(
+        new Error("delete failed"),
+      );
+      const result = await getTool("move_file").handler({
+        source: "old.md",
+        destination: "new.md",
+      });
+      // putContent succeeded, deleteFile failed → result is an error
+      // describing the partial-failure (destination created, source not deleted).
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("delete failed");
+      expect(client.putContent).toHaveBeenCalledWith("new.md", "# Content");
+      expect(client.deleteFile).toHaveBeenCalledWith("old.md");
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Tenth Stage 2 backfill PR. handleMoveFile in src/tools/shared.ts (22 mutants).

- **Aggregate:** 74.28% → ~74.65% (+0.3-0.4pp). Distance to 80: 5.72 → ~5.35pp.
- **Diff:** tests-only, +124 lines (7 new tests).

## Test additions

- Non-.md source rejection (exact message)
- Non-.md destination rejection (exact message)
- .MD uppercase ext accepted (case-insensitive filter)
- getFileContents call args: format='markdown' + rawBypass=true
- NoteJson source returns type-guard error
- Non-404 conflict-check error rethrows (not swallowed as not-found)
- deleteFile failure after putContent → explicit error

## Stage 2 cumulative

| PR | Δ | Cumulative |
|---|---:|---:|
| #49-58 | various | 74.28% |
| **this** | **~+0.3-0.4** | **~74.65%** |

## Test plan

- [ ] CI completes — only Pipeline-gate (Stryker) fails
- [ ] Reviewers triaged
- [ ] Admin-merge under Stage 2 pre-authorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)