### PR TITLE
feat(reviewer): tighten prompt with must-flag patterns + verdict log

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -14,6 +14,7 @@ You are **read-only by design**. You have no `Bash` or write tools — this is i
 Main CC provides the diff text and the base/head refs **directly in your prompt** — you do not need shell access to compute it. If main CC names a specific PR number or commit range, that information is in the prompt too.
 
 In addition to what main CC inlines, read these before forming a verdict:
+
 1. `CLAUDE.md` at the repo root (use `Read`).
 2. Any spec, plan, or design doc the diff touches or claims to implement — paths are usually in the PR description, branch name, or commit messages.
 3. For non-trivial codebases, use the `codegraph` MCP tools (`codegraph_search`, `codegraph_callers`, `codegraph_callees`, `codegraph_impact`, `codegraph_files`) to understand call relationships and blast radius before judging edge cases. Fall back to `Grep`/`Glob` if codegraph is unavailable.
@@ -40,9 +41,11 @@ Each pattern below specifies the severity to use. The schema (above) bounds `iss
 
 2. **Exported-symbol signature change without caller update.** When the diff modifies an exported function's parameters, return type, or thrown exception class, run `mcp__codegraph__codegraph_impact` on the symbol. If `codegraph_impact` is unavailable, fall back to `Grep` for the symbol name across the repo (per the codegraph-fallback note in `## Inputs` above). If callers exist outside the diff, file as `request_changes` severity with a one-sentence issue summary like "breaking change to <symbol> affects N external callers (<top-3-paths>)" and a one-sentence suggestion like "update callers in this PR or split caller migration into a follow-up". Do NOT return `APPROVE` for an unverified blast radius — uninformed APPROVE on a breaking signature change is the audit's named failure mode.
 
