### PR TITLE
test(tools): backfill configure-reset handler in shared.ts (~14 mutants)

### DIFF
--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -34,7 +34,7 @@ vi.mock("../config.js", async (importOriginal) => {
 // ---------------------------------------------------------------------------
 
 import type { Config } from "../config.js";
-import { saveConfigToFile, log } from "../config.js";
+import { saveConfigToFile, log, setDebugEnabled } from "../config.js";
 import { registerAllTools } from "../tools.js";
 import { registerGranularTools } from "../tools/granular.js";
 import { registerConsolidatedTools } from "../tools/consolidated.js";
@@ -2112,6 +2112,127 @@ describe("granular tools — registration and basic behavior", () => {
       const { getTool } = setup();
       const result = await getTool("configure").handler({ action: "reset" });
       expect(result.isError).toBe(true);
+    });
+
+    // --- Stryker mutation backfill: handleConfigureReset + buildConfigReset ---
+
+    // buildConfigReset enum coverage — kills the per-setting StringLiteral
+    // mutants on each `case` arm and the DEFAULTS-spread shape mutants.
+    it.each([
+      ["debug", { debug: false }],
+      ["compactResponses", { compactResponses: false }],
+      ["timeout", { reliability: { timeout: 30000 } }],
+      ["verifyWrites", { reliability: { verifyWrites: false } }],
+      ["maxResponseChars", { reliability: { maxResponseChars: 500000 } }],
+      ["toolMode", { tools: { mode: "granular" } }],
+      ["toolPreset", { tools: { preset: "full" } }],
+    ])(
+      "reset %s produces the default-restoring config update",
+      async (setting, expected) => {
+        const { getTool } = setup();
+        const result = await getTool("configure").handler({
+          action: "reset",
+          setting,
+        });
+        expect(result.isError).toBeFalsy();
+        expect(saveConfigToFile).toHaveBeenLastCalledWith(
+          expect.any(String),
+          expected,
+        );
+      },
+    );
+
+    // Immediate-vs-restart message contract — kills the L354 conditional
+    // mutants and the L360/L364 message StringLiteral mutants.
+    it.each(["debug", "compactResponses"])(
+      "reset %s returns 'effective immediately' message",
+      async (setting) => {
+        const { getTool } = setup();
+        try {
+          const result = await getTool("configure").handler({
+            action: "reset",
+            setting,
+          });
+          expect(result.isError).toBeFalsy();
+          expect(getText(result)).toBe(
+            `Setting "${setting}" reset to default (effective immediately)`,
+          );
+        } finally {
+          // Reset module-level state for compactResponses; debug uses
+          // the mocked setDebugEnabled (no real side-effect).
+          if (setting === "compactResponses") setCompactResponses(false);
+        }
+      },
+    );
+
+    it.each([
+      "timeout",
+      "verifyWrites",
+      "maxResponseChars",
+      "toolMode",
+      "toolPreset",
+    ])("reset %s returns 'Restart the server' message", async (setting) => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({
+        action: "reset",
+        setting,
+      });
+      expect(result.isError).toBeFalsy();
+      expect(getText(result)).toBe(
+        `Setting "${setting}" reset to default in config file. Restart the server for this change to take effect.`,
+      );
+    });
+
+    it("rejects empty setting with explicit message", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({
+        action: "reset",
+        setting: "",
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toBe(
+        "[configure] Setting name is required for 'reset' action",
+      );
+    });
+
+    it("rejects unknown setting with explicit message including setting name", async () => {
+      const { getTool } = setup();
+      const result = await getTool("configure").handler({
+        action: "reset",
+        setting: "nonexistent-setting",
+      });
+      expect(result.isError).toBe(true);
+      expect(getText(result)).toBe(
+        "[configure] Unknown setting: nonexistent-setting",
+      );
+    });
+
+    it("does NOT call applyImmediateSetting (via setDebugEnabled) for restart-only settings", async () => {
+      const { getTool } = setup();
+      vi.mocked(setDebugEnabled).mockClear();
+
+      await getTool("configure").handler({
+        action: "reset",
+        setting: "timeout",
+      });
+
+      // Restart-only settings (timeout/verifyWrites/etc.) MUST NOT call
+      // setDebugEnabled — that's reserved for the debug/compactResponses
+      // immediate path.
+      expect(setDebugEnabled).not.toHaveBeenCalled();
+    });
+
+    it("DOES call setDebugEnabled when resetting debug (immediate effect)", async () => {
+      const { getTool } = setup();
+      vi.mocked(setDebugEnabled).mockClear();
+
+      await getTool("configure").handler({
+        action: "reset",
+        setting: "debug",
+      });
+
+      // Reset uses DEFAULTS.debug which is `false` → setDebugEnabled(false).
+      expect(setDebugEnabled).toHaveBeenCalledWith(false);
     });
   });
 

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -2130,15 +2130,21 @@ describe("granular tools — registration and basic behavior", () => {
       "reset %s produces the default-restoring config update",
       async (setting, expected) => {
         const { getTool } = setup();
-        const result = await getTool("configure").handler({
-          action: "reset",
-          setting,
-        });
-        expect(result.isError).toBeFalsy();
-        expect(saveConfigToFile).toHaveBeenLastCalledWith(
-          expect.any(String),
-          expected,
-        );
+        try {
+          const result = await getTool("configure").handler({
+            action: "reset",
+            setting,
+          });
+          expect(result.isError).toBeFalsy();
+          expect(saveConfigToFile).toHaveBeenLastCalledWith(
+            expect.any(String),
+            expected,
+          );
+        } finally {
+          // Reset module-level state for compactResponses; debug uses
+          // the mocked setDebugEnabled (no real side-effect).
+          if (setting === "compactResponses") setCompactResponses(false);
+        }
       },
     );
 
@@ -2207,20 +2213,28 @@ describe("granular tools — registration and basic behavior", () => {
       );
     });
 
