### PR TITLE
test(tools): backfill buildVaultStructure in shared.ts (10 mutants)

### DIFF
--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -2284,6 +2284,106 @@ describe("granular tools — registration and basic behavior", () => {
       expect(parsed).toMatchObject({ orphanCount: 1, edgeCount: 1 });
     });
 
+    // --- Stryker mutation backfill: buildVaultStructure (10 survivors) ---
+    //
+    // The directory-traversal loop walks each file path one slash at a time
+    // (lastIndexOf "/" → slice → check Set → ascend), and the orphans list
+    // is sliced to the first 20. Targets the L397-411 mutant cluster.
+
+    function buildStructureClient(
+      fileList: ReadonlyArray<string>,
+      orphans: ReadonlyArray<string> = [],
+      noteCount = fileList.length,
+      linkCount = 0,
+      edgeCount = 0,
+    ): ReturnType<typeof setup> {
+      const { server, getTool } = makeMockServer();
+      const client = makeMockClient();
+      const cache = makeMockCache(true);
+      vi.mocked(cache.getOrphanNotes).mockReturnValue(orphans as string[]);
+      vi.mocked(cache.getMostConnectedNotes).mockReturnValue([]);
+      vi.mocked(cache.getEdgeCount).mockReturnValue(edgeCount);
+      vi.mocked(cache.getFileList).mockReturnValue(fileList as string[]);
+      Object.defineProperty(cache, "noteCount", {
+        get: vi.fn().mockReturnValue(noteCount),
+      });
+      Object.defineProperty(cache, "linkCount", {
+        get: vi.fn().mockReturnValue(linkCount),
+      });
+      registerGranularTools(
+        server as never,
+        client,
+        cache,
+        () => true,
+        makeConfig({ enableCache: true }),
+      );
+      return { client, cache, getTool };
+    }
+
+    async function callVaultStructure(
+      getTool: (name: string) => CapturedTool,
+      limit = 10,
+    ): Promise<Record<string, unknown>> {
+      const result = await getTool("get_vault_structure").handler({ limit });
+      const parsed: unknown = JSON.parse(getText(result));
+      if (parsed === null || typeof parsed !== "object") {
+        throw new Error("expected object response");
+      }
+      return parsed as Record<string, unknown>;
+    }
+
+    it("counts unique directories across nested paths (no duplicates, parents tracked)", async () => {
+      // a/b/c/note.md → directories: "a/b/c", "a/b", "a"
+      // a/b/other.md  → directories: "a/b" (already tracked, BREAK), "a" (skipped)
+      // x/y.md        → directories: "x"
+      // root.md       → no directories
+      // Expected unique: { "a/b/c", "a/b", "a", "x" } → 4
+      const { getTool } = buildStructureClient([
+        "a/b/c/note.md",
+        "a/b/other.md",
+        "x/y.md",
+        "root.md",
+      ]);
+      const parsed = await callVaultStructure(getTool);
+      expect(parsed["directoryCount"]).toBe(4);
+    });
+
+    it("treats files at the vault root as zero directories", async () => {
+      const { getTool } = buildStructureClient(["a.md", "b.md", "c.md"]);
+      const parsed = await callVaultStructure(getTool);
+      expect(parsed["directoryCount"]).toBe(0);
+    });
+
+    it("dedupes ancestor directories (early-break optimization)", async () => {
+      // 100 sibling files in deep/nested/dir/ should produce ONLY 3 dirs
+      // ("deep/nested/dir", "deep/nested", "deep"), not 100 × 3 = 300.
+      // The `break` on dirs.has(dir) ensures parents are skipped once seen.
+      const fileList = Array.from(
+        { length: 100 },
+        (_, i) => `deep/nested/dir/file${i}.md`,
+      );
+      const { getTool } = buildStructureClient(fileList);
+      const parsed = await callVaultStructure(getTool);
+      expect(parsed["directoryCount"]).toBe(3);
+    });
+
+    it("slices orphans to first 20 even when cache returns more", async () => {
+      const orphans = Array.from({ length: 35 }, (_, i) => `orphan${i}.md`);
+      const { getTool } = buildStructureClient([], orphans);
+      const parsed = await callVaultStructure(getTool);
+      expect(parsed["orphanCount"]).toBe(35); // total count preserved
+      expect(Array.isArray(parsed["orphans"])).toBe(true);
+      expect((parsed["orphans"] as unknown[]).length).toBe(20); // sliced
+    });
+
+    it("returns all orphans when cache returns ≤ 20", async () => {
+      const orphans = ["a.md", "b.md", "c.md"];
+      const { getTool } = buildStructureClient([], orphans);
+      const parsed = await callVaultStructure(getTool);
+      expect(parsed["orphanCount"]).toBe(3);
+      expect(parsed["orphans"]).toEqual(["a.md", "b.md", "c.md"]);
+    });
+
     it("succeeds when cache becomes ready within the wait window", async () => {
       const { server, getTool } = makeMockServer();
       const client = makeMockClient();

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -2290,10 +2290,8 @@ describe("granular tools — registration and basic behavior", () => {
     // (lastIndexOf "/" → slice → check Set → ascend), and the orphans list
     // is sliced to the first 20. Targets the L397-411 mutant cluster.
 
-    function isStructurePlainObject(
-      v: unknown,
-    ): v is Record<string, unknown> {
-      return v !== null && typeof v === "object";
+    function isStructurePlainObject(v: unknown): v is Record<string, unknown> {
+      return v !== null && typeof v === "object" && !Array.isArray(v);
     }
 
     function buildStructureClient(
@@ -2318,12 +2316,18 @@ describe("granular tools — registration and basic behavior", () => {
       Object.defineProperty(cache, "linkCount", {
         get: vi.fn().mockReturnValue(linkCount),
       });
-      // Use Parameters<typeof registerGranularTools>[0] to derive the
-      // expected McpServer type from the function signature itself, so
-      // the cast is provably safe (same pattern applied to consolidated
-      // test helpers in PR #58).
+      // Construct a typed-server-shaped object via `satisfies` so the
+      // compiler verifies our mock matches what registerGranularTools
+      // expects (no `as` assertion). The full McpServer interface has
+      // many members but registerGranularTools only calls registerTool,
+      // so we cast the satisfies result to the parameter type via a
+      // single bridge cast — this still avoids `as never` and gives
+      // TypeScript a chance to verify the mock's shape.
+      const typedServer = {
+        registerTool: server.registerTool,
+      } satisfies { registerTool: typeof server.registerTool };
       registerGranularTools(
-        server as Parameters<typeof registerGranularTools>[0],
+        typedServer as Parameters<typeof registerGranularTools>[0],
         client,
         cache,
         () => true,

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -2318,8 +2318,12 @@ describe("granular tools — registration and basic behavior", () => {
       Object.defineProperty(cache, "linkCount", {
         get: vi.fn().mockReturnValue(linkCount),
       });
+      // Use Parameters<typeof registerGranularTools>[0] to derive the
+      // expected McpServer type from the function signature itself, so
+      // the cast is provably safe (same pattern applied to consolidated
+      // test helpers in PR #58).
       registerGranularTools(
-        server as never,
+        server as Parameters<typeof registerGranularTools>[0],
         client,
         cache,
         () => true,

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -2290,9 +2290,15 @@ describe("granular tools — registration and basic behavior", () => {
     // (lastIndexOf "/" → slice → check Set → ascend), and the orphans list
     // is sliced to the first 20. Targets the L397-411 mutant cluster.
 
+    function isStructurePlainObject(
+      v: unknown,
+    ): v is Record<string, unknown> {
+      return v !== null && typeof v === "object";
+    }
+
     function buildStructureClient(
-      fileList: ReadonlyArray<string>,
-      orphans: ReadonlyArray<string> = [],
+      fileList: readonly string[],
+      orphans: readonly string[] = [],
       noteCount = fileList.length,
       linkCount = 0,
       edgeCount = 0,
@@ -2300,10 +2306,12 @@ describe("granular tools — registration and basic behavior", () => {
       const { server, getTool } = makeMockServer();
       const client = makeMockClient();
       const cache = makeMockCache(true);
-      vi.mocked(cache.getOrphanNotes).mockReturnValue(orphans as string[]);
+      // VaultCache.getOrphanNotes/getFileList return readonly string[]; the
+      // helper accepts the same shape, no `as` cast needed.
+      vi.mocked(cache.getOrphanNotes).mockReturnValue([...orphans]);
       vi.mocked(cache.getMostConnectedNotes).mockReturnValue([]);
       vi.mocked(cache.getEdgeCount).mockReturnValue(edgeCount);
-      vi.mocked(cache.getFileList).mockReturnValue(fileList as string[]);
+      vi.mocked(cache.getFileList).mockReturnValue([...fileList]);
       Object.defineProperty(cache, "noteCount", {
         get: vi.fn().mockReturnValue(noteCount),
       });
@@ -2326,10 +2334,10 @@ describe("granular tools — registration and basic behavior", () => {
     ): Promise<Record<string, unknown>> {
       const result = await getTool("get_vault_structure").handler({ limit });
       const parsed: unknown = JSON.parse(getText(result));
-      if (parsed === null || typeof parsed !== "object") {
+      if (!isStructurePlainObject(parsed)) {
         throw new Error("expected object response");
       }
-      return parsed as Record<string, unknown>;
+      return parsed;
     }
 
     it("counts unique directories across nested paths (no duplicates, parents tracked)", async () => {
@@ -2372,8 +2380,9 @@ describe("granular tools — registration and basic behavior", () => {
       const { getTool } = buildStructureClient([], orphans);
       const parsed = await callVaultStructure(getTool);
       expect(parsed["orphanCount"]).toBe(35); // total count preserved
-      expect(Array.isArray(parsed["orphans"])).toBe(true);
-      expect((parsed["orphans"] as unknown[]).length).toBe(20); // sliced
+      const sliced = parsed["orphans"];
+      if (!Array.isArray(sliced)) throw new Error("expected orphans array");
+      expect(sliced.length).toBe(20); // sliced
     });
 
     it("returns all orphans when cache returns ≤ 20", async () => {


### PR DESCRIPTION
## Summary

Thirteenth Stage 2 backfill PR. buildVaultStructure in src/tools/shared.ts (10 mutants on directory-traversal + orphans slice).

- **Aggregate:** 75.39% → ~75.6% (+0.2pp). Distance to 80: 4.61 → ~4.4pp.
- **Diff:** tests-only, +100 lines (5 new tests + buildStructureClient helper).

## Test additions

Appended to existing get_vault_structure describe block:
1. Counts unique directories across nested paths (4 unique from 4 files)
2. Root-level-only files → 0 directories
3. Dedupes ancestor dirs via early-break (100 siblings in deep/nested/dir → 3 dirs not 300)
4. Slices orphans to first 20 when cache returns more (35 in → 20 in array, 35 in count)
5. Returns all orphans when cache returns ≤ 20

## Stage 2 cumulative

| PR | Δ | Cumulative |
|---|---:|---:|
| #49-61 | various | 75.39% |
| **this** | **~+0.2** | **~75.6%** |

## Test plan

- [ ] CI completes — only Pipeline-gate (Stryker) fails
- [ ] Reviewers triaged
- [ ] Admin-merge under Stage 2 pre-authorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)