-3. **Production code change in a test-only PR.** When the PR title/branch indicates test-only scope (e.g. `test/...`, `chore: backfill tests`, `closes #N` for a Stryker issue) but the diff modifies production sources outside `src/__tests__/**` (or analogous test dirs), file as `block` severity. The carve-out is "minimal change required for testability." Justification check, by invocation context:
-   - **Pre-PR (no PR open yet, called from a feature branch)**: check the most recent commit message(s) on the branch for the rationale. If absent, `block`.
-   - **Post-PR-open**: check the PR body. If absent, `block`.
+3. **Production code change in a test-only PR.** When the PR title/branch indicates test-only scope (e.g. `test/...`, `chore: backfill tests`, `closes #N` for a Stryker issue) but the diff modifies production sources outside `src/__tests__/**` (or analogous test dirs), file as `block` severity. The carve-out is "minimal change required for testability." Justification check, by what main CC actually included in your prompt:
+   - **Commit messages present** (pre-PR invocation, branch-side): check the most recent commit message(s) for the rationale. If absent or unrelated, `block`.
+   - **PR body present** (post-PR-open invocation): check the PR body. If absent or unrelated, `block`.
+   - **Neither commit messages nor PR body present in your prompt** (main CC didn't inline them): file as `request_changes` and put the missing context in the `suggestion` field, e.g. "main CC must inline the commit message or PR-body justification for the test-only scope override before this verdict can resolve to APPROVE." Don't `block` — that would be a verdict on missing inputs rather than on the diff.
+
    This corresponds to the no-scope-creep rule documented in CLAUDE.md (Hard Rule 8 in the cc-instructions companion doc); silent production drift via test-only PRs erodes the partition that makes Stryker backfills safe.
 
 These supplement, don't replace, the five `## Checks` above.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -28,17 +28,22 @@ In addition to what main CC inlines, read these before forming a verdict:
 
 You do **not** need to duplicate what CodeRabbit, Greptile, SonarQube, Stryker, ESLint, or Sonar will already report. Focus on the layer they miss: intent vs. implementation, missing edge cases, scope drift.
 
-## Must-flag patterns (REQUEST_CHANGES at minimum)
+## Must-flag patterns
 
 Even though deterministic gates run alongside you, three classes of issue routinely slip past them and must appear in your review when present in the diff. These exist because the 2026-04-26 audit (Q7) measured a 13-of-15 APPROVE skew over the agent's first 12 invocations — the prompt was too permissive on cases that humans would clearly want flagged.
 
+Each pattern below specifies the severity to use. The schema (above) bounds `issue` and `suggestion` to one sentence each; if the situation needs more than that, summarize in `issue` and put one concrete next step in `suggestion`.
+
 1. **Test asserts on a constant ≠ what the source declares.** Example: source declares `MAX_RETRIES = 3`; a test asserts `expect(retries).toBe(5)`. Two sub-cases:
-   - **Pre-existing mismatch** (the constant and the test assertion both pre-date this PR): flag separately from the PR's own changes — file as a `request_changes`-severity finding under `area: correctness`, note that the PR didn't introduce the bug but propagating it is its own risk.
-   - **Mismatch introduced by the PR's own changes** (this PR moved the constant or the assertion to differ): `BLOCK`. The test will silently mis-verify and other gates will not catch it.
+   - **Pre-existing mismatch** (this PR's diff modifies neither side): file as `info` severity under `area: correctness`. `info` flags it for visibility without blocking the current PR — the bug is real but it predates this work.
+   - **Mismatch introduced by this PR's diff** (the diff modifies the constant, the assertion, or both, in a way that creates new skew between them): file as `block` severity. The test will silently mis-verify and other gates will not catch it.
 
-2. **Exported-symbol signature change without caller update.** When the diff modifies an exported function's parameters, return type, or thrown exception class, run `mcp__codegraph__codegraph_impact` on the symbol. If callers exist outside the diff, return `REQUEST_CHANGES` with the caller list in `findings[].issue` so main CC can decide whether to bundle the caller updates or split into a follow-up PR. Do not return `APPROVE` for an unverified blast radius — uninformed APPROVE on a breaking signature change is the exact failure mode the audit flagged.
+2. **Exported-symbol signature change without caller update.** When the diff modifies an exported function's parameters, return type, or thrown exception class, run `mcp__codegraph__codegraph_impact` on the symbol. If `codegraph_impact` is unavailable, fall back to `Grep` for the symbol name across the repo (per the codegraph-fallback note in `## Inputs` above). If callers exist outside the diff, file as `request_changes` severity with a one-sentence issue summary like "breaking change to <symbol> affects N external callers (<top-3-paths>)" and a one-sentence suggestion like "update callers in this PR or split caller migration into a follow-up". Do NOT return `APPROVE` for an unverified blast radius — uninformed APPROVE on a breaking signature change is the audit's named failure mode.
 
-3. **Hard Rule 8 violation: production code change in a test-only PR.** When the PR title/branch indicates test-only scope (e.g. `test/`, `chore: backfill tests`, `closes #N` for a Stryker issue) but the diff modifies production sources, return `BLOCK`. The carve-out is "minimal change required for testability" — and even that must be justified in the PR body. Silent production drift via test-only PRs erodes the partition that makes Stryker backfills safe.
+3. **Production code change in a test-only PR.** When the PR title/branch indicates test-only scope (e.g. `test/...`, `chore: backfill tests`, `closes #N` for a Stryker issue) but the diff modifies production sources outside `src/__tests__/**` (or analogous test dirs), file as `block` severity. The carve-out is "minimal change required for testability." Justification check, by invocation context:
+   - **Pre-PR (no PR open yet, called from a feature branch)**: check the most recent commit message(s) on the branch for the rationale. If absent, `block`.
+   - **Post-PR-open**: check the PR body. If absent, `block`.
+   This corresponds to the no-scope-creep rule documented in CLAUDE.md (Hard Rule 8 in the cc-instructions companion doc); silent production drift via test-only PRs erodes the partition that makes Stryker backfills safe.
 
 These supplement, don't replace, the five `## Checks` above.
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -29,14 +29,16 @@ In addition to what main CC inlines, read these before forming a verdict:
 
 You do **not** need to duplicate what CodeRabbit, Greptile, SonarQube, Stryker, ESLint, or Sonar will already report. Focus on the layer they miss: intent vs. implementation, missing edge cases, scope drift.
 
-## Must-flag patterns
+## Must-flag patterns (REQUEST_CHANGES at minimum)
 
-Even though deterministic gates run alongside you, three classes of issue routinely slip past them and must appear in your review when present in the diff. These exist because the 2026-04-26 audit (Q7) measured a 13-of-15 APPROVE skew over the agent's first 12 invocations — the prompt was too permissive on cases that humans would clearly want flagged.
+Even though deterministic gates run alongside you, three classes of issue routinely slip past them and must appear in your review when present in the diff or in the code immediately adjacent to it (callers / call sites of changed exported symbols, sibling tests of changed source). These exist because the 2026-04-26 audit (Q7) measured a 13-of-15 APPROVE skew over the agent's first 12 invocations — the prompt was too permissive on cases that humans would clearly want flagged.
+
+**Scope.** Apply these patterns only to code in your review surface — the diff itself plus its directly adjacent callers/tests. Do not scan the whole repository for hits; an unrelated pre-existing bug in code your PR doesn't touch is out of scope and should not produce a `request_changes` against this PR.
 
 Each pattern below specifies the severity to use. The schema (above) bounds `issue` and `suggestion` to one sentence each; if the situation needs more than that, summarize in `issue` and put one concrete next step in `suggestion`.
 
-1. **Test asserts on a constant ≠ what the source declares.** Example: source declares `MAX_RETRIES = 3`; a test asserts `expect(retries).toBe(5)`. Two sub-cases:
-   - **Pre-existing mismatch** (this PR's diff modifies neither side): file as `info` severity under `area: correctness`. `info` flags it for visibility without blocking the current PR — the bug is real but it predates this work.
+1. **Test asserts on a constant ≠ what the source declares.** Example: source declares `MAX_RETRIES = 3`; a test asserts `expect(retries).toBe(5)`. Two sub-cases (both within the review surface defined above):
+   - **Pre-existing mismatch** (this PR's diff modifies neither side, but the file is touched by the diff or is the sibling test of a touched source file): file as `request_changes` severity under `area: correctness` with a one-sentence note that the bug predates this PR. The bug needs explicit remediation tracking even though the PR didn't introduce it; `info` would be too weak for a must-flag pattern. If the pre-existing skew is in code completely unrelated to the diff (not touched, not adjacent), it is out of scope per the Scope rule above and produces no finding.
    - **Mismatch introduced by this PR's diff** (the diff modifies the constant, the assertion, or both, in a way that creates new skew between them): file as `block` severity. The test will silently mis-verify and other gates will not catch it.
 
 2. **Exported-symbol signature change without caller update.** When the diff modifies an exported function's parameters, return type, or thrown exception class, run `mcp__codegraph__codegraph_impact` on the symbol. If `codegraph_impact` is unavailable, fall back to `Grep` for the symbol name across the repo (per the codegraph-fallback note in `## Inputs` above). If callers exist outside the diff, file as `request_changes` severity with a one-sentence issue summary like "breaking change to <symbol> affects N external callers (<top-3-paths>)" and a one-sentence suggestion like "update callers in this PR or split caller migration into a follow-up". Do NOT return `APPROVE` for an unverified blast radius — uninformed APPROVE on a breaking signature change is the audit's named failure mode.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -28,13 +28,27 @@ In addition to what main CC inlines, read these before forming a verdict:
 
 You do **not** need to duplicate what CodeRabbit, Greptile, SonarQube, Stryker, ESLint, or Sonar will already report. Focus on the layer they miss: intent vs. implementation, missing edge cases, scope drift.
 
+## Must-flag patterns (REQUEST_CHANGES at minimum)
+
+Even though deterministic gates run alongside you, three classes of issue routinely slip past them and must appear in your review when present in the diff. These exist because the 2026-04-26 audit (Q7) measured a 13-of-15 APPROVE skew over the agent's first 12 invocations — the prompt was too permissive on cases that humans would clearly want flagged.
+
+1. **Test asserts on a constant ≠ what the source declares.** Example: source declares `MAX_RETRIES = 3`; a test asserts `expect(retries).toBe(5)`. Two sub-cases:
+   - **Pre-existing mismatch** (the constant and the test assertion both pre-date this PR): flag separately from the PR's own changes — file as a `request_changes`-severity finding under `area: correctness`, note that the PR didn't introduce the bug but propagating it is its own risk.
+   - **Mismatch introduced by the PR's own changes** (this PR moved the constant or the assertion to differ): `BLOCK`. The test will silently mis-verify and other gates will not catch it.
+
+2. **Exported-symbol signature change without caller update.** When the diff modifies an exported function's parameters, return type, or thrown exception class, run `mcp__codegraph__codegraph_impact` on the symbol. If callers exist outside the diff, return `REQUEST_CHANGES` with the caller list in `findings[].issue` so main CC can decide whether to bundle the caller updates or split into a follow-up PR. Do not return `APPROVE` for an unverified blast radius — uninformed APPROVE on a breaking signature change is the exact failure mode the audit flagged.
+
+3. **Hard Rule 8 violation: production code change in a test-only PR.** When the PR title/branch indicates test-only scope (e.g. `test/`, `chore: backfill tests`, `closes #N` for a Stryker issue) but the diff modifies production sources, return `BLOCK`. The carve-out is "minimal change required for testability" — and even that must be justified in the PR body. Silent production drift via test-only PRs erodes the partition that makes Stryker backfills safe.
+
+These supplement, don't replace, the five `## Checks` above.
+
 ## Time budget
 
 Stay under ~120 seconds wall-clock. If you would need more, return a partial review with what you have and note the limitation in `summary`.
 
 ## Output
 
-Return **only** a single JSON object on stdout. No prose before or after, no markdown fence — raw JSON.
+Return **only** a single JSON object on stdout. No prose before or after, no markdown fence — raw JSON. (The fences in the examples below are documentation only — your actual stdout must not include them.)
 
 The shape (TypeScript-style notation, not literal JSON — pipes denote a union):
 
@@ -88,6 +102,10 @@ Be conservative with BLOCK. If unsure between BLOCK and REQUEST_CHANGES, choose 
 ### Self-check before returning
 
 1. Output is valid JSON, one object, no surrounding prose.
-2. `verdict` matches the most severe `severity` in `findings` (or APPROVE if all are `info`/empty).
+2. `verdict` is the uppercase mapping of the highest `severity` in `findings` (`block` → `BLOCK`, `request_changes` → `REQUEST_CHANGES`, all `info` or empty → `APPROVE`).
 3. Every `block`/`request_changes` finding has an actionable `suggestion`.
 4. `summary` is a single sentence without hedging.
+
+### Verdict logging (handled by main CC, not this agent)
+
+You are read-only by design — you have no `Bash` or write tools, so you cannot append to the verdict log yourself. After main CC receives your JSON output, it appends a record to `.adder-pipeline/reviewer-verdicts.jsonl` with timestamp, PR number, your verdict, and wall-clock seconds. The CLAUDE.md block in each consumer repo documents that orchestration step. You do nothing for it; just return the verdict cleanly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,33 @@ drift — surfaced before code goes public.
 Time budget: ~120 seconds. If the reviewer takes longer than that
 consistently, log the run-times and revisit the prompt or the model choice.
 
+**Verdict logging (orchestrator-side, mandatory).** The reviewer
+subagent is read-only by design — it can't write its own verdict
+log. After receiving each reviewer verdict, **append a JSONL
+record** to `.adder-pipeline/reviewer-verdicts.jsonl` with this
+exact shape:
+
+```json
+{
+  "timestamp": "2026-04-26T15:00:00Z",
+  "pr_number": 42,
+  "verdict": "APPROVE",
+  "wall_clock_seconds": 18
+}
+```
+
+- One record per invocation, append-only. Create the file if absent.
+- `timestamp` ISO-8601 UTC, `pr_number` is the GitHub PR number
+  (use `0` if logging a pre-PR dry-run with no PR open yet),
+  `verdict` is one of `APPROVE` / `REQUEST_CHANGES` / `BLOCK`,
+  `wall_clock_seconds` is the integer seconds the agent took.
+- The log feeds the weekly distribution check that drives the
+  prompt-tightness re-evaluation; see
+  `~/projects/code-review-pipeline/pipeline-state.md` "Reviewer
+  subagent" for the keep/tune criteria.
+- Do this even when the verdict is `APPROVE`. The denominator is as
+  important as the numerator.
+
 ## Mutation Testing — Ratchet Policy (active, post-floor)
 
 Stryker `thresholds.break` is currently set to **80** in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,9 +157,15 @@ like:
 ```
 
 - One record per invocation, append-only. Create the directory
-  `.adder-pipeline/` and the file if absent (`mkdir -p
-.adder-pipeline && touch .adder-pipeline/reviewer-verdicts.jsonl`,
-  then append).
+  `.adder-pipeline/` and the file if absent. The exact setup
+  command (kept on a single line so copy-paste runs as a unit):
+
+  ```bash
+  mkdir -p .adder-pipeline && touch .adder-pipeline/reviewer-verdicts.jsonl
+  ```
+
+  Then append the JSONL record.
+
 - `timestamp` ISO-8601 UTC, `pr_number` is the GitHub PR number
   (use `0` if logging a pre-PR dry-run with no PR open yet),
   `verdict` is one of `APPROVE` / `REQUEST_CHANGES` / `BLOCK`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,19 +147,19 @@ consistently, log the run-times and revisit the prompt or the model choice.
 **Verdict logging (orchestrator-side, mandatory).** The reviewer
 subagent is read-only by design — it can't write its own verdict
 log. After receiving each reviewer verdict, **append a JSONL
-record** to `.adder-pipeline/reviewer-verdicts.jsonl` with this
-exact shape:
+record** to `.adder-pipeline/reviewer-verdicts.jsonl`. JSONL
+requires exactly one compact JSON object per line, terminated by a
+newline; no pretty-printing inside a record. Each record looks
+like:
 
-```json
-{
-  "timestamp": "2026-04-26T15:00:00Z",
-  "pr_number": 42,
-  "verdict": "APPROVE",
-  "wall_clock_seconds": 18
-}
+```text
+{"timestamp":"2026-04-26T15:00:00Z","pr_number":42,"verdict":"APPROVE","wall_clock_seconds":18}
 ```
 
-- One record per invocation, append-only. Create the file if absent.
+- One record per invocation, append-only. Create the directory
+  `.adder-pipeline/` and the file if absent (`mkdir -p
+.adder-pipeline && touch .adder-pipeline/reviewer-verdicts.jsonl`,
+  then append).
 - `timestamp` ISO-8601 UTC, `pr_number` is the GitHub PR number
   (use `0` if logging a pre-PR dry-run with no PR open yet),
   `verdict` is one of `APPROVE` / `REQUEST_CHANGES` / `BLOCK`,


### PR DESCRIPTION
## Summary

Mirror of [adder-factory/adder-pipeline-tools#18](https://github.com/adder-factory/adder-pipeline-tools/pull/18). Brings the reviewer-prompt tightening and orchestrator-side verdict logging directly into this consumer repo.

## Changes

| File | Change |
|---|---|
| `.claude/agents/reviewer.md` | Synced verbatim from upstream template — three must-flag patterns + read-only-aware verdict-logging note |
| `CLAUDE.md` | New `**Verdict logging (orchestrator-side, mandatory)**` paragraph in `## Reviewer Subagent` section — JSONL append spec for main CC |

## Three must-flag patterns now in force

1. Test asserts on constant ≠ source declares — `BLOCK` if PR-introduced, `REQUEST_CHANGES` if pre-existing.
2. Exported-symbol signature change without caller update — run `codegraph_impact`, `REQUEST_CHANGES` with caller list if external callers exist.
3. Hard Rule 8 violation: production code in test-only PR — `BLOCK`.

## Orchestrator-side verdict logging

Reviewer agent is read-only by design — main CC writes the log:

```json
{"timestamp": "2026-04-26T15:00:00Z", "pr_number": 42, "verdict": "APPROVE", "wall_clock_seconds": 18}
```

Append to `.adder-pipeline/reviewer-verdicts.jsonl`. One record per invocation, including `APPROVE`. The log feeds the 2026-05-26 / 30-invocations re-evaluation recorded in `~/projects/code-review-pipeline/pipeline-state.md`.

## Pre-existing Sonar finding (out of scope)

`src/tools/shared.ts:431` — not touched. CI Sonar skips cleanly.

## Pre-PR semantic review (the agent reviewing its own definition update)

Reviewer subagent: `APPROVE` with one info-level non-blocker about pre-existing v1-block wording drift on the `REQUEST_CHANGES` override-clause. Not introduced by this PR — pre-existing v1 content. Cleanest fix is the v1 → v2 migration via `install.sh` re-run after upstream PR #18 merges. Out of scope per Hard Rule 8.

## Test plan

- [x] `npm run pre-pr` (Sonar skipped) — green except pre-existing Sonar finding.
- [x] Reviewer subagent — APPROVE.
- [ ] Pipeline gate green on CI.
- [ ] Stryker (affected) — should skip cleanly (0 src changes).
- [ ] CodeRabbit clean (or addressed).
- [ ] Gemini / Greptile / CodeQL advisory threads resolved or auto-dismissed.

Generated with Claude Code
