### PR TITLE
chore: drop CodeAnt refs + add Spec Drift Prevention rule

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -115,8 +115,10 @@ jobs:
         run: semgrep --config p/default --config p/typescript --config p/javascript --error --metrics=off --quiet .
 
       # Qwen step intentionally omitted — runs locally only via
-      # scripts/pre-pr.sh (spec step 15). CI relies on CodeRabbit + CodeAnt
-      # for the post-push AI review perspective.
+      # scripts/pre-pr.sh (spec step 15). CI relies on CodeRabbit (required)
+      # plus advisory reviewers (Gemini, Greptile, CodeQL) for the post-push
+      # AI review perspective. The live reviewer roster lives in
+      # ~/projects/code-review-pipeline/pipeline-state.md.
 
   sonar:
     name: SonarQube

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,11 +410,9 @@ Coverage thresholds belong in `vitest.config.ts` / `jest.config.js`.
    - **Advisory finding contradicts an explicit rule in this CLAUDE.md**:
      auto-dismiss; cite the CLAUDE.md section in the dismissal note.
    - **Substantive disagreement that doesn't fit the above** (e.g. two
-     incompatible fixes, both defensible): stop and ask the human.
-5. If reviewers disagree substantively (e.g. CodeRabbit and Gemini propose
-   incompatible fixes), stop and ask the human — do not oscillate between
-   the two reviewers' preferred approaches.
-6. Ask the human to merge only when all the following are true:
+     incompatible fixes, both defensible): stop and ask the human — do not
+     oscillate between the two reviewers' preferred approaches.
+5. Ask the human to merge only when all the following are true:
    - All CI checks green
    - All CodeRabbit threads resolved
    - All advisory-reviewer threads resolved or explicitly auto-dismissed in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,28 @@ next. Format per stage:
 Do NOT batch verification at end of all stages. A failed early stage that
 propagates is harder to diagnose than one caught immediately.
 
+## Spec Drift Prevention
+
+Adding a new gate, reviewer, or pipeline step requires a PR to
+`~/projects/code-review-pipeline/pipeline-state.md` FIRST, before the
+implementing PR. The `pipeline-state.md` update is part of the
+implementing PR's diff or immediately precedes it.
+
+Removing a gate, reviewer, or step requires the same — a
+`pipeline-state.md` PR documenting the removal alongside or immediately
+preceding the change.
+
+Drift erodes trust. Every drift item caught in the 2026-04-26 audit (Q5
+in `~/projects/code-review-pipeline/build-log.md`) happened because this
+rule didn't exist. CodeAnt was dropped on 2026-04-23 and the docs took
+three days to catch up; CodeQL, the reviewer subagent, the
+JSDoc-coverage gate, and the Stryker hard-floor were all added without
+ever updating the spec. The cost was real: the audit had to reconstruct
+live state from PR history because no single document reflected reality.
+
+`pipeline-state.md` is the live-state document. `pipeline-spec.md` is
+now marked superseded and preserved for the design-intent record only.
+
 ## When to Use Subagents
 
 Subagents are not free — each burns its own context window, and
@@ -369,16 +391,22 @@ Coverage thresholds belong in `vitest.config.ts` / `jest.config.js`.
 ### Pull request workflow
 
 1. Open PR against `main`
-2. CodeRabbit Pro Plus AND CodeAnt AI both auto-review — you will see comments
-   from both within minutes
+2. **CodeRabbit Pro Plus** (required) auto-reviews. **Gemini**, **Greptile**,
+   and **CodeQL** also post advisory findings. The live reviewer roster is
+   recorded in `~/projects/code-review-pipeline/pipeline-state.md`.
 3. Dependabot runs on dep-related PRs
-4. Iterate on every comment from BOTH reviewers. Nitpicks count. No "will fix later."
-5. If CodeRabbit and CodeAnt disagree on something, stop and ask the human — do
-   not oscillate between the two reviewers' preferred approaches
+4. Iterate on every comment from CodeRabbit (the required reviewer). Resolve
+   advisory-reviewer threads with the same rigor — nitpicks count — but apply
+   Hard Rule 8 triage when an advisory reviewer disagrees with CodeRabbit or
+   the project's CLAUDE.md conventions.
+5. If reviewers disagree substantively (e.g. CodeRabbit and Gemini propose
+   incompatible fixes), stop and ask the human — do not oscillate between
+   the two reviewers' preferred approaches.
 6. Ask the human to merge only when all of the following are true:
    - All CI checks green
    - All CodeRabbit threads resolved
