### PR TITLE
test(tools): backfill configure helpers in shared.ts (parser + Map cluster)

### DIFF
--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1979,6 +1979,103 @@ describe("granular tools — registration and basic behavior", () => {
         });
       },
     );
+
+    // --- Additional happy-path / negative coverage (CodeRabbit cycle-5 ask) ---
+
+    // parsePosIntValue boundary + larger integer (timeout, min=1)
+    it.each([
+      ["1", 1],
+      ["60000", 60000],
+      ["2147483647", 2147483647],
+    ])("accepts timeout=%s and saves as %i", async (value, expected) => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({
+        action: "set",
+        setting: "timeout",
+        value,
+      });
+      expect(result.isError).toBeFalsy();
+      expect(saveConfigToFile).toHaveBeenLastCalledWith(expect.any(String), {
+        reliability: { timeout: expected },
+      });
+    });
+
+    it("accepts maxResponseChars=10 (typical positive integer)", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({
+        action: "set",
+        setting: "maxResponseChars",
+        value: "10",
+      });
+      expect(result.isError).toBeFalsy();
+      expect(saveConfigToFile).toHaveBeenLastCalledWith(expect.any(String), {
+        reliability: { maxResponseChars: 10 },
+      });
+    });
+
+    // Boolean false-path — kills a separate StringLiteral mutant on
+    // parseBoolValue("false") and the wrap-as-{ key: false } shape.
+    it("compactResponses=false produces { compactResponses: false }", async () => {
+      const { getTool } = setup();
+      try {
+        const result = await getTool("configure").handler({
+          action: "set",
+          setting: "compactResponses",
+          value: "false",
+        });
+        expect(result.isError).toBeFalsy();
+        expect(saveConfigToFile).toHaveBeenLastCalledWith(expect.any(String), {
+          compactResponses: false,
+        });
+      } finally {
+        // configure handler ALSO calls setCompactResponses(false) for false;
+        // explicit reset for symmetry with the =true test above.
+        setCompactResponses(false);
+      }
+    });
+
+    it("verifyWrites=false produces { reliability: { verifyWrites: false } }", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({
+        action: "set",
+        setting: "verifyWrites",
+        value: "false",
+      });
+      expect(result.isError).toBeFalsy();
+      expect(saveConfigToFile).toHaveBeenLastCalledWith(expect.any(String), {
+        reliability: { verifyWrites: false },
+      });
+    });
+
+    // Invalid enum value rejection for toolPreset (existing test covers
+    // toolMode invalid; add the symmetric one for toolPreset).
+    it("rejects invalid toolPreset value", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({
+        action: "set",
+        setting: "toolPreset",
+        value: "experimental", // not in enum
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toContain("Invalid value");
+    });
+
+    // Empty/whitespace string → "Invalid value" error message contract for
+    // boolean settings (parseBoolValue returns undefined → handler returns
+    // errorResult with "Invalid value").
+    it.each(["", "   ", "\n", "\t"])(
+      "rejects empty/whitespace boolean value '%s' with 'Invalid value'",
+      async (value) => {
+        const { getTool } = setup();
+        const result = await getTool("configure").handler({
+          action: "set",
+          setting: "verifyWrites",
+          value,
+        });
+        expect(result.isError).toBe(true);
+        expect(getText(result)).toContain("Invalid value");
+      },
+    );
   });
 
   // -------------------------------------------------------------------------

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -55,6 +55,13 @@ import { CACHE_INIT_TIMEOUT_MS } from "../tools/shared.js";
 
 beforeEach(() => {
   vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  // Clear stale call history on the file-scoped saveConfigToFile mock.
+  // vi.restoreAllMocks() in the afterEach below restores spies but does
+  // NOT clear call history on module mocks — without this, tests that
+  // assert via toHaveBeenLastCalledWith could be satisfied by a prior
+  // test's call. File-scoped so EVERY test (not just the configure-set
+  // describe block) starts with an empty history.
+  vi.mocked(saveConfigToFile).mockClear();
 });
 
 afterEach(() => {
@@ -1711,16 +1718,6 @@ describe("granular tools — registration and basic behavior", () => {
   // configure — set (immediate settings)
   // -------------------------------------------------------------------------
   describe("configure — set action (immediate settings)", () => {
-    // Clear stale saveConfigToFile call history between tests. The mock
-    // is installed at the file level via vi.mock("../config.js", ...) as
-    // a vi.fn(), and vi.restoreAllMocks() does NOT clear call history on
-    // module-level mocks — only restores spied implementations. Without
-    // this beforeEach, toHaveBeenLastCalledWith assertions could be
-    // satisfied by a prior test's call rather than the test's own.
-    beforeEach(() => {
-      vi.mocked(saveConfigToFile).mockClear();
-    });
-
     it("sets debug=true and calls saveConfigToFile", async () => {
       const { getTool } = setup({ configFilePath: "/tmp/test-config.json" });
       const result = await getTool("configure").handler({

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1711,6 +1711,16 @@ describe("granular tools — registration and basic behavior", () => {
   // configure — set (immediate settings)
   // -------------------------------------------------------------------------
   describe("configure — set action (immediate settings)", () => {
+    // Clear stale saveConfigToFile call history between tests. The mock
+    // is installed at the file level via vi.mock("../config.js", ...) as
+    // a vi.fn(), and vi.restoreAllMocks() does NOT clear call history on
+    // module-level mocks — only restores spied implementations. Without
+    // this beforeEach, toHaveBeenLastCalledWith assertions could be
+    // satisfied by a prior test's call rather than the test's own.
+    beforeEach(() => {
+      vi.mocked(saveConfigToFile).mockClear();
+    });
+
     it("sets debug=true and calls saveConfigToFile", async () => {
       const { getTool } = setup({ configFilePath: "/tmp/test-config.json" });
       const result = await getTool("configure").handler({

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -39,6 +39,7 @@ import { registerAllTools } from "../tools.js";
 import { registerGranularTools } from "../tools/granular.js";
 import { registerConsolidatedTools } from "../tools/consolidated.js";
 import type { ObsidianClient, NoteJson, ToolResult } from "../obsidian.js";
+import { setCompactResponses } from "../obsidian.js";
 import type { VaultCache, CachedNote } from "../cache.js";
 import {
   ObsidianApiError,
@@ -1814,6 +1815,159 @@ describe("granular tools — registration and basic behavior", () => {
       });
       expect(getText(result)).toContain("Restart the server");
     });
+
+    // --- Stryker mutation backfill: parseBoolValue + parsePosIntValue + CONFIG_UPDATE_PARSERS ---
+
+    // parseBoolValue is private; exercise via the boolean settings (debug,
+    // compactResponses, verifyWrites). Each `true`/`false` string must parse
+    // and any other input must be rejected. Tests the L119/L120 string-equality
+    // mutants ("true" → "", "false" → "").
+
+    it.each([
+      ["true", true],
+      ["false", false],
+    ])("parses debug='%s' to boolean %s", async (input, expected) => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({
+        action: "set",
+        setting: "debug",
+        value: input,
+      });
+      expect(result.isError).toBeFalsy();
+      expect(saveConfigToFile).toHaveBeenLastCalledWith(expect.any(String), {
+        debug: expected,
+      });
+    });
+
+    it.each(["TRUE", "True", "1", "0", "yes", "no", ""])(
+      "rejects non-boolean debug value '%s'",
+      async (value) => {
+        const { getTool } = setup();
+        const result = await getTool("configure").handler({
+          action: "set",
+          setting: "debug",
+          value,
+        });
+        expect(result.isError).toBe(true);
+        expect(getText(result)).toContain("Invalid value");
+      },
+    );
+
+    // parsePosIntValue is private; exercise via timeout (min=1) and
+    // maxResponseChars (min=0). Tests:
+    //   - empty string rejected (L131 trim guard)
+    //   - non-numeric rejected (L132 Number cast)
+    //   - non-finite rejected (Infinity, NaN)
+    //   - non-integer rejected (decimals like 1.5)
+    //   - below-min rejected (timeout < 1, maxResponseChars < 0)
+
+    it.each([
+      ["", "empty string"],
+      [" ", "whitespace-only"],
+      ["abc", "non-numeric text"],
+      ["1.5", "decimal"],
+      ["NaN", "literal NaN"],
+      ["Infinity", "literal Infinity"],
+      ["0", "below min=1"],
+      ["-5", "negative"],
+    ])("rejects timeout=%j (%s)", async (value) => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({
+        action: "set",
+        setting: "timeout",
+        value,
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    it("accepts maxResponseChars=0 (min=0 boundary)", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({
+        action: "set",
+        setting: "maxResponseChars",
+        value: "0",
+      });
+      expect(result.isError).toBeFalsy();
+      expect(saveConfigToFile).toHaveBeenLastCalledWith(expect.any(String), {
+        reliability: { maxResponseChars: 0 },
+      });
+    });
+
+    it("rejects maxResponseChars=-1 (below min=0)", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({
+        action: "set",
+        setting: "maxResponseChars",
+        value: "-1",
+      });
+      expect(result.isError).toBe(true);
+    });
+
+    // CONFIG_UPDATE_PARSERS Map entries — each setting must route to its
+    // parser and produce the correct nested update shape. Kills the
+    // ArrayDeclaration mutants on each Map row (parser deletion would
+    // mean the setting is not recognized, returning "Unknown setting").
+
+    it("compactResponses=true produces { compactResponses: true }", async () => {
+      const { getTool } = setup();
+      try {
+        await getTool("configure").handler({
+          action: "set",
+          setting: "compactResponses",
+          value: "true",
+        });
+        expect(saveConfigToFile).toHaveBeenLastCalledWith(expect.any(String), {
+          compactResponses: true,
+        });
+      } finally {
+        // Reset module-level state — the configure handler calls
+        // setCompactResponses(true) as an immediate side-effect, which
+        // would otherwise leak into other tests using jsonResult().
+        setCompactResponses(false);
+      }
+    });
+
+    it("verifyWrites=true produces { reliability: { verifyWrites: true } }", async () => {
+      const { getTool } = setup();
+      await getTool("configure").handler({
+        action: "set",
+        setting: "verifyWrites",
+        value: "true",
+      });
+      expect(saveConfigToFile).toHaveBeenLastCalledWith(expect.any(String), {
+        reliability: { verifyWrites: true },
+      });
+    });
+
+    it.each(["granular", "consolidated"])(
+      "toolMode='%s' produces { tools: { mode: '%s' } }",
+      async (value) => {
+        const { getTool } = setup();
+        await getTool("configure").handler({
+          action: "set",
+          setting: "toolMode",
+          value,
+        });
+        expect(saveConfigToFile).toHaveBeenLastCalledWith(expect.any(String), {
+          tools: { mode: value },
+        });
+      },
+    );
+
+    it.each(["full", "read-only", "minimal", "safe"])(
+      "toolPreset='%s' produces { tools: { preset: '%s' } }",
+      async (value) => {
+        const { getTool } = setup();
+        await getTool("configure").handler({
+          action: "set",
+          setting: "toolPreset",
+          value,
+        });
+        expect(saveConfigToFile).toHaveBeenLastCalledWith(expect.any(String), {
+          tools: { preset: value },
+        });
+      },
+    );
   });
 
   // -------------------------------------------------------------------------

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1911,11 +1911,12 @@ describe("granular tools — registration and basic behavior", () => {
     it("compactResponses=true produces { compactResponses: true }", async () => {
       const { getTool } = setup();
       try {
-        await getTool("configure").handler({
+        const result = await getTool("configure").handler({
           action: "set",
           setting: "compactResponses",
           value: "true",
         });
+        expect(result.isError).toBeFalsy();
         expect(saveConfigToFile).toHaveBeenLastCalledWith(expect.any(String), {
           compactResponses: true,
         });
@@ -1929,11 +1930,12 @@ describe("granular tools — registration and basic behavior", () => {
 
     it("verifyWrites=true produces { reliability: { verifyWrites: true } }", async () => {
       const { getTool } = setup();
-      await getTool("configure").handler({
+      const result = await getTool("configure").handler({
         action: "set",
         setting: "verifyWrites",
         value: "true",
       });
+      expect(result.isError).toBeFalsy();
       expect(saveConfigToFile).toHaveBeenLastCalledWith(expect.any(String), {
         reliability: { verifyWrites: true },
       });
@@ -1943,11 +1945,12 @@ describe("granular tools — registration and basic behavior", () => {
       "toolMode='%s' produces { tools: { mode: '%s' } }",
       async (value) => {
         const { getTool } = setup();
-        await getTool("configure").handler({
+        const result = await getTool("configure").handler({
           action: "set",
           setting: "toolMode",
           value,
         });
+        expect(result.isError).toBeFalsy();
         expect(saveConfigToFile).toHaveBeenLastCalledWith(expect.any(String), {
           tools: { mode: value },
         });
@@ -1958,11 +1961,12 @@ describe("granular tools — registration and basic behavior", () => {
       "toolPreset='%s' produces { tools: { preset: '%s' } }",
       async (value) => {
         const { getTool } = setup();
-        await getTool("configure").handler({
+        const result = await getTool("configure").handler({
           action: "set",
           setting: "toolPreset",
           value,
         });
+        expect(result.isError).toBeFalsy();
         expect(saveConfigToFile).toHaveBeenLastCalledWith(expect.any(String), {
           tools: { preset: value },
         });

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1847,7 +1847,7 @@ describe("granular tools — registration and basic behavior", () => {
     });
 
     it.each(["TRUE", "True", "1", "0", "yes", "no", ""])(
-      "rejects non-boolean debug value '%s'",
+      "rejects non-boolean debug value '%s' and does not write config",
       async (value) => {
         const { getTool } = setup();
         const result = await getTool("configure").handler({
@@ -1857,6 +1857,7 @@ describe("granular tools — registration and basic behavior", () => {
         });
         expect(result.isError).toBe(true);
         expect(getText(result)).toContain("Invalid value");
+        expect(saveConfigToFile).not.toHaveBeenCalled();
       },
     );
 
@@ -1877,7 +1878,7 @@ describe("granular tools — registration and basic behavior", () => {
       ["Infinity", "literal Infinity"],
       ["0", "below min=1"],
       ["-5", "negative"],
-    ])("rejects timeout=%j (%s)", async (value) => {
+    ])("rejects timeout=%j (%s) and does not write config", async (value) => {
       const { getTool } = setup();
       const result = await getTool("configure").handler({
         action: "set",
@@ -1885,6 +1886,7 @@ describe("granular tools — registration and basic behavior", () => {
         value,
       });
       expect(result.isError).toBe(true);
+      expect(saveConfigToFile).not.toHaveBeenCalled();
     });
 
     it("accepts maxResponseChars=0 (min=0 boundary)", async () => {
@@ -1900,7 +1902,7 @@ describe("granular tools — registration and basic behavior", () => {
       });
     });
 
-    it("rejects maxResponseChars=-1 (below min=0)", async () => {
+    it("rejects maxResponseChars=-1 (below min=0) and does not write config", async () => {
       const { getTool } = setup();
       const result = await getTool("configure").handler({
         action: "set",
@@ -1908,6 +1910,7 @@ describe("granular tools — registration and basic behavior", () => {
         value: "-1",
       });
       expect(result.isError).toBe(true);
+      expect(saveConfigToFile).not.toHaveBeenCalled();
     });
 
     // CONFIG_UPDATE_PARSERS Map entries — each setting must route to its
@@ -2049,7 +2052,7 @@ describe("granular tools — registration and basic behavior", () => {
 
     // Invalid enum value rejection for toolPreset (existing test covers
     // toolMode invalid; add the symmetric one for toolPreset).
-    it("rejects invalid toolPreset value", async () => {
+    it("rejects invalid toolPreset value and does not write config", async () => {
       const { getTool } = setup();
       const result = await getTool("configure").handler({
         action: "set",
@@ -2058,13 +2061,14 @@ describe("granular tools — registration and basic behavior", () => {
       });
       expect(result.isError).toBe(true);
       expect(getText(result)).toContain("Invalid value");
+      expect(saveConfigToFile).not.toHaveBeenCalled();
     });
 
     // Empty/whitespace string → "Invalid value" error message contract for
     // boolean settings (parseBoolValue returns undefined → handler returns
     // errorResult with "Invalid value").
     it.each(["", "   ", "\n", "\t"])(
-      "rejects empty/whitespace boolean value '%s' with 'Invalid value'",
+      "rejects empty/whitespace boolean value '%s' with 'Invalid value' and does not write config",
       async (value) => {
         const { getTool } = setup();
         const result = await getTool("configure").handler({
@@ -2074,6 +2078,7 @@ describe("granular tools — registration and basic behavior", () => {
         });
         expect(result.isError).toBe(true);
         expect(getText(result)).toContain("Invalid value");
+        expect(saveConfigToFile).not.toHaveBeenCalled();
       },
     );
   });


### PR DESCRIPTION
## Summary

Eleventh Stage 2 backfill PR. Configure helpers cluster in src/tools/shared.ts (parseBoolValue + parsePosIntValue + CONFIG_UPDATE_PARSERS Map, lines 118-216).

- **Aggregate:** 74.73% → ~75.1% (+0.4pp). Distance to 80: 5.27 → ~4.9pp.
- **Diff:** tests-only, +154 lines (27 new tests added to existing configure-set describe block).

## Coverage added

- parseBoolValue: "true"/"false" accepted + 7 invalid forms rejected (TRUE/True/1/0/yes/no/empty)
- parsePosIntValue (via timeout, min=1): empty, whitespace, non-numeric, decimal, NaN, Infinity, below-min, negative all rejected
- parsePosIntValue (via maxResponseChars, min=0): boundary 0 accepted, -1 rejected
- CONFIG_UPDATE_PARSERS Map: each setting (compactResponses, verifyWrites, toolMode×2, toolPreset×4) verified to produce its exact nested update shape

## Test isolation note

The compactResponses=true test wraps in try/finally to call setCompactResponses(false) afterward — the configure handler triggers a real module-level side-effect that would otherwise leak compact mode into other tests using jsonResult().

## Stage 2 cumulative

| PR | Δ | Cumulative |
|---|---:|---:|
| #49-59 | various | 74.73% |
| **this** | **~+0.4** | **~75.1%** |

## Test plan

- [ ] CI completes — only Pipeline-gate (Stryker) fails
- [ ] Reviewers triaged
- [ ] Admin-merge under Stage 2 pre-authorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)