-    it("does NOT call applyImmediateSetting (via setDebugEnabled) for restart-only settings", async () => {
-      const { getTool } = setup();
-      vi.mocked(setDebugEnabled).mockClear();
+    it.each([
+      "timeout",
+      "verifyWrites",
+      "maxResponseChars",
+      "toolMode",
+      "toolPreset",
+    ])(
+      "does NOT call applyImmediateSetting (via setDebugEnabled) for restart-only setting %s",
+      async (setting) => {
+        const { getTool } = setup();
+        vi.mocked(setDebugEnabled).mockClear();
 
-      await getTool("configure").handler({
-        action: "reset",
-        setting: "timeout",
-      });
+        await getTool("configure").handler({
+          action: "reset",
+          setting,
+        });
 
-      // Restart-only settings (timeout/verifyWrites/etc.) MUST NOT call
-      // setDebugEnabled — that's reserved for the debug/compactResponses
-      // immediate path.
-      expect(setDebugEnabled).not.toHaveBeenCalled();
-    });
+        // Restart-only settings MUST NOT call setDebugEnabled — that's
+        // reserved for the debug/compactResponses immediate path.
+        expect(setDebugEnabled).not.toHaveBeenCalled();
+      },
+    );
 
     it("DOES call setDebugEnabled when resetting debug (immediate effect)", async () => {
       const { getTool } = setup();

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -2116,6 +2116,18 @@ describe("granular tools — registration and basic behavior", () => {
 
     // --- Stryker mutation backfill: handleConfigureReset + buildConfigReset ---
 
+    // Single source of truth for the restart-only reset settings (settings
+    // whose reset writes to config but does NOT trigger an immediate
+    // side-effect via applyImmediateSetting). Used by the "Restart the
+    // server" message tests and the "does NOT call setDebugEnabled" tests.
+    const RESTART_ONLY_RESET_SETTINGS = [
+      "timeout",
+      "verifyWrites",
+      "maxResponseChars",
+      "toolMode",
+      "toolPreset",
+    ] as const;
+
     // buildConfigReset enum coverage — kills the per-setting StringLiteral
     // mutants on each `case` arm and the DEFAULTS-spread shape mutants.
     it.each([
@@ -2171,23 +2183,20 @@ describe("granular tools — registration and basic behavior", () => {
       },
     );
 
-    it.each([
-      "timeout",
-      "verifyWrites",
-      "maxResponseChars",
-      "toolMode",
-      "toolPreset",
-    ])("reset %s returns 'Restart the server' message", async (setting) => {
-      const { getTool } = setup();
-      const result = await getTool("configure").handler({
-        action: "reset",
-        setting,
-      });
-      expect(result.isError).toBeFalsy();
-      expect(getText(result)).toBe(
-        `Setting "${setting}" reset to default in config file. Restart the server for this change to take effect.`,
-      );
-    });
+    it.each(RESTART_ONLY_RESET_SETTINGS)(
+      "reset %s returns 'Restart the server' message",
+      async (setting) => {
+        const { getTool } = setup();
+        const result = await getTool("configure").handler({
+          action: "reset",
+          setting,
+        });
+        expect(result.isError).toBeFalsy();
+        expect(getText(result)).toBe(
+          `Setting "${setting}" reset to default in config file. Restart the server for this change to take effect.`,
+        );
+      },
+    );
 
     it("rejects empty setting with explicit message", async () => {
       const { getTool } = setup();
@@ -2213,13 +2222,7 @@ describe("granular tools — registration and basic behavior", () => {
       );
     });
 
-    it.each([
-      "timeout",
-      "verifyWrites",
-      "maxResponseChars",
-      "toolMode",
-      "toolPreset",
-    ])(
+    it.each(RESTART_ONLY_RESET_SETTINGS)(
       "does NOT call applyImmediateSetting (via setDebugEnabled) for restart-only setting %s",
       async (setting) => {
         const { getTool } = setup();
@@ -2236,7 +2239,7 @@ describe("granular tools — registration and basic behavior", () => {
       },
     );
 
-    it("DOES call setDebugEnabled when resetting debug (immediate effect)", async () => {
+    it("DOES call setDebugEnabled exactly once when resetting debug (immediate effect)", async () => {
       const { getTool } = setup();
       vi.mocked(setDebugEnabled).mockClear();
 
@@ -2246,7 +2249,10 @@ describe("granular tools — registration and basic behavior", () => {
       });
 
       // Reset uses DEFAULTS.debug which is `false` → setDebugEnabled(false).
-      expect(setDebugEnabled).toHaveBeenCalledWith(false);
+      // Assert exact call count + last-call args to catch extra/misordered
+      // invocations a looser .toHaveBeenCalledWith would miss.
+      expect(setDebugEnabled).toHaveBeenCalledTimes(1);
+      expect(setDebugEnabled).toHaveBeenLastCalledWith(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Fourteenth Stage 2 backfill PR. handleConfigureReset + buildConfigReset in shared.ts (~14 mutants).

- **Aggregate:** 75.58% → ~75.85% (+0.3pp). Distance to 80: 4.42 → ~4.15pp.
- **Diff:** tests-only, +122 lines (18 new tests + setDebugEnabled import).

## Coverage

- buildConfigReset: 7 it.each over all settings, exact default-shape assertion
- Immediate-vs-restart: 2 it.each (debug+compactResponses with reset state cleanup) + 5 it.each (restart-only settings) asserting exact message text
- Validation errors: empty setting + unknown setting with exact message contracts
- Apply routing: restart-only settings do NOT call setDebugEnabled; debug-reset DOES call setDebugEnabled(false)

## Stage 2 cumulative

| PR | Δ | Cumulative |
|---|---:|---:|
| #49-62 | various | 75.58% |
| **this** | **~+0.3** | **~75.85%** |

## Test plan

- [ ] CI completes — only Pipeline-gate (Stryker) fails
- [ ] Reviewers triaged
- [ ] Admin-merge under Stage 2 pre-authorization

🤖 Generated with [Claude Code](https://claude.com/claude-code)