-   - All CodeAnt threads resolved
+   - All advisory-reviewer threads resolved or explicitly auto-dismissed in
+     the PR body
    - `npm run pre-pr` passes locally on the branch head
 
    **There is no human code review.** The pipeline spec is explicit: "No

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,14 +310,15 @@ propagates is harder to diagnose than one caught immediately.
 
 ## Spec Drift Prevention
 
-Adding a new gate, reviewer, or pipeline step requires a PR to
-`~/projects/code-review-pipeline/pipeline-state.md` FIRST, before the
-implementing PR. The `pipeline-state.md` update is part of the
-implementing PR's diff or immediately precedes it.
-
-Removing a gate, reviewer, or step requires the same — a
-`pipeline-state.md` PR documenting the removal alongside or immediately
-preceding the change.
+Any addition or removal of a gate, reviewer, or pipeline step must be
+recorded in `~/projects/code-review-pipeline/pipeline-state.md`. Because
+`pipeline-state.md` lives in a separate filesystem location from this
+repo (it is vault-adjacent, not part of any repo's diff), the rule is:
+**commit the `pipeline-state.md` update alongside or immediately before
+the implementing PR**. "Alongside" means in the same working session;
+"immediately before" means no other implementing PR lands between the
+state-doc update and the change it documents. The state document must
+always reflect what `main` actually runs.
 
 Drift erodes trust. Every drift item caught in the 2026-04-26 audit (Q5
 in `~/projects/code-review-pipeline/build-log.md`) happened because this
@@ -396,9 +397,17 @@ Coverage thresholds belong in `vitest.config.ts` / `jest.config.js`.
    recorded in `~/projects/code-review-pipeline/pipeline-state.md`.
 3. Dependabot runs on dep-related PRs
 4. Iterate on every comment from CodeRabbit (the required reviewer). Resolve
-   advisory-reviewer threads with the same rigor — nitpicks count — but apply
-   Hard Rule 8 triage when an advisory reviewer disagrees with CodeRabbit or
-   the project's CLAUDE.md conventions.
+   advisory-reviewer threads with the same rigor — nitpicks count. When an
+   advisory reviewer disagrees with CodeRabbit or with this CLAUDE.md, the
+   triage rule is:
+   - **Convergent finding** (≥2 reviewers flag the same issue): auto-apply.
+   - **CodeRabbit vs. advisory disagreement**: prefer CodeRabbit (the
+     required reviewer); auto-dismiss the advisory finding with a one-line
+     reason in the PR body.
+   - **Advisory finding contradicts an explicit rule in this CLAUDE.md**:
+     auto-dismiss; cite the CLAUDE.md section in the dismissal note.
+   - **Substantive disagreement that doesn't fit the above** (e.g. two
+     incompatible fixes, both defensible): stop and ask the human.
 5. If reviewers disagree substantively (e.g. CodeRabbit and Gemini propose
    incompatible fixes), stop and ask the human — do not oscillate between
    the two reviewers' preferred approaches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,7 +394,10 @@ Coverage thresholds belong in `vitest.config.ts` / `jest.config.js`.
 1. Open PR against `main`
 2. **CodeRabbit Pro Plus** (required) auto-reviews. **Gemini**, **Greptile**,
    and **CodeQL** also post advisory findings. The live reviewer roster is
-   recorded in `~/projects/code-review-pipeline/pipeline-state.md`.
+   recorded in `~/projects/code-review-pipeline/pipeline-state.md` (internal
+   maintainer configuration — not accessible or editable by external
+   contributors; the required-vs-advisory split above is the effective
+   roster they should treat as authoritative).
 3. Dependabot runs on dep-related PRs
 4. Iterate on every comment from CodeRabbit (the required reviewer). Resolve
    advisory-reviewer threads with the same rigor — nitpicks count. When an
