### PR TITLE
feat(claude-md): mandate codegraph_impact on exported-symbol refactors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,7 @@ window to decide whether to keep or remove the wiring.
 - **When investigating bugs across multiple files**, use
   `mcp__codegraph__codegraph_explore` instead of `Grep + Read`. One
   graph query replaces 20+ file reads.
-- **When self-reviewing a PR with src changes**, run
+- **When self-reviewing a PR with source changes**, run
   `mcp__codegraph__codegraph_impact` on each modified exported
   symbol. Document the result in the PR body so reviewers see the
   blast radius CC checked.
@@ -335,7 +335,7 @@ Usage is measured weekly by
 `adder-pipeline-tools/scripts/codegraph-usage-counter.sh`. See
 `~/projects/code-review-pipeline/pipeline-state.md` for the keep/cut
 decision criteria — the wiring is on probation until 2026-05-03. The
-mandates above are in force *during* probation so the measurement
+mandates above are in force _during_ probation so the measurement
 reflects the policy actually being followed; if the decision on
 2026-05-03 is "cut," these mandates are removed alongside the MCP
 wiring.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,14 +317,15 @@ the wiring being in place — the tools were treated as optional. This
 section makes specific uses **mandatory** and creates a measurement
 window to decide whether to keep or remove the wiring.
 
-- **Before refactoring any exported symbol** (function, class, type,
-  interface), call `mcp__codegraph__codegraph_impact` with the symbol
-  name to surface affected callers. Do NOT skip this for
-  "small-looking" changes — exported-symbol blast radius is the exact
-  failure mode CodeGraph exists to prevent.
-- **When investigating bugs across multiple files**, prefer
-  `mcp__codegraph__codegraph_explore` over `Grep + Read`. One graph
-  query replaces 20+ file reads.
+- **Before refactoring any exported symbol** (e.g., function, class,
+  type, interface, enum, exported const), call
+  `mcp__codegraph__codegraph_impact` with the symbol name to surface
+  affected callers. Do NOT skip this for "small-looking" changes —
+  exported-symbol blast radius is the exact failure mode CodeGraph
+  exists to prevent.
+- **When investigating bugs across multiple files**, use
+  `mcp__codegraph__codegraph_explore` instead of `Grep + Read`. One
+  graph query replaces 20+ file reads.
 - **When self-reviewing a PR with src changes**, run
   `mcp__codegraph__codegraph_impact` on each modified exported
   symbol. Document the result in the PR body so reviewers see the
@@ -333,7 +334,11 @@ window to decide whether to keep or remove the wiring.
 Usage is measured weekly by
 `adder-pipeline-tools/scripts/codegraph-usage-counter.sh`. See
 `~/projects/code-review-pipeline/pipeline-state.md` for the keep/cut
-decision criteria — the wiring is on probation until 2026-05-03.
+decision criteria — the wiring is on probation until 2026-05-03. The
+mandates above are in force *during* probation so the measurement
+reflects the policy actually being followed; if the decision on
+2026-05-03 is "cut," these mandates are removed alongside the MCP
+wiring.
 
 ## Spec Drift Prevention
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,33 @@ next. Format per stage:
 Do NOT batch verification at end of all stages. A failed early stage that
 propagates is harder to diagnose than one caught immediately.
 
+## CodeGraph Usage
+
+CodeGraph indexes this repo via `.codegraph/` and exposes
+`mcp__codegraph__*` tools to Claude Code. The 2026-04-26 audit found
+zero actual MCP invocations across 7,499 lines of transcripts despite
+the wiring being in place — the tools were treated as optional. This
+section makes specific uses **mandatory** and creates a measurement
+window to decide whether to keep or remove the wiring.
+
+- **Before refactoring any exported symbol** (function, class, type,
+  interface), call `mcp__codegraph__codegraph_impact` with the symbol
+  name to surface affected callers. Do NOT skip this for
+  "small-looking" changes — exported-symbol blast radius is the exact
+  failure mode CodeGraph exists to prevent.
+- **When investigating bugs across multiple files**, prefer
+  `mcp__codegraph__codegraph_explore` over `Grep + Read`. One graph
+  query replaces 20+ file reads.
+- **When self-reviewing a PR with src changes**, run
+  `mcp__codegraph__codegraph_impact` on each modified exported
+  symbol. Document the result in the PR body so reviewers see the
+  blast radius CC checked.
+
+Usage is measured weekly by
+`adder-pipeline-tools/scripts/codegraph-usage-counter.sh`. See
+`~/projects/code-review-pipeline/pipeline-state.md` for the keep/cut
+decision criteria — the wiring is on probation until 2026-05-03.
+
 ## Spec Drift Prevention
 
 Any addition or removal of a gate, reviewer, or pipeline step must be


### PR DESCRIPTION
## Summary

Mirror of [adder-factory/adder-pipeline-tools#16](https://github.com/adder-factory/adder-pipeline-tools/pull/16) (templates side). Implements 2026-04-26 audit Q8 for this consumer repo: 0 actual `mcp__codegraph__*` `tool_use` invocations across 7,499 lines of session transcripts despite CodeGraph being indexed and the MCP server wired.

## Changes

`CLAUDE.md`: new top-level `## CodeGraph Usage` section before `## Spec Drift Prevention`. Three mandatory triggers:

1. **Before refactoring any exported symbol** — call `mcp__codegraph__codegraph_impact` to surface affected callers.
2. **Multi-file bug investigation** — prefer `mcp__codegraph__codegraph_explore` over `Grep + Read` (one query replaces 20+ file reads).
3. **Self-reviewing a PR with src changes** — run `mcp__codegraph__codegraph_impact` per modified exported symbol and document the result in the PR body.

Cross-references the probation period (2026-04-26 → 2026-05-03) and keep/cut decision criteria in `~/projects/code-review-pipeline/pipeline-state.md`.

## Known mild inconsistency, deferred

The legacy v1 ADDER-PIPELINE block at the bottom of CLAUDE.md (installed by an earlier `install.sh` run) still has the soft "prefer `mcp__codegraph_*`" wording that now contradicts the new mandatory section above. The cleanup path is the v1 → v2 migration triggered by re-running `install.sh` after upstream PR #16 merges — that overwrites the entire block with the v2 version carrying the same mandatory wording. Out of scope for this PR per Hard Rule 8.

## Pre-existing Sonar finding (out of scope)

`src/tools/shared.ts:431` (typescript:S3776 cognitive complexity, CRITICAL) — not touched by this docs-only diff. CI Sonar skips cleanly (no `SONAR_TOKEN` in GHA secrets).

## Pre-PR semantic review

Reviewer subagent: `APPROVE`. One info-level finding (the v1-block contradiction) accepted as deferred per scope.

## Test plan

- [x] `npm run pre-pr` (Sonar skipped) — green except pre-existing Sonar finding.
- [x] Reviewer subagent — APPROVE.
- [ ] Pipeline gate green on CI.
- [ ] Stryker (affected) — should skip cleanly (0 src changes).
- [ ] CodeRabbit clean (or addressed).
- [ ] Gemini / Greptile / CodeQL advisory threads resolved or auto-dismissed.

Generated with Claude Code
