### PR TITLE
fix(sonar): refactor handleRecentChanges below S3776 cognitive-complexity threshold

### DIFF
--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -420,6 +420,61 @@ export function buildVaultStructure(
 const RECENT_CHANGES_BATCH_SIZE = 20;
 
 /**
+ * Records one batch result into the success accumulator. Fulfilled results
+ * land in `successes`; rejected ones are logged at warn level so a per-file
+ * failure surfaces without aborting the whole call. Extracted from
+ * {@link handleRecentChanges} to keep that function under Sonar's
+ * cognitive-complexity ceiling (S3776).
+ * @param result - One settled result from `Promise.allSettled`.
+ * @param fp - Path string for log diagnostics on rejection.
+ * @param successes - Output accumulator; mutated in place on fulfillment.
+ */
+function recordBatchResult(
+  result: PromiseSettledResult<{ path: string; mtime: number }>,
+  fp: string,
+  successes: Array<{ path: string; mtime: number }>,
+): void {
+  if (result.status === "fulfilled") {
+    successes.push(result.value);
+    return;
+  }
+  const reason =
+    result.reason instanceof Error
+      ? result.reason.message
+      : String(result.reason);
+  log("warn", `recent_changes: skipping ${fp} (read failed: ${reason})`);
+}
+
+/**
+ * Reads stats for one batch of vault paths via the Obsidian REST API,
+ * returning the successful entries. Failures are logged inside
+ * {@link recordBatchResult} (best-effort: partial data is OK, but every
+ * skip must be observable per CLAUDE.md "NEVER swallow errors silently").
+ * @param client - The Obsidian API client.
+ * @param batch - Vault paths to fetch stats for in parallel.
+ * @returns Successful entries only; failures are logged but not returned.
+ */
+async function readBatchStats(
+  client: ObsidianClient,
+  batch: readonly string[],
+): Promise<Array<{ path: string; mtime: number }>> {
+  const results = await Promise.allSettled(
+    batch.map(async (fp) => {
+      const result = await client.getFileContents(fp, "json");
+      if (typeof result !== "string" && "stat" in result) {
+        return { path: fp, mtime: result.stat.mtime };
+      }
+      return { path: fp, mtime: 0 };
+    }),
+  );
+  const successes: Array<{ path: string; mtime: number }> = [];
+  results.forEach((r, j) => {
+    recordBatchResult(r, batch[j] ?? "<unknown>", successes);
+  });
+  return successes;
+}
+
+/**
  * Fetches recent changes using cache if available, or batched API calls as fallback.
  * Batching is used to avoid unbounded concurrent calls on large vaults.
  * @param client - The Obsidian API client.
@@ -447,34 +502,7 @@ export async function handleRecentChanges(
   const withStats: Array<{ path: string; mtime: number }> = [];
   for (let i = 0; i < mdFiles.length; i += RECENT_CHANGES_BATCH_SIZE) {
     const batch = mdFiles.slice(i, i + RECENT_CHANGES_BATCH_SIZE);
-    const results = await Promise.allSettled(
-      batch.map(async (fp) => {
-        const result = await client.getFileContents(fp, "json");
-        if (typeof result !== "string" && "stat" in result) {
-          return { path: fp, mtime: result.stat.mtime };
-        }
-        return { path: fp, mtime: 0 };
-      }),
-    );
-    for (let j = 0; j < results.length; j++) {
-      const r = results[j];
-      if (r === undefined) continue;
-      if (r.status === "fulfilled") {
-        withStats.push(r.value);
-      } else {
-        // Surface partial-data-loss conditions (CLAUDE.md: "NEVER swallow
-        // errors silently — always log or rethrow"). The recent-changes
-        // result is a best-effort summary, so a per-file failure shouldn't
-        // abort the whole call — but it must be observable.
-        const failedPath = batch[j] ?? "<unknown>";
-        const reason =
-          r.reason instanceof Error ? r.reason.message : String(r.reason);
-        log(
-          "warn",
-          `recent_changes: skipping ${failedPath} (read failed: ${reason})`,
-        );
-      }
-    }
+    withStats.push(...(await readBatchStats(client, batch)));
   }
   withStats.sort((a, b) => b.mtime - a.mtime);
   return jsonResult(withStats.slice(0, limit));

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -419,21 +419,34 @@ export function buildVaultStructure(
 /** Batch size for concurrent API calls in the cache-miss fallback path. */
 const RECENT_CHANGES_BATCH_SIZE = 20;
 
+/** Per-file mtime stat collected by {@link readBatchStats}. */
+interface RecentChangeStat {
+  readonly path: string;
+  readonly mtime: number;
+}
+
+/** Parameters for {@link recordBatchResult} (destructured per CLAUDE.md
+ *  "destructure function params when >2 params"). */
+interface RecordBatchResultParams {
+  readonly result: PromiseSettledResult<RecentChangeStat>;
+  readonly fp: string;
+  /** Output accumulator; mutated in place on fulfillment. */
+  readonly successes: RecentChangeStat[];
+}
+
 /**
  * Records one batch result into the success accumulator. Fulfilled results
  * land in `successes`; rejected ones are logged at warn level so a per-file
  * failure surfaces without aborting the whole call. Extracted from
  * {@link handleRecentChanges} to keep that function under Sonar's
  * cognitive-complexity ceiling (S3776).
- * @param result - One settled result from `Promise.allSettled`.
- * @param fp - Path string for log diagnostics on rejection.
- * @param successes - Output accumulator; mutated in place on fulfillment.
+ * @param params - Destructured params per CLAUDE.md style guide.
  */
-function recordBatchResult(
-  result: PromiseSettledResult<{ path: string; mtime: number }>,
-  fp: string,
-  successes: Array<{ path: string; mtime: number }>,
-): void {
+function recordBatchResult({
+  result,
+  fp,
+  successes,
+}: RecordBatchResultParams): void {
   if (result.status === "fulfilled") {
     successes.push(result.value);
     return;
@@ -457,9 +470,9 @@ function recordBatchResult(
 async function readBatchStats(
   client: ObsidianClient,
   batch: readonly string[],
-): Promise<Array<{ path: string; mtime: number }>> {
+): Promise<RecentChangeStat[]> {
   const results = await Promise.allSettled(
-    batch.map(async (fp) => {
+    batch.map(async (fp): Promise<RecentChangeStat> => {
       const result = await client.getFileContents(fp, "json");
       if (typeof result !== "string" && "stat" in result) {
         return { path: fp, mtime: result.stat.mtime };
@@ -467,9 +480,9 @@ async function readBatchStats(
       return { path: fp, mtime: 0 };
     }),
   );
-  const successes: Array<{ path: string; mtime: number }> = [];
+  const successes: RecentChangeStat[] = [];
   results.forEach((r, j) => {
-    recordBatchResult(r, batch[j] ?? "<unknown>", successes);
+    recordBatchResult({ result: r, fp: batch[j] ?? "<unknown>", successes });
   });
   return successes;
 }


### PR DESCRIPTION
## Summary

Closes the SonarQube **S3776 (Cognitive Complexity) CRITICAL** finding on `src/tools/shared.ts:431`. `handleRecentChanges` was at complexity 16 against the threshold of 15. This finding has been the recurring "pre-existing, out-of-scope" Sonar disclaimer on every PR for the past day — this PR clears it.

Wave 3 of today's audit-follow-up cleanup.

## Refactor

Extracted two private helpers from the original body of `handleRecentChanges`:

1. **`recordBatchResult(result, fp, successes)`** — pure function: fulfilled `PromiseSettledResult` → `successes`; rejected → warn log. The `"recent_changes: skipping <path> (read failed: <reason>)"` message format is preserved verbatim.

2. **`readBatchStats(client, batch)`** — async wrapper around `Promise.allSettled` that accumulates successes via `recordBatchResult`. Returns only successful entries; failures stay observable via the warn log inside the helper.

`handleRecentChanges` body is now:
- Cache path unchanged (early return as before).
- Fallback path simplified to: list vault → filter `.md` → batch in chunks of `RECENT_CHANGES_BATCH_SIZE` (= 20) → `withStats.push(...await readBatchStats(client, batch))` → sort → slice.

## Behavior preserved verbatim

- Same `RECENT_CHANGES_BATCH_SIZE` (20).
- Same warn log message format and call site (still inside the rejected branch).
- Same `r.reason instanceof Error ? .message : String(r.reason)` fallback for non-Error rejections.
- Same `batch[j] ?? "<unknown>"` path-lookup guard for `noUncheckedIndexedAccess`.
- Same final sort by mtime desc + slice to `limit`.
- `handleRecentChanges` signature unchanged. New helpers are NOT exported.

## Verification

- `npm test` → **1126/1126 tests pass**, including the 33-mutant Stryker backfill series for `handleRecentChanges` in `src/__tests__/tools.test.ts:5100+`.
- `npm run pre-pr` (with `PIPELINE_SKIP_QWEN=1`) → all 12 gates green including **SonarQube ✓** (was ✗ on this exact issue).

## Pre-PR semantic review

Reviewer subagent: `APPROVE` with one info-level finding (JSDoc `@param`/`@returns` on the new private helpers for style consistency — applied for free).

## Test plan

- [x] All tests pass (1126/1126).
- [x] Local pre-pr.sh fully green including Sonar.
- [x] Reviewer subagent APPROVE.
- [ ] Pipeline gate green on CI.
- [ ] Stryker (affected) re-runs and stays above the 80 floor (refactor preserves logic, mutants should still kill).
- [ ] CodeRabbit clean (or addressed).
- [ ] SonarQube CI verdict OK.

Generated with Claude Code
