### PR TITLE
docs(claude-md): clarify CodeGraph vs Grep boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,19 +357,56 @@ the wiring being in place — the tools were treated as optional. This
 section makes specific uses **mandatory** and creates a measurement
 window to decide whether to keep or remove the wiring.
 
+### What CodeGraph is and is not
+
+CodeGraph indexes the **abstract syntax tree** of source files —
+symbols (functions, classes, methods, types), imports, and call
+relationships. It is **not** a full-text index. It is the right
+tool for **structural** questions and the wrong tool for **substring**
+questions:
+
+| Question shape                                       | Right tool                                       |
+| ---------------------------------------------------- | ------------------------------------------------ |
+| Where is symbol X defined?                           | `mcp__codegraph__codegraph_search`               |
+| Who calls X? What does X call?                       | `mcp__codegraph__codegraph_callers` / `_callees` |
+| What does changing X impact?                         | `mcp__codegraph__codegraph_impact`               |
+| What's the high-level structure of `src/`?           | `mcp__codegraph__codegraph_files`                |
+| Trace call relationships across files                | `mcp__codegraph__codegraph_explore`              |
+| Is this literal string in any file?                  | `Grep`                                           |
+| Find this error message / regex / TODO comment       | `Grep`                                           |
+| Find this word in markdown / json / yaml             | `Grep`                                           |
+| Substring search where I don't know if it's a symbol | `Grep`                                           |
+
+The dividing line: CodeGraph knows the AST; Grep knows file bytes.
+Pick the tool that matches the question shape, not the one you're
+more fluent with — the audit's 0-invocation finding was a
+muscle-memory problem, not a tool-quality problem.
+
+### Mandatory uses (must call CodeGraph, not Grep)
+
 - **Before refactoring any exported symbol** (e.g., function, class,
   type, interface, enum, exported const), call
   `mcp__codegraph__codegraph_impact` with the symbol name to surface
   affected callers. Do NOT skip this for "small-looking" changes —
   exported-symbol blast radius is the exact failure mode CodeGraph
   exists to prevent.
-- **When investigating bugs across multiple files**, use
-  `mcp__codegraph__codegraph_explore` instead of `Grep + Read`. One
-  graph query replaces 20+ file reads.
+- **When tracing call / caller relationships across files** (e.g.,
+  "what does this function depend on?", "who else uses this
+  method?"), use `mcp__codegraph__codegraph_explore` or
+  `_callers` / `_callees`. One graph query replaces 20+ file reads.
 - **When self-reviewing a PR with source changes**, run
   `mcp__codegraph__codegraph_impact` on each modified exported
   symbol. Document the result in the PR body so reviewers see the
   blast radius CC checked.
+
+Note: bug investigations involving error messages, log strings, or
+literal text content are **substring** queries — use `Grep` for
+those. The mandate above is for relationship-tracing investigations
+(stack of callers, dependency chain), not for "find the string
+'connection refused' in any file."
+
+File reads (`Read`) are for when you need the actual source to edit;
+use CodeGraph for AST discovery and Grep for substring lookups.
 
 Usage is measured weekly by
 `adder-pipeline-tools/scripts/codegraph-usage-counter.sh`. See

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,7 +403,7 @@ Note: bug investigations involving error messages, log strings, or
 literal text content are **substring** queries — use `Grep` for
 those. The mandate above is for relationship-tracing investigations
 (stack of callers, dependency chain), not for "find the string
-'connection refused' in any file."
+`connection refused` in any file."
 
 File reads (`Read`) are for when you need the actual source to edit;
 use CodeGraph for AST discovery and Grep for substring lookups.


### PR DESCRIPTION
## Summary

Mirror of [adder-factory/adder-pipeline-tools#19](https://github.com/adder-factory/adder-pipeline-tools/pull/19). Restructures the `## CodeGraph Usage` section in this repo's `CLAUDE.md` to make the structural-vs-substring boundary explicit.

## Empirical motivation

Running the actual `mcp__codegraph__*` tools against this repo's index this session showed:
- `codegraph_impact errorResult` → 26 affected symbols across 4 files in one structured call.
- Same tool on substring queries (e.g., "find this error message in any file") → empty results (it indexes the AST, not file bytes).
- Grep does substring queries in 8 ms.

Both behaviors are correct for what each tool was designed to do. The audit Q8 mandate's wording in PR #16 conflated the two.

## Changes

`CLAUDE.md` `## CodeGraph Usage` section restructured:

- New "What CodeGraph is and is not" subsection with question-shape → right-tool table.
- "Mandatory uses (must call CodeGraph, not Grep)" subsection with same three triggers; trigger 2 narrowed from "multi-file bug investigations" to "tracing call / caller relationships across files."
- Bug investigations on error messages / log strings / literal text content explicitly carved out into Grep territory.
- Closing sentence on Read vs CodeGraph vs Grep tool selection.

## What is NOT changing

- The three mandatory triggers themselves.
- The probation period (2026-04-26 → 2026-05-03).
- The decision matrix in `pipeline-state.md`.

This is a clarification of **when** the rules fire, not **what** they enforce — so per the Spec Drift Prevention rule, `pipeline-state.md` does not need an update.

## Pre-existing Sonar finding (out of scope)

`src/tools/shared.ts:431` (typescript:S3776 cognitive complexity) — not touched. CI Sonar skips cleanly.

## Pre-PR semantic review

Reviewer subagent: `APPROVE` with one info-level acknowledgment of the pre-existing v1-block `### CodeGraph` subsection drift (the legacy v1 ADDER-PIPELINE block at the bottom of this CLAUDE.md still has the old wording — resolves when `install.sh` re-runs to migrate v1 → v2).

## Test plan

- [x] `npm run pre-pr` (Sonar skipped) — green except pre-existing Sonar finding.
- [x] Reviewer subagent — APPROVE.
- [ ] Pipeline gate green on CI.
- [ ] Stryker (affected) — should skip cleanly (0 src changes).
- [ ] CodeRabbit clean (or addressed).
- [ ] Gemini / Greptile / CodeQL advisory threads resolved or auto-dismissed.

Generated with Claude Code