@@ -411,7 +414,7 @@ Coverage thresholds belong in `vitest.config.ts` / `jest.config.js`.
 5. If reviewers disagree substantively (e.g. CodeRabbit and Gemini propose
    incompatible fixes), stop and ask the human — do not oscillate between
    the two reviewers' preferred approaches.
-6. Ask the human to merge only when all of the following are true:
+6. Ask the human to merge only when all the following are true:
    - All CI checks green
    - All CodeRabbit threads resolved
    - All advisory-reviewer threads resolved or explicitly auto-dismissed in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,8 +314,8 @@ Any addition or removal of a gate, reviewer, or pipeline step must be
 recorded in `~/projects/code-review-pipeline/pipeline-state.md`. Because
 `pipeline-state.md` lives in a separate filesystem location from this
 repo (it is vault-adjacent, not part of any repo's diff), the rule is:
-**commit the `pipeline-state.md` update alongside or immediately before
-the implementing PR**. "Alongside" means in the same working session;
+**update `pipeline-state.md` in its own location and commit that change
+alongside or immediately before the implementing PR in this repo**. "Alongside" means in the same working session;
 "immediately before" means no other implementing PR lands between the
 state-doc update and the change it documents. The state document must
 always reflect what `main` actually runs.
@@ -397,7 +397,7 @@ Coverage thresholds belong in `vitest.config.ts` / `jest.config.js`.
    recorded in `~/projects/code-review-pipeline/pipeline-state.md` (internal
    maintainer configuration — not accessible or editable by external
    contributors; the required-vs-advisory split above is the effective
-   roster they should treat as authoritative).
+   roster external contributors should treat as authoritative).
 3. Dependabot runs on dep-related PRs
 4. Iterate on every comment from CodeRabbit (the required reviewer). Resolve
    advisory-reviewer threads with the same rigor — nitpicks count. When an


### PR DESCRIPTION
## Summary

Companion to [adder-pipeline-tools#13](https://github.com/adder-factory/adder-pipeline-tools/pull/13). Doc-only sweep in this consumer repo:

- **CLAUDE.md** — drops CodeAnt references in the embedded ADDER-PIPELINE block (PR-workflow steps 2/4/5/6) and adds a new `## Spec Drift Prevention` section codifying that future gate / reviewer changes must update `~/projects/code-review-pipeline/pipeline-state.md` alongside the implementing PR.
- **.github/workflows/pipeline.yml** — comment update on the Qwen-omitted block; reviewer roster now points at `pipeline-state.md`.

The live-state document (`pipeline-state.md`) and the spec banner are at `~/projects/code-review-pipeline/`, not in this repo. The 2026-04-26 audit found seven drift items rooted in the absence of this rule; CodeAnt was the most user-visible.

## Pre-existing Sonar finding (out of scope)

Local `pre-pr.sh` reports `SonarQube quality gate: ERROR — new_violations: actual=1 GT threshold=0` on `src/tools/shared.ts:431` (rule `typescript:S3776`, cognitive complexity, CRITICAL). That file is **not touched** by this diff. The violation pre-dates this PR (build-log.md predicted "burst of failing conditions on the first PR after Issue #7 fix propagation"). CI Sonar skips cleanly (no SONAR_TOKEN in GHA). Cleanup is a separate follow-up PR per Hard Rule 8 — this PR is doc-only.

All other gates pass:

| Gate | Result |
|---|---|
| Prettier / ESLint / tsc / knip | pass |
| JSDoc coverage | pass |
| Tests + coverage | pass |
| Stryker (incremental) | pass |
| Gitleaks / Madge / Semgrep | pass |

## Pre-PR semantic review

Reviewer subagent ran on the diff; verdict `APPROVE`. One info-level finding noted that `## Git Workflow` (line 110-112, outside the v1 block, predates this PR) still reads `CodeRabbitAI + Greptile review automatically` and omits CodeQL — stale but not introduced here, deferred to a follow-up chore PR per the reviewer suggestion.

## Test plan

- [x] `npm run pre-pr` (with Sonar skipped) — green.
- [x] Reviewer subagent — APPROVE.
- [ ] Pipeline gate on CI green.
- [ ] CodeRabbit clean (or addressed).
- [ ] Gemini / CodeQL / Greptile advisory threads resolved or auto-dismissed.

Generated with Claude Code
