### PR TITLE
feat(ci): partition Stryker into affected + full workflows

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # needed for diff-based tools (Stryker --incremental etc.)
+          fetch-depth: 0 # needed for diff-based tools that compare against base ref
 
       - uses: actions/setup-node@v4
         with:
@@ -66,39 +66,15 @@ jobs:
       - name: Tests + coverage
         run: npm test -- --coverage
 
-      # Stryker --incremental reads/writes reports/stryker-incremental.json.
-      # Without this cache, every CI run is cold (~15-20 min on a typical repo)
-      # because the file is gone between runs. Restore-keys fall back to the
-      # base branch cache (with same config hash), then to any cache for the
-      # OS+config, so a feature branch's first run still benefits from main's
-      # most recent cache while preventing stale-config cache hits.
-      #
-      # Cache key includes hashFiles('stryker.conf.mjs') because Stryker
-      # incremental does NOT invalidate on config changes (e.g. mutate-glob
-      # carve-outs). Without the config hash a cache built when src/index.ts
-      # was in the mutate set will keep reporting 270 NoCoverage mutants on
-      # index.ts even after the carve-out lands. Discovered on PR #69.
-      - name: Restore Stryker incremental cache
-        id: stryker_cache
-        if: ${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') != '' }}
-        uses: actions/cache@v4
-        with:
-          path: reports/stryker-incremental.json
-          key: stryker-incremental-${{ runner.os }}-${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') }}-${{ github.ref_name }}-${{ github.sha }}
-          restore-keys: |
-            stryker-incremental-${{ runner.os }}-${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') }}-${{ github.ref_name }}-
-            stryker-incremental-${{ runner.os }}-${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') }}-main-
-            stryker-incremental-${{ runner.os }}-${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') }}-
-
-      # Surface cache hit/miss in CI logs — Phase 5 doctor.sh hit-rate
-      # monitoring reads this signal directly from workflow output.
-      - name: Stryker cache stats
-        if: ${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') != '' }}
-        run: 'echo "Stryker incremental cache hit: ${{ steps.stryker_cache.outputs.cache-hit }}"'
-
-      - name: Stryker
-        if: ${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json') != '' }}
-        run: npx stryker run --incremental
+      # Stryker is partitioned into two dedicated workflows:
+      #   - stryker-affected.yml — runs on every PR, only mutates files in the
+      #     diff against base (target steady-state wall-clock <2 min).
+      #   - stryker-full.yml — runs nightly + on every push to main, full sweep
+      #     (catches incremental-cache staleness; populates the cache that
+      #     stryker-affected.yml restores from).
+      # See ~/projects/code-review-pipeline/pipeline-state.md "Mutation-testing
+      # policy" for rationale (2026-04-26 audit Q4: Stryker was 93 % of
+      # Pipeline-gate wall-clock).
 
       - name: Gitleaks
         run: gitleaks detect --source . --verbose --redact --no-banner

--- a/.github/workflows/stryker-affected.yml
+++ b/.github/workflows/stryker-affected.yml
@@ -1,0 +1,157 @@
+name: Stryker (affected)
+
+# Feature-branch Stryker: only mutates source files actually changed in the
+# PR diff. Steady-state wall-clock target: <2 min. Bootstrap (first run, no
+# cache) may take up to 30 min — see timeout-minutes below.
+#
+# Companion to stryker-full.yml (which runs nightly + on every push to main
+# and populates the incremental cache that this workflow restores from).
+#
+# Background: 2026-04-26 audit Q4 found Stryker was 93 % of Pipeline-gate
+# wall-clock (~16 min of 17 min) on every PR, including doc-only and
+# test-only PRs that didn't touch any mutation-relevant source. Partitioning
+# into "affected on PRs / full nightly + on main" cuts feature-branch CI
+# turnaround by ~10x in steady state.
+
+on:
+  pull_request:
+    branches: [main]
+
+# One concurrent run per PR — cancel in-progress on new push.
+concurrency:
+  group: stryker-affected-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  stryker-affected:
+    name: Stryker (affected)
+    runs-on: ubuntu-latest
+    # Generous timeout for bootstrap (first run after partition lands has no
+    # cache to restore from — falls back to a full sweep, ~16-20 min). After
+    # one stryker-full.yml run on main has populated the cache, steady state
+    # is <2 min for typical PR sizes.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need full history to diff against PR base. Shallow clones break
+          # `git diff origin/<base>...HEAD` for any non-trivial PR.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      # Skip cleanly when the target repo doesn't have a Stryker config —
+      # mirrors pipeline.yml's hashFiles guard so opt-in projects don't see
+      # spurious failures.
+      - name: Detect Stryker config
+        id: detect
+        run: |
+          if [ -f stryker.conf.mjs ] || [ -f stryker.conf.js ] || [ -f stryker.config.json ]; then
+            echo "present=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=0" >> "$GITHUB_OUTPUT"
+            echo "No Stryker config — skipping affected mutation testing."
+          fi
+
+      # Compute the list of source files actually changed in this PR. We
+      # restrict to *.ts under src/ (mutation surface) and exclude test
+      # files (Stryker doesn't mutate them).
+      #
+      # If the diff contains zero qualifying files, we exit successfully
+      # without invoking Stryker at all. Test-only and doc-only PRs land in
+      # this branch — the nightly stryker-full.yml validates the aggregate
+      # for them.
+      - name: Compute affected source files
+        id: affected
+        if: steps.detect.outputs.present == '1'
+        run: |
+          set -euo pipefail
+          BASE="${{ github.base_ref }}"
+          # Need the FULL history of the base branch so the three-dot diff
+          # below can locate the merge-base. `actions/checkout@v4` with
+          # `fetch-depth: 0` already fetched all history of the PR ref, but
+          # the base branch is not always populated as a tracked remote ref
+          # in the PR-event context — fetch it explicitly without a depth
+          # cap. A shallow fetch (`--depth=1`) silently breaks the three-dot
+          # diff on any PR with more than one commit since branching, which
+          # combined with `|| true` was a silent-pass failure mode (no
+          # mutation testing, gate appears green) — flagged by reviewer
+          # subagent on PR review of this very change.
+          git fetch --no-tags origin "$BASE"
+          # Three-dot diff finds files changed since merge-base of HEAD and
+          # base — i.e. files this PR changed, ignoring concurrent main
+          # commits. AMRC = Added / Modified / Renamed / Copied (Copied
+          # files often arrive with content modifications and should be
+          # mutated alongside ordinary modifications).
+          # No `|| true` — a real error (e.g. bad ref, missing merge-base)
+          # must fail the gate, not silently skip Stryker.
+          CHANGED=$(git diff --name-only --diff-filter=AMRC "origin/$BASE...HEAD" -- 'src/**/*.ts' \
+            | grep -vE '\.test\.ts$|\.spec\.ts$' || true)
+          # `grep` exits 1 when no lines match — that is the legitimate
+          # "no qualifying files" path, so `|| true` here is correct
+          # (different from suppressing a `git fetch`/`git diff` failure).
+          if [ -z "$CHANGED" ]; then
+            echo "empty=1" >> "$GITHUB_OUTPUT"
+            echo "::notice::No qualifying src/**/*.ts changes — Stryker affected step skipped. Aggregate validation deferred to nightly stryker-full.yml."
+          else
+            # Stryker --mutate accepts a comma-separated glob list.
+            MUTATE=$(printf '%s\n' "$CHANGED" | paste -sd, -)
+            echo "mutate=$MUTATE" >> "$GITHUB_OUTPUT"
+            echo "Affected files for mutation:"
+            printf '%s\n' "$CHANGED" | sed 's/^/  /'
+          fi
+
+      # Restore the incremental cache populated by stryker-full.yml on main.
+      #
+      # Cache-key strategy (replaces the prior `github.sha`-based key that
+      # forced a fresh save on every commit — 2026-04-26 audit Q4 finding):
+      #
+      # - Primary key hashes the inputs that actually invalidate Stryker's
+      #   per-file mutant state: stryker.conf.mjs (mutate globs, threshold,
+      #   carve-outs), package-lock.json (test-runner deps, mutator versions),
+      #   and src/**/*.ts (the mutation surface itself).
+      # - Restore-keys fall back to base-branch cache (typically main) and
+      #   then any cache for the OS — so the first run of any feature branch
+      #   inherits main's most recent populated cache.
+      # - Removed `${{ github.sha }}` — it changed every commit and forced a
+      #   fresh save, exhausting cache quota with near-duplicate entries.
+      - name: Restore Stryker incremental cache
+        id: stryker_cache
+        if: steps.detect.outputs.present == '1' && steps.affected.outputs.empty != '1'
+        uses: actions/cache@v4
+        with:
+          path: reports/stryker-incremental.json
+          key: stryker-incremental-${{ runner.os }}-${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json', 'package-lock.json') }}-${{ hashFiles('src/**/*.ts') }}
+          restore-keys: |
+            stryker-incremental-${{ runner.os }}-${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json', 'package-lock.json') }}-
+            stryker-incremental-${{ runner.os }}-
+
+      - name: Stryker cache stats
+        if: steps.detect.outputs.present == '1' && steps.affected.outputs.empty != '1'
+        run: 'echo "Stryker incremental cache hit: ${{ steps.stryker_cache.outputs.cache-hit }}"'
+
+      # Run Stryker over only the affected files. --incremental still applies:
+      # within the affected set, files whose hashes match the cached state
+      # skip re-mutation; only files whose hash changed get re-tested.
+      #
+      # Caveat: --mutate overrides the config's `mutate` glob entirely. If
+      # the target repo has carve-outs (e.g. `!src/index.ts`) declared in
+      # stryker.conf.mjs, those are NOT honored when we pass --mutate. The
+      # workflow filter excludes test files explicitly; carved-out src files
+      # still slip through if the PR happens to touch one. In practice
+      # carve-outs are typically entry-point wiring that PRs rarely touch,
+      # and the nightly stryker-full.yml does respect the config — so the
+      # aggregate score remains correct on main even if a feature branch
+      # transiently re-mutates a carved-out file.
+      - name: Stryker (affected)
+        if: steps.detect.outputs.present == '1' && steps.affected.outputs.empty != '1'
+        run: npx stryker run --incremental --mutate "${{ steps.affected.outputs.mutate }}"

--- a/.github/workflows/stryker-affected.yml
+++ b/.github/workflows/stryker-affected.yml
@@ -99,13 +99,25 @@ jobs:
           # concurrent main commits. AMRC = Added / Modified / Renamed /
           # Copied (copied files often arrive with content modifications
           # and should be mutated alongside ordinary modifications).
-          # No `|| true` on git diff — a real error (bad SHA, missing
-          # merge-base) must fail the gate, not silently skip Stryker.
-          CHANGED=$(git diff --name-only --diff-filter=AMRC "$BASE_SHA...$HEAD_SHA" -- 'src/**/*.ts' \
-            | grep -vE '\.test\.ts$|\.spec\.ts$' || true)
+          #
+          # We split git-diff and grep into two separate command
+          # substitutions on purpose. If we piped them as
+          # `git diff ... | grep ... || true`, then under `pipefail`:
+          # a real `git diff` failure (bad SHA, missing merge-base)
+          # combined with grep's no-match exit (also non-zero) would
+          # leave the pipeline exit non-zero, which `|| true` then
+          # swallows — silently treating "git diff broke" as "no
+          # qualifying files" and skipping Stryker. CodeRabbit caught
+          # this on a second pass after the first attempt at this
+          # block — keeping the structure split prevents the silent-
+          # pass class of failure regardless of how subsequent edits
+          # rearrange the body.
+          DIFF_OUTPUT=$(git diff --name-only --diff-filter=AMRC "$BASE_SHA...$HEAD_SHA" -- 'src/**/*.ts')
           # `grep` exits 1 when no lines match — that is the legitimate
           # "no qualifying files" path, so `|| true` here is correct
-          # (different from suppressing a `git fetch`/`git diff` failure).
+          # (and only here). `git diff` already executed successfully
+          # above; no failure can hide behind this `|| true`.
+          CHANGED=$(printf '%s\n' "$DIFF_OUTPUT" | grep -vE '\.test\.ts$|\.spec\.ts$' || true)
           if [ -z "$CHANGED" ]; then
             echo "empty=1" >> "$GITHUB_OUTPUT"
             echo "::notice::No qualifying src/**/*.ts changes — Stryker affected step skipped. Aggregate validation deferred to nightly stryker-full.yml."

--- a/.github/workflows/stryker-affected.yml
+++ b/.github/workflows/stryker-affected.yml
@@ -37,8 +37,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Need full history to diff against PR base. Shallow clones break
-          # `git diff origin/<base>...HEAD` for any non-trivial PR.
+          # Need full history so the PR base SHA is reachable for the
+          # three-dot diff in "Compute affected source files" below. The
+          # default shallow clone won't include the merge-base commit on
+          # any non-trivial PR, which would make the diff fail.
           fetch-depth: 0
 
       - uses: actions/setup-node@v4
@@ -75,26 +77,31 @@ jobs:
         if: steps.detect.outputs.present == '1'
         run: |
           set -euo pipefail
-          BASE="${{ github.base_ref }}"
-          # Need the FULL history of the base branch so the three-dot diff
-          # below can locate the merge-base. `actions/checkout@v4` with
-          # `fetch-depth: 0` already fetched all history of the PR ref, but
-          # the base branch is not always populated as a tracked remote ref
-          # in the PR-event context — fetch it explicitly without a depth
-          # cap. A shallow fetch (`--depth=1`) silently breaks the three-dot
-          # diff on any PR with more than one commit since branching, which
-          # combined with `|| true` was a silent-pass failure mode (no
-          # mutation testing, gate appears green) — flagged by reviewer
-          # subagent on PR review of this very change.
-          git fetch --no-tags origin "$BASE"
-          # Three-dot diff finds files changed since merge-base of HEAD and
-          # base — i.e. files this PR changed, ignoring concurrent main
-          # commits. AMRC = Added / Modified / Renamed / Copied (Copied
-          # files often arrive with content modifications and should be
-          # mutated alongside ordinary modifications).
-          # No `|| true` — a real error (e.g. bad ref, missing merge-base)
-          # must fail the gate, not silently skip Stryker.
-          CHANGED=$(git diff --name-only --diff-filter=AMRC "origin/$BASE...HEAD" -- 'src/**/*.ts' \
+          # Use SHAs from the GitHub PR context (not `origin/<base>` ref)
+          # for two reasons:
+          #   1. Robust for fork PRs: SHAs are absolute and don't depend on
+          #      whether the fork has a current view of the base branch.
+          #   2. base.sha is the PR's branch-off point — exactly what
+          #      "files this PR changed" semantically means. Using
+          #      origin/<base> would also pick up files main moved since
+          #      branch-off, which we don't want to mutate.
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          # `actions/checkout@v4` with `fetch-depth: 0` already fetched all
+          # history of the PR's merge ref. The base SHA is normally
+          # reachable through that, but fetch it explicitly as cheap
+          # insurance for unusual fork/repo states. `|| true` because if
+          # the SHA is already present, the fetch is a no-op that may
+          # exit non-zero on some setups.
+          git fetch --no-tags origin "$BASE_SHA" || true
+          # Three-dot diff (`A...B`) finds the merge-base of A and B then
+          # diffs against B — i.e. files this PR changed, ignoring
+          # concurrent main commits. AMRC = Added / Modified / Renamed /
+          # Copied (copied files often arrive with content modifications
+          # and should be mutated alongside ordinary modifications).
+          # No `|| true` on git diff — a real error (bad SHA, missing
+          # merge-base) must fail the gate, not silently skip Stryker.
+          CHANGED=$(git diff --name-only --diff-filter=AMRC "$BASE_SHA...$HEAD_SHA" -- 'src/**/*.ts' \
             | grep -vE '\.test\.ts$|\.spec\.ts$' || true)
           # `grep` exits 1 when no lines match — that is the legitimate
           # "no qualifying files" path, so `|| true` here is correct
@@ -124,10 +131,18 @@ jobs:
       #   inherits main's most recent populated cache.
       # - Removed `${{ github.sha }}` — it changed every commit and forced a
       #   fresh save, exhausting cache quota with near-duplicate entries.
+      # Restore-only (`actions/cache/restore@v4`, not `actions/cache@v4`):
+      # this workflow MUST NOT save the cache. Save is the dedicated job of
+      # stryker-full.yml — feature branches restoring from main's most
+      # recent populated cache is the design. If we used the read+write
+      # variant here, every PR with src changes would save a near-duplicate
+      # cache entry (a different `hashFiles(src/**/*.ts)` per commit),
+      # exhausting the 10 GB GHA cache quota with churn. Reviewer
+      # subagent / Gemini flagged this on initial review of this change.
       - name: Restore Stryker incremental cache
         id: stryker_cache
         if: steps.detect.outputs.present == '1' && steps.affected.outputs.empty != '1'
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: reports/stryker-incremental.json
           key: stryker-incremental-${{ runner.os }}-${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json', 'package-lock.json') }}-${{ hashFiles('src/**/*.ts') }}

--- a/.github/workflows/stryker-full.yml
+++ b/.github/workflows/stryker-full.yml
@@ -44,8 +44,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        # No fetch-depth override — full sweep does not diff anything,
+        # so the default shallow clone is sufficient and faster.
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/stryker-full.yml
+++ b/.github/workflows/stryker-full.yml
@@ -71,9 +71,17 @@ jobs:
       # it. Cache key matches stryker-affected.yml so restores hit cleanly.
       - name: Stryker (full sweep)
         if: steps.detect.outputs.present == '1'
+        # `rm -f` first so the run starts from a clean slate (the whole
+        # point of stryker-full.yml — fresh score, no cache reuse). Pass
+        # `--incremental` so Stryker still WRITES the new cache file at
+        # the end. Without --incremental the run does a fresh sweep but
+        # produces no incremental.json, the actions/cache/save step
+        # below saves a non-existent path, and every stryker-affected.yml
+        # run on PRs is then a cold sweep — silently defeating the <2 min
+        # steady-state target. Greptile P2 caught this on initial review.
         run: |
           rm -f reports/stryker-incremental.json
-          npx stryker run
+          npx stryker run --incremental
 
       - name: Save Stryker incremental cache
         if: steps.detect.outputs.present == '1' && success() && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/stryker-full.yml
+++ b/.github/workflows/stryker-full.yml
@@ -1,0 +1,83 @@
+name: Stryker (full)
+
+# Full-sweep Stryker: runs nightly and on every push to main.
+#
+# Two roles:
+#   1. Catch incremental-cache staleness. Stryker --incremental invalidates
+#      only on source-file changes, not test-file changes — meaning a chain
+#      of test-only PRs can drift the reported aggregate from reality. The
+#      2026-04-26 audit observed this: incremental was reporting 79.59 %
+#      while a fresh full run revealed the true 81.34 %.
+#   2. Populate the incremental cache that stryker-affected.yml restores
+#      from. Without a populated main-branch cache, every PR's first run is
+#      a cold sweep (~16-20 min) — the partition only delivers <2 min
+#      feature-branch turnaround once main has a fresh cache to hand off.
+#
+# Schedule: 05:00 UTC daily. The exact hour matters less than picking a
+# time that doesn't collide with peak human PR review hours (so cache
+# write doesn't race feature-branch reads).
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  push:
+    branches: [main]
+  workflow_dispatch:
+    # Manual trigger so a human can pre-warm the cache after a config
+    # change without waiting for the next nightly cron — useful right
+    # after the partition lands or after a Stryker config bump.
+
+# Don't cancel in-progress full runs on new pushes — full sweeps are
+# expensive to redo and the cache they produce is valuable. Let them
+# complete; the next push picks up its own run.
+concurrency:
+  group: stryker-full-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  stryker-full:
+    name: Stryker (full)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Detect Stryker config
+        id: detect
+        run: |
+          if [ -f stryker.conf.mjs ] || [ -f stryker.conf.js ] || [ -f stryker.config.json ]; then
+            echo "present=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=0" >> "$GITHUB_OUTPUT"
+            echo "No Stryker config — skipping full mutation testing."
+          fi
+
+      # Full sweep starts from a clean cache by design — that is the whole
+      # point of the workflow, to catch incremental-cache staleness. Save
+      # the resulting cache afterward so feature branches can restore from
+      # it. Cache key matches stryker-affected.yml so restores hit cleanly.
+      - name: Stryker (full sweep)
+        if: steps.detect.outputs.present == '1'
+        run: |
+          rm -f reports/stryker-incremental.json
+          npx stryker run
+
+      - name: Save Stryker incremental cache
+        if: steps.detect.outputs.present == '1' && success() && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        uses: actions/cache/save@v4
+        with:
+          path: reports/stryker-incremental.json
+          key: stryker-incremental-${{ runner.os }}-${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json', 'package-lock.json') }}-${{ hashFiles('src/**/*.ts') }}

--- a/.github/workflows/stryker-full.yml
+++ b/.github/workflows/stryker-full.yml
@@ -83,6 +83,17 @@ jobs:
           rm -f reports/stryker-incremental.json
           npx stryker run --incremental
 
+      # `actions/cache/save@v4` fails when a cache with the exact key
+      # already exists (cache keys are immutable on GHA — verified via
+      # web query during PR review). For our setup that failure is
+      # benign: the key is content-addressed (config + lockfile + src
+      # hashes), so an existing cache under the same key has the same
+      # content semantics anyway. The save warning is logged in the
+      # workflow output but does NOT fail the job — the existing cache
+      # remains correctly available for stryker-affected.yml restores.
+      # This commonly happens when stryker-full.yml runs twice without
+      # any src/conf/lockfile change (e.g., the nightly cron between
+      # two doc-only days, or `workflow_dispatch` shortly after a push).
       - name: Save Stryker incremental cache
         if: steps.detect.outputs.present == '1' && success() && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         uses: actions/cache/save@v4

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,7 @@
 .adder-pipeline/
 .github/workflows/pipeline.yml
+.github/workflows/stryker-affected.yml
+.github/workflows/stryker-full.yml
 knip.json
 
 # Tool-generated (managed by external tools, not ours to format)


### PR DESCRIPTION
## Summary

Mirror of [adder-pipeline-tools#15](https://github.com/adder-factory/adder-pipeline-tools/pull/15) (templates side). Implements 2026-04-26 audit Q4 — partitioning Stryker out of `pipeline.yml` so feature-branch CI drops from ~17 min (~93 % of total wall-clock) to <2 min in steady state.

## Changes

| File | Change |
|---|---|
| `.github/workflows/pipeline.yml` | Stryker steps removed (cache restore, cache stats, run). Comment block points at the two new workflows. |
| `.github/workflows/stryker-affected.yml` | **NEW** — copied verbatim from upstream template. PR-only, three-dot diff against base, `--mutate <list>`, target <2 min steady-state. |
| `.github/workflows/stryker-full.yml` | **NEW** — copied verbatim from upstream template. Nightly cron + push-to-main + workflow_dispatch. Full sweep, saves cache. |
| `.prettierignore` | Two new workflow files added to the ignore list. |

## Cache-key strategy

```yaml
key: stryker-incremental-${{ runner.os }}-${{ hashFiles('stryker.conf.mjs', 'stryker.conf.js', 'stryker.config.json', 'package-lock.json') }}-${{ hashFiles('src/**/*.ts') }}
```

`stryker-full.yml` saves it; `stryker-affected.yml` restores from it. Removed `github.sha` entirely (the prior key changed every commit, exhausting cache quota with near-duplicate entries).

## Carve-out caveat

This repo has **1/5** carve-out: `!src/index.ts` (entry-point wiring). The affected workflow's `--mutate` overrides config glob, so a PR that touches `src/index.ts` will be mutated by `stryker-affected.yml`. The nightly full run respects the config and corrects aggregate drift on `main`. In practice `index.ts` is rarely touched.

## Pre-existing Sonar finding (out of scope)

`src/tools/shared.ts:431` (typescript:S3776 cognitive complexity, CRITICAL) — pre-dates this PR, not touched by this diff. CI Sonar skips cleanly (no `SONAR_TOKEN` in GHA secrets). Cleanup is a separate follow-up PR per Hard Rule 8.

## Pre-PR semantic review

Reviewer subagent: `APPROVE` with one info-level cosmetic finding (workflow comment references `~/projects/code-review-pipeline/pipeline-state.md` — a local path) — deferred per triage rule (single-reviewer info-severity; the reference matches an established convention used in upstream CLAUDE.md and templates/claude-md-block.md).

## Bootstrap & branch-protection follow-ups

- **Bootstrap**: first run of `stryker-affected.yml` after merge will see a cold cache and may take up to 30 min (timeout). After one `stryker-full.yml` run on `main` has populated the cache, steady state is <2 min. May need an admin-merge if the bootstrap run blocks.
- **Branch protection**: add `Stryker (affected)` as a required-status context on main. Existing `Pipeline gate` context still passes (Stryker no longer there). Both upstream PR #15 and this PR must merge before the protection update.

## Test plan

- [x] `npm run pre-pr` (with Sonar skipped) — green except the pre-existing Sonar finding.
- [x] Reviewer subagent — APPROVE.
- [ ] Pipeline gate (post-Stryker-removal) green on CI — should be ~30-60 s.
- [ ] Stryker (affected) runs cleanly (or admin-merge if bootstrap exceeds budget).
- [ ] Stryker (full) on push-to-main populates the cache.
- [ ] CodeRabbit clean (or addressed).
- [ ] Gemini / Greptile / CodeQL advisory threads resolved or auto-dismissed.

Generated with Claude Code
