### PR TITLE
chore(stryker): resume ratchet policy — aggregate crossed 80%

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -69,19 +69,26 @@ jobs:
       # Stryker --incremental reads/writes reports/stryker-incremental.json.
       # Without this cache, every CI run is cold (~15-20 min on a typical repo)
       # because the file is gone between runs. Restore-keys fall back to the
-      # base branch cache, then to any cache for the OS, so a feature branch's
-      # first run still benefits from main's most recent cache.
+      # base branch cache (with same config hash), then to any cache for the
+      # OS+config, so a feature branch's first run still benefits from main's
+      # most recent cache while preventing stale-config cache hits.
+      #
+      # Cache key includes hashFiles('stryker.conf.mjs') because Stryker
+      # incremental does NOT invalidate on config changes (e.g. mutate-glob
+      # carve-outs). Without the config hash a cache built when src/index.ts
+      # was in the mutate set will keep reporting 270 NoCoverage mutants on
+      # index.ts even after the carve-out lands. Discovered on PR #69.
       - name: Restore Stryker incremental cache
         id: stryker_cache
         if: ${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') != '' }}
         uses: actions/cache@v4
         with:
           path: reports/stryker-incremental.json
-          key: stryker-incremental-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+          key: stryker-incremental-${{ runner.os }}-${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            stryker-incremental-${{ runner.os }}-${{ github.ref_name }}-
-            stryker-incremental-${{ runner.os }}-main-
-            stryker-incremental-${{ runner.os }}-
+            stryker-incremental-${{ runner.os }}-${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') }}-${{ github.ref_name }}-
+            stryker-incremental-${{ runner.os }}-${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') }}-main-
+            stryker-incremental-${{ runner.os }}-${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') }}-
 
       # Surface cache hit/miss in CI logs — Phase 5 doctor.sh hit-rate
       # monitoring reads this signal directly from workflow output.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,57 +144,36 @@ drift — surfaced before code goes public.
 Time budget: ~120 seconds. If the reviewer takes longer than that
 consistently, log the run-times and revisit the prompt or the model choice.
 
-## Mutation Testing — Hard 80% Floor (active)
+## Mutation Testing — Ratchet Policy (active, post-floor)
 
-Stryker `thresholds.break` is set to **80** in `stryker.conf.mjs`. The
-pipeline (`npm run pre-pr`) blocks any push whose mutation score is
-below 80%. As of the bootstrap PR (#49) the score is **64.66%**, so
-**every PR opened now will fail the Stryker gate** until the cumulative
-backfill series lifts the aggregate score over the floor.
+Stryker `thresholds.break` is currently set to **80** in
+`stryker.conf.mjs` (the hard floor, held for one cycle before the
+first ratchet bump above the floor — see the score-history comment
+in `stryker.conf.mjs` for the rationale). The pipeline
+(`npm run pre-pr`) blocks any push whose mutation score drops below
+the current threshold. Aggregate score crossed 80 on 2026-04-26 with
+PR #68 merged; a fresh full Stryker run confirmed **81.34%**. The
+Stage 1/2 bootstrap+backfill series is complete and the ratchet
+policy is now in effect.
 
-### Why every backfill PR also needs admin-merge
+### Standing rules
 
-Stryker measures the whole `src/**/*.ts` surface, not just the file a
-PR touches. A single backfill PR that adds tests for one file might
-move the aggregate from 64.66 → 65.5 — still red against the 80 floor.
-**The Stryker gate therefore stays red across the entire backfill
-series**, not just the bootstrap PR. Every backfill PR in the series
-will need an admin-merge override, not just this one. That is the real
-cost of Option C: ~N admin-merges, where N is roughly the number of
-files needed to cross the aggregate floor. Plan accordingly.
-
-Once the aggregate crosses 80, normal gate enforcement resumes
-automatically — no further admin-merges needed.
-
-### Rules while the floor is unmet
-
-- **No feature work.** Pipeline is frozen for new features. The only
-  PR types allowed to merge are (a) the floor-bootstrap PR itself, and
-  (b) backfill PRs that add tests to kill surviving mutants. Both PR
-  types require admin-merge until the aggregate score crosses 80.
-- **Temporary exception to the standard pipeline gates.** Two
-  sections below — "Adder Code Review Pipeline → Before every push"
-  (`npm run pre-pr` must pass before push) and "Pull request workflow
-  → step 6" (all CI green + `npm run pre-pr` passing before merge) —
-  together would block any PR whose pre-pr fails on Stryker. While
-  the floor is unmet, bootstrap and backfill PRs are exempt from
-  both rules **for the Stryker / Pipeline-gate failure only**.
-  Every other pre-pr step (build, lint, audit, knip, madge, semgrep,
-  snyk, sonar) must still pass, every other CI check must still be
-  green, and every reviewer thread must still be resolved. Once
-  aggregate ≥ 80 the standard rules resume automatically for all PRs.
-- **One file (or one logical group) per backfill PR** — no mega-PRs.
-  This makes each merge's contribution to the aggregate score easy to
-  attribute and roll back if a regression surfaces.
-- **Tests-only.** Hard Rule 8 still applies: backfill PRs add tests,
-  not production code, unless a minimal change is genuinely required
-  to make code testable (justify in PR body).
-- **Per-file carve-outs allowed but justified.** If a file truly can't
-  hit 80 (entry-point wiring like `index.ts`, content-heavy modules),
-  exclude it from the Stryker `mutate` glob and explain why in the PR
-  body. The file's mutants are removed from the aggregate calculation,
-  so the rest of the codebase isn't dragged down by an inherently
-  untestable file. Example carve-out in `stryker.conf.mjs`:
+- **Ratchet on improvement.** When a PR raises the aggregate above
+  the current `thresholds.break + 1pp`, raise `thresholds.break` to
+  `(new_score − 1pp)` so it always sits ~1pp below the current kill
+  rate — tight enough to catch a regression, loose enough to tolerate
+  incremental-cache noise. Hard floor: never drop below 80.
+- **Tests-only for kill-rate work.** Hard Rule 8 applies: PRs that
+  exist primarily to raise the mutation score add tests, not
+  production code, unless a minimal change is genuinely required to
+  make code testable (justify in PR body).
+- **Per-file carve-outs allowed but justified.** Some files truly
+  cannot hit 80 (entry-point wiring, content-heavy modules whose
+  mutants are static-initialized at module load and Vitest worker
+  caching defeats Stryker's mutation injection). Exclude them from
+  the Stryker `mutate` glob and document the reason in the PR body.
+  The file's mutants are removed from the aggregate denominator.
+  Example carve-out in `stryker.conf.mjs`:
 
   ```javascript
   // Excluding entry-point wiring that can't be unit-tested without
@@ -202,21 +181,19 @@ automatically — no further admin-merges needed.
   mutate: ["src/**/*.ts", "!src/**/*.test.ts", "!src/index.ts"],
   ```
 
-  More than 5 carve-outs ⇒ escalate for human policy review.
-- **Re-baseline after each merge.** Update the score-history comment
-  in `stryker.conf.mjs` (the in-repo authoritative record). The
-  maintainer-local audit log at `~/projects/code-review-pipeline/build-log.md`
-  is updated by the same maintainer who runs the Adder pipeline locally;
-  contributors not running that pipeline can skip it — the in-repo
-  comment in `stryker.conf.mjs` is sufficient to know where the next
-  backfill PR starts from.
-
-### After the floor is hit
-
-Once the aggregate score is ≥80, the ratchet policy resumes:
-`thresholds.break = (current_score - 1pp)`, with a hard floor that
-never drops below 80. `low`/`high` re-separate from `break` at that
-point and the three-threshold band becomes meaningful again.
+  More than 5 carve-outs ⇒ escalate for human policy review. Current
+  count is tracked in `stryker.conf.mjs` via grep-able
+  `// Carve-out N/5: <path>` comments.
+- **Re-baseline after each merge that moves the score.** Update the
+  score-history comment in `stryker.conf.mjs` (the in-repo
+  authoritative record) and bump `thresholds.break` per the ratchet
+  formula above.
+- **Beware incremental-cache staleness.** Stryker's `--incremental`
+  cache invalidates on source-file changes but NOT on test-file
+  changes — meaning test-only PRs may report a stale aggregate that
+  doesn't reflect newly-added kills. Periodically run a fresh
+  (non-incremental) Stryker pass to confirm the true score, especially
+  before a ratchet bump or threshold adjustment.
 
 ## Testing
 
@@ -367,13 +344,6 @@ incorrectly failing, fix the gate's config rather than skipping it.
 `--skip-qwen` is allowed during fast iteration but the final run before
 opening a PR must include Qwen.
 
-**Exception while the Stryker mutation-testing floor is unmet:**
-bootstrap and backfill PRs may push despite a `npm run pre-pr` failure
-**caused only by the Stryker / Pipeline-gate red**. All other pre-pr
-steps must still pass. See "Mutation Testing — Hard 80% Floor (active)"
-above for the full carve-out rules. The exception ends automatically
-when aggregate score crosses 80.
-
 The gate invokes `npm test -- --coverage`. Your project's `test` script
 must be plain (e.g. `"test": "vitest run"`), without a hardcoded
 `--coverage` flag — otherwise the runner sees a duplicate flag and fails.
@@ -402,13 +372,6 @@ Coverage thresholds belong in `vitest.config.ts` / `jest.config.js`.
    - All CodeRabbit threads resolved
    - All CodeAnt threads resolved
    - `npm run pre-pr` passes locally on the branch head
-
-   **Exception while the Stryker mutation-testing floor is unmet:**
-   bootstrap and backfill PRs are exempt from the "all CI checks
-   green" and "`npm run pre-pr` passes" requirements **for the
-   Stryker / Pipeline-gate failure only**. See "Mutation Testing —
-   Hard 80% Floor (active)" above for the full carve-out rules. The
-   exception ends automatically when aggregate score crosses 80.
 
    **There is no human code review.** The pipeline spec is explicit: "No
    human code review — pipeline must be thorough enough that human only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,11 @@ policy is now in effect.
   `(new_score − 1pp)` so it always sits ~1pp below the current kill
   rate — tight enough to catch a regression, loose enough to tolerate
   incremental-cache noise. Hard floor: never drop below 80.
+  **Stryker invariant `high >= low >= break` must hold.** When
+  bumping `break` above 80, also bump `low` and `high` so the
+  inequality stays valid (e.g. all three to the new value, or
+  `low = break` and `high = 100` if you want a high-band signal).
+  Failing to do so produces a Stryker config error at gate time.
 - **Tests-only for kill-rate work.** Hard Rule 8 applies: PRs that
   exist primarily to raise the mutation score add tests, not
   production code, unless a minimal change is genuinely required to
@@ -184,10 +189,13 @@ policy is now in effect.
   More than 5 carve-outs ⇒ escalate for human policy review. Current
   count is tracked in `stryker.conf.mjs` via grep-able
   `// Carve-out N/5: <path>` comments.
+
 - **Re-baseline after each merge that moves the score.** Update the
   score-history comment in `stryker.conf.mjs` (the in-repo
-  authoritative record) and bump `thresholds.break` per the ratchet
-  formula above.
+  authoritative record) and bump the entire `thresholds` object per
+  the ratchet formula above — remember `high >= low >= break` so
+  `low` and `high` move with `break` whenever `break` exceeds the
+  current `low` value.
 - **Beware incremental-cache staleness.** Stryker's `--incremental`
   cache invalidates on source-file changes but NOT on test-file
   changes — meaning test-only PRs may report a stale aggregate that

--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -16,11 +16,11 @@ export default {
   // See pipeline-spec.md → Stryker section → "key glob patterns to
   // actual project file types".
   //
-  // Per-file carve-outs — see CLAUDE.md "Mutation Testing — Hard 80%
-  // Floor (active)" → "Per-file carve-outs allowed but justified".
-  // Budget: 5. Active count below; >5 ⇒ escalate for human policy review.
-  // Each line below is `// Carve-out N/5: <path>` so future authors can
-  // grep `Carve-out` to count what's already in flight.
+  // Per-file carve-outs — see CLAUDE.md "Mutation Testing — Ratchet
+  // Policy (active, post-floor)" → "Per-file carve-outs allowed but
+  // justified". Budget: 5. Active count below; >5 ⇒ escalate for human
+  // policy review. Each line below is `// Carve-out N/5: <path>` so
+  // future authors can grep `Carve-out` to count what's already in flight.
   //
   // Carve-out 1/5: src/index.ts — entry-point wiring. Boots the MCP
   //   server + StdioServerTransport, reads package.json for version,
@@ -66,6 +66,23 @@ export default {
   //                           pp from removing src/index.ts from mutate
   //                           glob — entry-point wiring, justified above
   //                           in the per-file carve-outs comment.)
+  //   ...                    (PRs #52-68, ~10pp from systematic backfills
+  //                           on obsidian.ts, consolidated.ts, shared.ts,
+  //                           tools.ts, config.ts. See git log for
+  //                           per-PR contributions.)
+  //   81.34 → break 80       (chore/stryker-resume-ratchet — fresh full
+  //                           Stryker run after PR #68 confirmed aggregate
+  //                           crossed 80. The incremental cache had been
+  //                           reporting stale numbers (79.59) because
+  //                           Stryker's --incremental invalidates only on
+  //                           source-file changes, not test-only changes;
+  //                           rebuilding the cache from scratch revealed
+  //                           the true 81.34. Floor met; ratchet policy
+  //                           resumes per CLAUDE.md "Mutation Testing —
+  //                           Ratchet Policy". Threshold remains at 80
+  //                           (the hard floor) for one more PR cycle to
+  //                           confirm cache stability before the first
+  //                           ratchet bump above the floor.)
   // See ~/projects/code-review-pipeline/baseline-findings.md for the bake-in
   // run and build-log.md for the ratchet history (including this floor entry).
   // `low` is collapsed to 80 alongside `break` and `high` — the 70-79 band


### PR DESCRIPTION
## Summary

🎉 **Aggregate mutation score crossed the hard 80% floor on 2026-04-26.** Fresh full Stryker run after PR #68 merge confirmed **81.34%** ("Final mutation score of 81.34 is greater than or equal to break threshold 80"). Stage 1/2 bootstrap+backfill series complete; ratchet policy resumes.

## Why this PR exists

Per CLAUDE.md "Mutation Testing — Hard 80% Floor (active)", the unmet-floor carve-outs (admin-merge requirement on every PR, Pipeline-gate exception in pre-pr / PR workflow) are scoped to the period the floor is unmet. With aggregate ≥ 80, those carve-outs expire and normal ratchet enforcement resumes. **This is the first PR after PR #68 that should pass the gate normally** (and it does — `npm run pre-pr` would not see a Stryker red on this branch).

## Diff scope

- **`CLAUDE.md`** — replaces "Mutation Testing — Hard 80% Floor (active)" (~70 lines) with "Mutation Testing — Ratchet Policy (active, post-floor)" (~45 lines). Preserves all standing rules (carve-out budget = 5, Hard Rule 8 tests-only, ratchet formula, score-history rebaseline). Adds an operational note about Stryker `--incremental` cache staleness on test-only PRs (the silent-pass issue that caused us to think we were at 79.59% when fresh runs show 81.34%). Removes the two now-obsolete "Exception while … unmet" paragraphs in "Before every push" and "Pull request workflow → step 6".
- **`stryker.conf.mjs`** — updates carve-out comment header reference. Appends score-history entry. Explains the deliberate one-cycle hold at `thresholds.break = 80` (vs. bumping to 80.34 per the strict ratchet formula) to verify incremental-cache stability before the first post-floor bump.

## Stage 2 series summary

| Stage | PRs | Aggregate | Notes |
|-------|-----|-----------|-------|
| Stage 1 bootstrap | #49 | 64.66 → break 80 | Floor declared |
| Stage 2 backfill | #50-68 | 65.45 → 81.34 (**+15.89 pp**) | 19 backfill PRs over ~2 days |
| Stage 3 (this) | #N | n/a | Policy resumption |

Per-file final scores:

| File | Score | Notes |
|------|-------|-------|
| consolidated.ts | 94.00 % | Reached in PR #54-55 |
| granular.ts | 95.22 % | Steady |
| shared.ts | 92.16 % | PRs #56-64 |
| skill.ts | 96.13 % | Was reported as 59% under stale incremental cache; fresh run shows true score |
| config.ts | 85.21 % | PRs #65, #68 |
| tools.ts | 87.43 % | PR #66 |
| obsidian.ts | 67.05 % | Largest remaining headroom; not a blocker |
| cache.ts | 66.97 % | Untouched; biggest single-file pool |
| errors.ts, schemas.ts | 100 % | |

## Reviewer subagent

Invoked. Verdict: **APPROVE** with one info-level nit on CLAUDE.md threshold-wording clarity — folded into this commit.

## Local gates

- [x] `npm test` — 1126/1126 pass
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Stryker (fresh) — **81.34% > 80** (gate passes)

## Stryker / Pipeline-gate

Should pass on this PR's CI run for the first time since PR #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)