### PR TITLE
feat(claude-md): codify reviewer-contradiction triage rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,12 @@ policy is now in effect.
 - **Tests-only for kill-rate work.** Hard Rule 8 applies: PRs that
   exist primarily to raise the mutation score add tests, not
   production code, unless a minimal change is genuinely required to
-  make code testable (justify in PR body).
+  make code testable (justify in PR body). See **Reviewer Triage
+  Rules** below for codified dismissal patterns (the auto-dismiss
+  list is the operational enforcement of Hard Rule 8 during
+  reviewer cycles — e.g. empty-string-as-undefined suggestions on
+  mutation-kill tests are auto-dismiss because they would silently
+  drop the kill the test was designed to catch).
 - **Per-file carve-outs allowed but justified.** Some files truly
   cannot hit 80 (entry-point wiring, content-heavy modules whose
   mutants are static-initialized at module load and Vitest worker
@@ -339,6 +344,61 @@ mandates above are in force _during_ probation so the measurement
 reflects the policy actually being followed; if the decision on
 2026-05-03 is "cut," these mandates are removed alongside the MCP
 wiring.
+
+## Reviewer Triage Rules
+
+When reviewers contradict each other or suggest defensive changes that
+conflict with mutation-test intent, apply these rules. Each is grounded
+in a real example logged in
+`~/projects/code-review-pipeline/run-log.md`; the audit (2026-04-26
+Q3) lifted them from tribal knowledge into codified policy so triage
+doesn't have to be rediscovered every PR.
+
+### Auto-dismiss (post a rationale comment, then `resolveReviewThread`)
+
+1. **Empty-string-as-undefined on mutation-kill tests** — when a
+   reviewer suggests treating empty string the same as undefined
+   inside a test designed to kill a string-literal mutant. The
+   test's exact-match behavior IS the kill mechanism; the
+   "defensive" merge would silently drop the kill.
+2. **Transient-error retry suggestions in CI gate scripts** — when a
+   reviewer suggests adding `curl`/network retry logic to a gate
+   script. Fail-loud-then-rerun is the correct retry layer; gate
+   scripts should be deterministic single-shot. Wrapping in retry
+   masks the failure mode the gate is supposed to surface.
+3. **API-style preference vs. existing pattern consistency** — when
+   a reviewer suggests switching to a "more idiomatic" API (e.g.
+   Zod `.unwrap()` over the in-place pattern, or `.then()` over
+   `async/await` in code that already uses one) where a different
+   pattern is used consistently across the codebase. Consistency
+   wins; one-off "improvements" become inconsistency tax for every
+   future reader.
+4. **Documented decisions self-defense** — when a reviewer (e.g. a
+   tool that was demoted in `pipeline-state.md`) suggests reverting
+   its own demotion. Doc-aligned action wins; cite the
+   `pipeline-state.md` entry in the dismissal note.
+
+### Auto-apply (high confidence)
+
+5. **Convergent ≥ 2 reviewers** — when 2 or more reviewers
+   independently flag the same issue, treat it as auto-apply unless
+   it conflicts with the auto-dismiss rules above. Convergent
+   findings have empirically been correct in every Phase-4 PR
+   logged in `run-log.md`. Convergence = strong signal.
+
+### Always escalate
+
+6. **Hallucinated diff content** — when a reviewer claims a file is
+   missing or present in a way that contradicts the actual diff
+   (Phase-4 example: Gemini HIGH on PR #17 of this repo claimed a
+   workflow file was absent when it was present in the diff).
+   Escalate to the human; this indicates a reviewer FP-rate concern,
+   not a PR concern, and the human needs to know if the reviewer's
+   signal quality is degrading.
+
+For the substantive-disagreement case (two reviewers propose
+incompatible fixes, both defensible), stop and ask the human — do
+not oscillate between the two reviewers' preferred approaches.
 
 ## Spec Drift Prevention
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,9 @@ policy is now in effect.
   list is the operational enforcement of Hard Rule 8 during
   reviewer cycles — e.g. empty-string-as-undefined suggestions on
   mutation-kill tests are auto-dismiss because they would silently
-  drop the kill the test was designed to catch).
+  drop the kill that the test was designed to catch). See
+  [Reviewer Triage Rules](#reviewer-triage-rules) below for the
+  full codified list.
 - **Per-file carve-outs allowed but justified.** Some files truly
   cannot hit 80 (entry-point wiring, content-heavy modules whose
   mutants are static-initialized at module load and Vitest worker
@@ -382,9 +384,12 @@ doesn't have to be rediscovered every PR.
 
 5. **Convergent ≥ 2 reviewers** — when 2 or more reviewers
    independently flag the same issue, treat it as auto-apply unless
-   it conflicts with the auto-dismiss rules above. Convergent
-   findings have empirically been correct in every Phase-4 PR
-   logged in `run-log.md`. Convergence = strong signal.
+   either (a) it conflicts with an auto-dismiss rule above, or (b)
+   the suggested change would violate an explicit rule defined
+   elsewhere in this CLAUDE.md (e.g. TypeScript Rules, Code Style,
+   security non-negotiables). Convergent findings have empirically
+   been correct in every Phase-4 PR logged in `run-log.md`, but
+   reviewer agreement does not override project standards.
 
 ### Always escalate
 


### PR DESCRIPTION
## Summary

Mirror of [adder-factory/adder-pipeline-tools#17](https://github.com/adder-factory/adder-pipeline-tools/pull/17). Implements 2026-04-26 audit Q3 for this consumer repo: lifts reviewer-contradiction triage rules from tribal knowledge in `~/projects/code-review-pipeline/run-log.md` into codified policy.

## Changes

`CLAUDE.md` (1 file, +60/-1):

- New top-level `## Reviewer Triage Rules` section between `## CodeGraph Usage` and `## Spec Drift Prevention`. Six named rules across three categories (auto-dismiss × 4, auto-apply × 1, escalate × 1). Identical wording to upstream, with rule 6 adjusted to "PR #17 of this repo" since the hallucinated-diff example IS in this repo.
- Pointer added to the existing `Hard Rule 8 applies` bullet at line 171 (in the Mutation Testing — Ratchet Policy section): cross-references the new section as the operational enforcement of Hard Rule 8 during reviewer cycles.

## Layering with the v1 ADDER-PIPELINE block

The legacy v1 block at the bottom of this CLAUDE.md has its own inline triage rules in step 4 of the PR-workflow. Those are the short summary and remain as-is; the new section adds named-cases granularity. The v1 → v2 `install.sh` migration will later replace the v1 block with the upstream v2 (which carries the same new section), so the duplication is transient.

## Pre-existing Sonar finding (out of scope)

`src/tools/shared.ts:431` (typescript:S3776 cognitive complexity, CRITICAL) — pre-dates this PR, not touched. CI Sonar skips cleanly (no `SONAR_TOKEN` in GHA secrets).

## Pre-PR semantic review

Reviewer subagent: `APPROVE` clean (zero findings).

## Test plan

- [x] `npm run pre-pr` (Sonar skipped) — green except pre-existing Sonar finding.
- [x] Reviewer subagent — APPROVE.
- [ ] Pipeline gate green on CI.
- [ ] Stryker (affected) — should skip cleanly (0 src changes).
- [ ] CodeRabbit clean (or addressed).
- [ ] Gemini / Greptile / CodeQL advisory threads resolved or auto-dismissed.

Generated with Claude Code
